### PR TITLE
Register Cell Helpers

### DIFF
--- a/Alicerce/Sources/Extensions/UICollectionView.swift
+++ b/Alicerce/Sources/Extensions/UICollectionView.swift
@@ -18,4 +18,12 @@ public extension UICollectionView {
         
         return cell
     }
+    
+    public func register<T: UICollectionViewCell>(_ cellType: T.Type) where T: ViewCellProtocol {
+        register(cellType, forCellWithReuseIdentifier: cellType.reuseIdentifier)
+    }
+    
+    public func register<T: AnyObject>(_ viewType: T.Type, forSupplementaryViewOfKind kind: String) where T: ViewCellProtocol {
+        register(viewType, forSupplementaryViewOfKind: kind, withReuseIdentifier: viewType.reuseIdentifier)
+    }
 }

--- a/Alicerce/Sources/Extensions/UITableView.swift
+++ b/Alicerce/Sources/Extensions/UITableView.swift
@@ -27,4 +27,12 @@ public extension UITableView {
         
         return view
     }
+    
+    public func register<T: UITableViewCell>(_ cellType: T.Type) where T: ViewCellProtocol {
+        register(cellType, forCellReuseIdentifier: cellType.reuseIdentifier)
+    }
+    
+    public func registerHeaderFooterView<T: AnyObject>(_ viewType: T.Type) where T: ViewCellProtocol {
+        register(viewType, forHeaderFooterViewReuseIdentifier: T.reuseIdentifier)
+    }
 }


### PR DESCRIPTION
# Register Cell Helpers
This adds 2 functions. One to the `UITableView` extension and another to the `UICollectionView` extension. It basically just makes registering a cell simpler when the cell conforms to `ViewCellProtocol`.