### PR TITLE
Add initial Deep Linking infrastructure

### DIFF
--- a/Alicerce.xcodeproj/project.pbxproj
+++ b/Alicerce.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0A182C4F1E9D7FBB004D7267 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A182C4E1E9D7FBB004D7267 /* Router.swift */; };
+		0A182C511E9EF891004D7267 /* ApplicationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A182C501E9EF891004D7267 /* ApplicationRouter.swift */; };
 		0AA577F41E927D8900F0FEE0 /* CoreDataEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA577ED1E927D8900F0FEE0 /* CoreDataEntity.swift */; };
 		0AA577F51E927D8900F0FEE0 /* CoreDataStack+ManagedObjectReflectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA577EE1E927D8900F0FEE0 /* CoreDataStack+ManagedObjectReflectable.swift */; };
 		0AA577F61E927D8900F0FEE0 /* CoreDataStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA577EF1E927D8900F0FEE0 /* CoreDataStack.swift */; };
@@ -15,6 +17,16 @@
 		0AA577FA1E927D8900F0FEE0 /* SiblingContextCoreDataStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA577F31E927D8900F0FEE0 /* SiblingContextCoreDataStack.swift */; };
 		0AA5781F1E92929E00F0FEE0 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA5781E1E92929E00F0FEE0 /* String.swift */; };
 		0ADDE4B21EA2AD4300FBD459 /* Placeholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ADDE4B11EA2AD4300FBD459 /* Placeholder.swift */; };
+		0AAC162A1EA54D1F001ABB80 /* Route+Tree_AddTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AAC16261EA54D1F001ABB80 /* Route+Tree_AddTests.swift */; };
+		0AAC162B1EA54D1F001ABB80 /* Route+Tree_InitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AAC16271EA54D1F001ABB80 /* Route+Tree_InitTests.swift */; };
+		0AAC162C1EA54D1F001ABB80 /* Route+Tree_MatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AAC16281EA54D1F001ABB80 /* Route+Tree_MatchTests.swift */; };
+		0AAC162D1EA54D1F001ABB80 /* Route+Tree_RemoveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AAC16291EA54D1F001ABB80 /* Route+Tree_RemoveTests.swift */; };
+		0AAC162F1EA54E18001ABB80 /* Route+ComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AAC162E1EA54E18001ABB80 /* Route+ComponentTests.swift */; };
+		0ADDE4B61EA2ADE700FBD459 /* Route.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ADDE4B51EA2ADE700FBD459 /* Route.swift */; };
+		0ADDE4B81EA2AE5500FBD459 /* Route+Component.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ADDE4B71EA2AE5500FBD459 /* Route+Component.swift */; };
+		0ADDE4BA1EA2AE9500FBD459 /* Route+Tree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ADDE4B91EA2AE9500FBD459 /* Route+Tree.swift */; };
+		0AE7606B1EA569E6007DC1BA /* TreeRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE7606A1EA569E6007DC1BA /* TreeRouterTests.swift */; };
+		0AF451B91E929E6000E1BF09 /* Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF451B81E929E6000E1BF09 /* Dictionary.swift */; };
 		0AF451BB1E92AF1600E1BF09 /* Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF451BA1E92AF1600E1BF09 /* Sequence.swift */; };
 		0AF451BD1E92FFD400E1BF09 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF451BC1E92FFD400E1BF09 /* Box.swift */; };
 		0AF451BF1E93012A00E1BF09 /* ApplicationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AF451BE1E93012A00E1BF09 /* ApplicationMode.swift */; };
@@ -100,6 +112,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0A182C4E1E9D7FBB004D7267 /* Router.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
+		0A182C501E9EF891004D7267 /* ApplicationRouter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApplicationRouter.swift; sourceTree = "<group>"; };
 		0AA577ED1E927D8900F0FEE0 /* CoreDataEntity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreDataEntity.swift; sourceTree = "<group>"; };
 		0AA577EE1E927D8900F0FEE0 /* CoreDataStack+ManagedObjectReflectable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CoreDataStack+ManagedObjectReflectable.swift"; sourceTree = "<group>"; };
 		0AA577EF1E927D8900F0FEE0 /* CoreDataStack.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreDataStack.swift; sourceTree = "<group>"; };
@@ -109,6 +123,15 @@
 		0AA577F31E927D8900F0FEE0 /* SiblingContextCoreDataStack.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiblingContextCoreDataStack.swift; sourceTree = "<group>"; };
 		0AA5781E1E92929E00F0FEE0 /* String.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
 		0ADDE4B11EA2AD4300FBD459 /* Placeholder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Placeholder.swift; sourceTree = "<group>"; };
+		0AAC16261EA54D1F001ABB80 /* Route+Tree_AddTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Route+Tree_AddTests.swift"; sourceTree = "<group>"; };
+		0AAC16271EA54D1F001ABB80 /* Route+Tree_InitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Route+Tree_InitTests.swift"; sourceTree = "<group>"; };
+		0AAC16281EA54D1F001ABB80 /* Route+Tree_MatchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Route+Tree_MatchTests.swift"; sourceTree = "<group>"; };
+		0AAC16291EA54D1F001ABB80 /* Route+Tree_RemoveTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Route+Tree_RemoveTests.swift"; sourceTree = "<group>"; };
+		0AAC162E1EA54E18001ABB80 /* Route+ComponentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Route+ComponentTests.swift"; sourceTree = "<group>"; };
+		0ADDE4B51EA2ADE700FBD459 /* Route.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Route.swift; sourceTree = "<group>"; };
+		0ADDE4B71EA2AE5500FBD459 /* Route+Component.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Route+Component.swift"; sourceTree = "<group>"; };
+		0ADDE4B91EA2AE9500FBD459 /* Route+Tree.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Route+Tree.swift"; sourceTree = "<group>"; };
+		0AE7606A1EA569E6007DC1BA /* TreeRouterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TreeRouterTests.swift; sourceTree = "<group>"; };
 		0AF451B81E929E6000E1BF09 /* Dictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Dictionary.swift; sourceTree = "<group>"; };
 		0AF451BA1E92AF1600E1BF09 /* Sequence.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Sequence.swift; sourceTree = "<group>"; };
 		0AF451BC1E92FFD400E1BF09 /* Box.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Box.swift; sourceTree = "<group>"; };
@@ -210,6 +233,18 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0A182C4D1E9D7FBB004D7267 /* DeepLinking */ = {
+			isa = PBXGroup;
+			children = (
+				0A182C501E9EF891004D7267 /* ApplicationRouter.swift */,
+				0A182C4E1E9D7FBB004D7267 /* Router.swift */,
+				0ADDE4B51EA2ADE700FBD459 /* Route.swift */,
+				0ADDE4B71EA2AE5500FBD459 /* Route+Component.swift */,
+				0ADDE4B91EA2AE9500FBD459 /* Route+Tree.swift */,
+			);
+			path = DeepLinking;
+			sourceTree = "<group>";
+		};
 		0AA577EC1E927D8900F0FEE0 /* Persistence */ = {
 			isa = PBXGroup;
 			children = (
@@ -224,6 +259,19 @@
 				0AA577F31E927D8900F0FEE0 /* SiblingContextCoreDataStack.swift */,
 			);
 			path = Persistence;
+			sourceTree = "<group>";
+		};
+		0AAC16251EA54D1F001ABB80 /* DeepLinking */ = {
+			isa = PBXGroup;
+			children = (
+				0AE7606A1EA569E6007DC1BA /* TreeRouterTests.swift */,
+				0AAC162E1EA54E18001ABB80 /* Route+ComponentTests.swift */,
+				0AAC16261EA54D1F001ABB80 /* Route+Tree_AddTests.swift */,
+				0AAC16271EA54D1F001ABB80 /* Route+Tree_InitTests.swift */,
+				0AAC16281EA54D1F001ABB80 /* Route+Tree_MatchTests.swift */,
+				0AAC16291EA54D1F001ABB80 /* Route+Tree_RemoveTests.swift */,
+			);
+			path = DeepLinking;
 			sourceTree = "<group>";
 		};
 		1B4B99CD1E968A180081A16A /* Network */ = {
@@ -251,6 +299,7 @@
 		1B70244F1E9DA0BF0059EA22 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				0AAC16251EA54D1F001ABB80 /* DeepLinking */,
 				1B7024501E9DA0BF0059EA22 /* Extensions */,
 				1B7024521E9DA0BF0059EA22 /* Network */,
 				1B7024591E9DA0BF0059EA22 /* Persistence */,
@@ -366,6 +415,7 @@
 		1BDD793E1E037CC400CC1EDA /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				0A182C4D1E9D7FBB004D7267 /* DeepLinking */,
 				1BDD79411E03840F00CC1EDA /* Extensions */,
 				1B4B99CD1E968A180081A16A /* Network */,
 				0AA577EC1E927D8900F0FEE0 /* Persistence */,
@@ -657,7 +707,9 @@
 				E406E1271EA66FEB002B2A58 /* NSManagedObjectContext+CoreDataStack.swift in Sources */,
 				0AA577F41E927D8900F0FEE0 /* CoreDataEntity.swift in Sources */,
 				0ADDE4B21EA2AD4300FBD459 /* Placeholder.swift in Sources */,
+				0A182C511E9EF891004D7267 /* ApplicationRouter.swift in Sources */,
 				0AF451C31E930E3E00E1BF09 /* HTTP.swift in Sources */,
+				0ADDE4B61EA2ADE700FBD459 /* Route.swift in Sources */,
 				0AF451C51E9318CA00E1BF09 /* NSPersistentStoreCoordinator+CoreDataStack.swift in Sources */,
 				E4D813021EA4F6E8000AB21D /* Thread.swift in Sources */,
 				0AA577F71E927D8900F0FEE0 /* ManagedObjectReflectable.swift in Sources */,
@@ -669,6 +721,7 @@
 				0AA577F81E927D8900F0FEE0 /* NestedContextCoreDataStack.swift in Sources */,
 				E46F60E51E97A14F0019958D /* Log+ConsoleLogDestination.swift in Sources */,
 				E46F60E61E97A14F0019958D /* Log+FileLogDestination.swift in Sources */,
+				0ADDE4B81EA2AE5500FBD459 /* Route+Component.swift in Sources */,
 				0AA577FA1E927D8900F0FEE0 /* SiblingContextCoreDataStack.swift in Sources */,
 				1B4B99CF1E968A340081A16A /* Network.swift in Sources */,
 				0AA5781F1E92929E00F0FEE0 /* String.swift in Sources */,
@@ -678,6 +731,7 @@
 				1BE792A61EA5730D00375D98 /* UIViewController.swift in Sources */,
 				0AF451BB1E92AF1600E1BF09 /* Sequence.swift in Sources */,
 				E46F60EC1E97A14F0019958D /* Log+NodeLogDestination.swift in Sources */,
+				0ADDE4BA1EA2AE9500FBD459 /* Route+Tree.swift in Sources */,
 				1BE256DA1E92936A00942DAC /* CollectionViewCell.swift in Sources */,
 				E46F60EB1E97A14F0019958D /* Log+BashLogItemLevelFormatter.swift in Sources */,
 				1BB0CC921E979C66007448C5 /* NetworkResource.swift in Sources */,
@@ -692,6 +746,7 @@
 				1BE256D51E928FFB00942DAC /* TableViewCell.swift in Sources */,
 				E46F60E81E97A14F0019958D /* Log+JSONLogItemFormatter.swift in Sources */,
 				E46F60EF1E97A14F0019958D /* LogItemLevelFormatter.swift in Sources */,
+				0A182C4F1E9D7FBB004D7267 /* Router.swift in Sources */,
 				1BE256D61E928FFB00942DAC /* TableViewHeaderFooterView.swift in Sources */,
 				1BDD79561E0389BD00CC1EDA /* ServiceLocator.swift in Sources */,
 				0AA577F61E927D8900F0FEE0 /* CoreDataStack.swift in Sources */,
@@ -719,17 +774,23 @@
 				E4D813051EA4FBBC000AB21D /* ThreadTests.swift in Sources */,
 				1BE2048D1EA59AC90011E719 /* UIColorTestCase.swift in Sources */,
 				1B7024701E9DA0BF0059EA22 /* MappableErrorTestCase.swift in Sources */,
+				0AAC162D1EA54D1F001ABB80 /* Route+Tree_RemoveTests.swift in Sources */,
 				1B70247B1E9DA0C00059EA22 /* CoreDataStackModel.xcdatamodeld in Sources */,
 				1B7024711E9DA0BF0059EA22 /* MappableModel.swift in Sources */,
+				0AAC162F1EA54E18001ABB80 /* Route+ComponentTests.swift in Sources */,
 				1B7024771E9DA0BF0059EA22 /* CoreDataStackSetupTests.swift in Sources */,
 				1B70246F1E9DA0BF0059EA22 /* OptionalTests.swift in Sources */,
+				0AAC162A1EA54D1F001ABB80 /* Route+Tree_AddTests.swift in Sources */,
 				1B7024761E9DA0BF0059EA22 /* CoreDataStackOperationTests.swift in Sources */,
+				0AAC162C1EA54D1F001ABB80 /* Route+Tree_MatchTests.swift in Sources */,
 				1B7024741E9DA0BF0059EA22 /* ParseTestCase.swift in Sources */,
 				1BE2048E1EA59AC90011E719 /* UIViewControllerTestCase.swift in Sources */,
 				1B7024731E9DA0BF0059EA22 /* NetworkTestCase.swift in Sources */,
 				1B7024811E9DA0C00059EA22 /* ResourceTestCase.swift in Sources */,
 				1B7024721E9DA0BF0059EA22 /* MappableTestCase.swift in Sources */,
+				0AAC162B1EA54D1F001ABB80 /* Route+Tree_InitTests.swift in Sources */,
 				1B7024751E9DA0BF0059EA22 /* URLSessionNetworkStackTestCase.swift in Sources */,
+				0AE7606B1EA569E6007DC1BA /* TreeRouterTests.swift in Sources */,
 				1B7024801E9DA0C00059EA22 /* NetworkResourceTestCase.swift in Sources */,
 				1B7024821E9DA0C00059EA22 /* ServiceLocatorTests.swift in Sources */,
 				1B7024791E9DA0BF0059EA22 /* MockErrorManagedObjectContext.m in Sources */,

--- a/Alicerce/Sources/DeepLinking/ApplicationRouter.swift
+++ b/Alicerce/Sources/DeepLinking/ApplicationRouter.swift
@@ -1,0 +1,20 @@
+//
+//  ApplicationRouter.swift
+//  Alicerce
+//
+//  Created by André Pacheco Neves on 13/04/2017.
+//  Copyright © 2017 Mindera. All rights reserved.
+//
+
+import UIKit
+
+public enum ApplicationRoute {
+    case url(URL, options: [UIApplicationOpenURLOptionsKey : Any])
+    @available(iOS 9.0, *)
+    case shortcutItem(UIApplicationShortcutItem, completion: (Bool) -> Void)
+    case userActivity(NSUserActivity, restoration: ([Any]?) -> Void)
+}
+
+protocol ApplicationRouter {
+    func route(_ route: ApplicationRoute)
+}

--- a/Alicerce/Sources/DeepLinking/Route+Component.swift
+++ b/Alicerce/Sources/DeepLinking/Route+Component.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-extension Route {
+public extension Route {
 
     public enum Component: ExpressibleByStringLiteral, CustomStringConvertible, CustomDebugStringConvertible, Hashable {
         case empty // for default handlers, e.g.: /home
@@ -36,7 +36,7 @@ extension Route {
             }
         }
 
-        var key: Key {
+        public var key: Key {
             switch self {
             case .empty: return .empty
             case let .constant(value): return .constant(value)
@@ -44,7 +44,7 @@ extension Route {
             }
         }
 
-        func edge<Handler>(for node: Tree<Handler>) -> Tree<Handler>.Edge {
+        public func edge<Handler>(for node: Tree<Handler>) -> Tree<Handler>.Edge {
             switch self {
             case .empty, .constant: return .simple(node)
             case let .variable(parameterName): return .parameter(parameterName, node)
@@ -53,7 +53,7 @@ extension Route {
 
         // MARK: Key (
 
-        enum Key : Hashable{
+        public enum Key : Hashable{
             case empty
             case constant(String)
             case variable

--- a/Alicerce/Sources/DeepLinking/Route+Component.swift
+++ b/Alicerce/Sources/DeepLinking/Route+Component.swift
@@ -1,0 +1,132 @@
+//
+//  Route+Component.swift
+//  Alicerce
+//
+//  Created by André Pacheco Neves on 15/04/2017.
+//  Copyright © 2017 Mindera. All rights reserved.
+//
+
+import Foundation
+
+extension Route {
+
+    public enum Component: ExpressibleByStringLiteral, CustomStringConvertible, CustomDebugStringConvertible, Hashable {
+        case empty // for default handlers, e.g.: /home
+        case constant(String)
+        case variable(String?) // variables and wildcard (*)
+
+        init(component: String) {
+            precondition(component.contains("/") == false, "💥: path components can't have any \"/\" characters!")
+
+            switch component.characters.first {
+            case ":"?:
+                let index = component.index(component.startIndex, offsetBy: 1)
+                let parameterName = component.substring(from: index)
+
+                assert(parameterName.characters.isEmpty == false, "🔥: path component's parameter name is empty!")
+
+                self = .variable(parameterName)
+            case "*"?:
+                assert(component.characters.count == 1, "🔥: wildcard path component must contain a single '*'")
+                self = .variable(nil)
+            case nil:
+                self = .empty
+            default:
+                self = .constant(component)
+            }
+        }
+
+        var key: Key {
+            switch self {
+            case .empty: return .empty
+            case let .constant(value): return .constant(value)
+            case .variable: return .variable
+            }
+        }
+
+        func edge<Handler>(for node: Tree<Handler>) -> Tree<Handler>.Edge {
+            switch self {
+            case .empty, .constant: return .simple(node)
+            case let .variable(parameterName): return .parameter(parameterName, node)
+            }
+        }
+
+        // MARK: Key (
+
+        enum Key : Hashable{
+            case empty
+            case constant(String)
+            case variable
+
+            public var hashValue: Int {
+                switch self {
+                case .empty: return "\(type(of: self).empty)".hashValue
+                case let .constant(value): return value.hashValue
+                case .variable: return "\(type(of: self).variable)".hashValue
+                }
+            }
+
+            public static func ==(lhs: Key, rhs: Key) -> Bool {
+                switch (lhs, rhs) {
+                case (.empty, .empty), (.variable, .variable): return true
+                case let (.constant(lhsString), .constant(rhsString)): return lhsString == rhsString
+                default: return false
+                }
+            }
+        }
+
+        // MARK: ExpressibleByStringLiteral
+
+        public init(stringLiteral value: String) {
+            self.init(component: value)
+        }
+
+        public init(extendedGraphemeClusterLiteral value: String) {
+            self.init(component: value)
+        }
+
+        public init(unicodeScalarLiteral value: String) {
+            self.init(component: value)
+        }
+
+        // MARK: CustomStringConvertible
+
+        public var description: String {
+            switch self {
+            case .empty: return ""
+            case let .constant(value): return value
+            case let .variable(value?): return ":" + value
+            case .variable(nil): return "*"
+            }
+        }
+
+        // MARK: CustomDebugStringConvertible
+
+        public var debugDescription: String {
+            switch self {
+            case .empty: return ".empty"
+            case let .constant(value): return ".constant(\(value))"
+            case let .variable(value): return ".variable(\(value ?? "*"))" 
+            }
+        }
+
+        // MARK: Hashable
+
+        public var hashValue: Int {
+            switch self {
+            case .empty: return "\(type(of: self).empty)".hashValue
+            case let .constant(value): return "\(type(of: self).constant)(\(value))".hashValue
+            case let .variable(parameter): return "\(type(of: self).variable)(\(String(describing: parameter)))".hashValue
+            }
+        }
+
+        public static func ==(lhs: Component, rhs: Component) -> Bool {
+            switch (lhs, rhs) {
+            case (.empty, .empty): return true
+            case let (.constant(lhsString), .constant(rhsString)): return lhsString == rhsString
+            case let (.variable(lhsParameter), .variable(rhsParameter)): return lhsParameter == rhsParameter
+            default: return false
+            }
+        }
+    }
+}

--- a/Alicerce/Sources/DeepLinking/Route+Tree.swift
+++ b/Alicerce/Sources/DeepLinking/Route+Tree.swift
@@ -8,13 +8,13 @@
 
 import Foundation
 
-extension Route {
+public extension Route {
 
-    indirect enum Tree<Handler> {
+    public indirect enum Tree<Handler> {
 
         // MARK: Nested types
 
-        enum Error: Swift.Error {
+        public enum Error: Swift.Error {
             case invalidRoute
             case duplicateEmptyComponent
             case conflictingParameterName(existing: String, new: String)
@@ -22,13 +22,13 @@ extension Route {
             case invalidComponent(Component)
         }
 
-        enum Edge {
+        public enum Edge {
             case simple(Tree<Handler>)
             case parameter(String?, Tree<Handler>)
         }
 
-        typealias ChildEdges = [Component.Key : Edge]
-        typealias Match = (parameters: [String : String], handler: Handler)
+        public typealias ChildEdges = [Component.Key : Edge]
+        public typealias Match = (parameters: [String : String], handler: Handler)
 
         // MARK: Implementation
 
@@ -50,7 +50,7 @@ extension Route {
             }
         }
 
-        mutating func add(route: [Component], handler: Handler) throws {
+        public mutating func add(route: [Component], handler: Handler) throws {
             let currentComponent = route.first ?? .empty
             let remainingRoute = Array(route.dropFirst())
 
@@ -82,7 +82,7 @@ extension Route {
             }
         }
 
-        mutating func remove(route: [Component]) throws -> Handler {
+        public mutating func remove(route: [Component]) throws -> Handler {
             switch self {
             case var .node(edges):
                 let currentComponent = route.first ?? .empty
@@ -121,7 +121,7 @@ extension Route {
 
         }
 
-        func match(route: [Component]) throws -> Match {
+        public func match(route: [Component]) throws -> Match {
             switch self {
             case let .node(edges):
                 let currentComponent = route.first ?? .empty
@@ -250,21 +250,21 @@ extension Route {
                                         childTree: Tree<Handler>,
                                         currentComponent: Component,
                                         remainingRoute: [Component]) throws -> Match {
-            let (parameters, handler) = try childTree.match(route: remainingRoute)
+            let match = try childTree.match(route: remainingRoute)
              
-            guard let parameterName = parameterName else { return (parameters, handler) }
+            guard let parameterName = parameterName else { return match }
 
-            var allParameters = parameters
+            var parameters = match.parameters
 
             guard case let .constant(parameterValue) = currentComponent else {
                 assertionFailure("🔥: matched non `.constant` component \(currentComponent) to `parameter(\(parameterName))` edge!")
                 throw Error.routeNotFound
             }
 
-            assert(allParameters[parameterName] == nil, "🔥: duplicate variable in route!")
-            allParameters[parameterName] = parameterValue
+            assert(parameters[parameterName] == nil, "🔥: duplicate variable in route!")
+            parameters[parameterName] = parameterValue
 
-            return (allParameters, handler)
+            return (parameters, match.handler)
         }
     }
 }

--- a/Alicerce/Sources/DeepLinking/Route+Tree.swift
+++ b/Alicerce/Sources/DeepLinking/Route+Tree.swift
@@ -1,0 +1,270 @@
+//
+//  Route+Tree.swift
+//  Alicerce
+//
+//  Created by André Pacheco Neves on 15/04/2017.
+//  Copyright © 2017 Mindera. All rights reserved.
+//
+
+import Foundation
+
+extension Route {
+
+    indirect enum Tree<Handler> {
+
+        // MARK: Nested types
+
+        enum Error: Swift.Error {
+            case invalidRoute
+            case duplicateEmptyComponent
+            case conflictingParameterName(existing: String, new: String)
+            case routeNotFound
+            case invalidComponent(Component)
+        }
+
+        enum Edge {
+            case simple(Tree<Handler>)
+            case parameter(String?, Tree<Handler>)
+        }
+
+        typealias ChildEdges = [Component.Key : Edge]
+        typealias Match = (parameters: [String : String], handler: Handler)
+
+        // MARK: Implementation
+
+        case node(ChildEdges)
+        case leaf(Handler)
+
+        init(route: [Component], handler: Handler) throws {
+            switch route.first {
+            case nil:
+                self = .leaf(handler)
+            case .empty?:
+                guard route.count == 1 else { throw Error.invalidRoute }
+                
+                self = .leaf(handler)
+            case let currentComponent?:
+                let nextTree: Tree<Handler> = try Tree(route: Array(route.dropFirst()), handler: handler)
+                let edges: ChildEdges = [currentComponent.key : currentComponent.edge(for: nextTree)]
+                self = .node(edges)
+            }
+        }
+
+        mutating func add(route: [Component], handler: Handler) throws {
+            let currentComponent = route.first ?? .empty
+            let remainingRoute = Array(route.dropFirst())
+
+            switch self {
+            case var .node(edges):
+                if let matchingChildEdge = edges[currentComponent.key] {
+                    edges = try mergeTree(in: edges,
+                                          matchingChildEdge: matchingChildEdge,
+                                          currentComponent: currentComponent,
+                                          remainingRoute: remainingRoute,
+                                          handler: handler)
+                } else {
+                    edges = try createNewTree(in: edges,
+                                              currentComponent: currentComponent,
+                                              remainingRoute: remainingRoute,
+                                              handler: handler)
+                }
+
+                self = .node(edges)
+            case let .leaf(existingHandler):
+
+                // turn leaf into a normal node, since this branch will grow
+                let edges = try convertLeafToTree(existingHandler: existingHandler,
+                                                  currentComponent: currentComponent,
+                                                  remainingRoute: remainingRoute,
+                                                  handler: handler)
+                
+                self = .node(edges)
+            }
+        }
+
+        mutating func remove(route: [Component]) throws -> Handler {
+            switch self {
+            case var .node(edges):
+                let currentComponent = route.first ?? .empty
+                let remainingRoute = Array(route.dropFirst())
+                let childTree: Tree<Handler>
+
+                // validate if we have an *exact* match with one of the edges
+                switch edges[currentComponent.key] {
+                case let .simple(nextTree)?: childTree = nextTree
+                case let .parameter(nodeParameterName, nextTree)? :
+                    guard case let .variable(componentParameterName) = currentComponent else {
+                        fatalError("💥: Can't match .parameter edge with .empty or .constant component! 😱")
+                    }
+
+                    guard nodeParameterName == componentParameterName else { throw Error.routeNotFound }
+
+                    childTree = nextTree
+                case nil: throw Error.routeNotFound
+                }
+
+                return try removeFromChildTree(childTree,
+                                               edges: edges,
+                                               currentComponent: currentComponent,
+                                               remainingRoute: remainingRoute)
+            case let .leaf(handler):
+
+                // only match if the route is empty or contains a *single* .empty component
+                guard route.first ?? .empty == .empty, route.count <= 1 else {
+                    throw Error.routeNotFound
+                }
+
+                // extract the handler and change to an empty node, effectively removing the handler from the tree
+                self = .node([:])
+                return handler
+            }
+
+        }
+
+        func match(route: [Component]) throws -> Match {
+            switch self {
+            case let .node(edges):
+                let currentComponent = route.first ?? .empty
+                let remainingRoute = Array(route.dropFirst())
+
+                switch try matchChildEdge(in: edges, component: currentComponent) {
+                case let .simple(childTree)?:
+                    return try childTree.match(route: remainingRoute)
+                case let .parameter(parameterName, childTree)?:
+                    return try matchParameterEdge(parameterName: parameterName,
+                                                  childTree: childTree,
+                                                  currentComponent: currentComponent,
+                                                  remainingRoute: remainingRoute)
+                case nil:
+                    throw Error.routeNotFound
+                }
+            case let .leaf(handler):
+                
+                // only match if the route is empty or contains a *single* .empty component
+                guard route.first ?? .empty == .empty, route.count <= 1 else {
+                    throw Error.routeNotFound
+                }
+
+                return ([:], handler)
+            }
+        }
+
+        // MARK: Auxiliary
+
+        private func createNewTree(in edges: ChildEdges,
+                                   currentComponent: Component,
+                                   remainingRoute: [Component],
+                                   handler: Handler) throws -> ChildEdges {
+            var newEdges = edges
+            let newTree = try Tree<Handler>(route: remainingRoute, handler: handler)
+            newEdges[currentComponent.key] = currentComponent.edge(for: newTree)
+            return newEdges
+        }
+
+        private func mergeTree(in edges: ChildEdges,
+                               matchingChildEdge: Edge,
+                               currentComponent: Component,
+                               remainingRoute: [Component],
+                               handler: Handler) throws -> ChildEdges {
+            var childTree: Tree<Handler>
+
+            switch currentComponent {
+            case .empty:
+                // this node already has an empty edge, so reject addition
+                throw Error.duplicateEmptyComponent
+            case .constant:
+                guard case let .simple(nextTree) = matchingChildEdge else {
+                    fatalError("💥: Can't match .parameter edge with .constant component! 😱")
+                }
+
+                childTree = nextTree
+            case let .variable(newParameterName):
+                guard case let .parameter(existingParameterName, nextTree) = matchingChildEdge else {
+                    fatalError("💥: Can't match .simple edge with .variable component! 😱")
+                }
+
+                guard existingParameterName == newParameterName else {
+                    throw Error.conflictingParameterName(existing: existingParameterName ?? "*",
+                                                         new: newParameterName ?? "*")
+                }
+
+                childTree = nextTree
+            }
+
+            try childTree.add(route: remainingRoute, handler: handler)
+
+            var newEdges = edges
+            newEdges[currentComponent.key] = currentComponent.edge(for: childTree)
+
+            return newEdges
+        }
+
+        private func convertLeafToTree(existingHandler: Handler,
+                                       currentComponent: Component,
+                                       remainingRoute: [Component],
+                                       handler: Handler) throws -> ChildEdges {
+            if case .empty = currentComponent {
+                // leaves cannot grow with an already empty component
+                throw Error.duplicateEmptyComponent
+            }
+
+            let newTree = try Tree<Handler>(route: remainingRoute, handler: handler)
+            return [.empty : .simple(.leaf(existingHandler)),
+                    currentComponent.key : currentComponent.edge(for: newTree)]
+        }
+
+        private mutating func removeFromChildTree(_ childTree: Tree<Handler>,
+                                                  edges: ChildEdges,
+                                                  currentComponent: Component,
+                                                  remainingRoute: [Component]) throws -> Handler {
+            var childTree = childTree
+            let handler = try childTree.remove(route: remainingRoute)
+            var newEdges = edges
+
+            // remove the node completely if it became empty (a leaf matched), or update edges with new node
+            if case let .node(nextTreeChildren) = childTree, nextTreeChildren.isEmpty {
+                newEdges[currentComponent.key] = nil
+            } else {
+                newEdges[currentComponent.key] = currentComponent.edge(for: childTree)
+            }
+
+            self = .node(newEdges)
+            return handler
+        }
+
+        private func matchChildEdge(in edges: ChildEdges, component: Component) throws -> Edge? {
+            switch component.key {
+            case .empty:
+                // match empty values separately
+                return edges[.empty]
+            case .constant:
+                // match constants first as their constant value, then match as variables (parameter/wildcard)
+                return edges[component.key] ?? edges[.variable]
+            case .variable:
+                // routes should be matched against empty or constant values only
+                throw Error.invalidComponent(component)
+            }
+        }
+
+        private func matchParameterEdge(parameterName: String?,
+                                        childTree: Tree<Handler>,
+                                        currentComponent: Component,
+                                        remainingRoute: [Component]) throws -> Match {
+            let (parameters, handler) = try childTree.match(route: remainingRoute)
+             
+            guard let parameterName = parameterName else { return (parameters, handler) }
+
+            var allParameters = parameters
+
+            guard case let .constant(parameterValue) = currentComponent else {
+                assertionFailure("🔥: matched non `.constant` component \(currentComponent) to `parameter(\(parameterName))` edge!")
+                throw Error.routeNotFound
+            }
+
+            assert(allParameters[parameterName] == nil, "🔥: duplicate variable in route!")
+            allParameters[parameterName] = parameterValue
+
+            return (allParameters, handler)
+        }
+    }
+}

--- a/Alicerce/Sources/DeepLinking/Route.swift
+++ b/Alicerce/Sources/DeepLinking/Route.swift
@@ -9,6 +9,6 @@
 import Foundation
 
 public enum Route {
-    typealias Scheme = String
-    typealias Parameters = [String : String]
+    public typealias Scheme = String
+    public typealias Parameters = [String : String]
 }

--- a/Alicerce/Sources/DeepLinking/Route.swift
+++ b/Alicerce/Sources/DeepLinking/Route.swift
@@ -1,0 +1,14 @@
+//
+//  Route.swift
+//  Alicerce
+//
+//  Created by André Pacheco Neves on 15/04/2017.
+//  Copyright © 2017 Mindera. All rights reserved.
+//
+
+import Foundation
+
+public enum Route {
+    typealias Scheme = String
+    typealias Parameters = [String : String]
+}

--- a/Alicerce/Sources/DeepLinking/Router.swift
+++ b/Alicerce/Sources/DeepLinking/Router.swift
@@ -1,0 +1,164 @@
+//
+//  Router.swift
+//  Alicerce
+//
+//  Created by André Pacheco Neves on 10/04/2017.
+//  Copyright © 2017 Mindera. All rights reserved.
+//
+
+import UIKit
+
+protocol RouteHandler {
+    func handle(route: URL, parameters: [String : String], queryItems: [URLQueryItem])
+}
+
+protocol Router {
+    associatedtype Handler: RouteHandler
+
+    func register(_ route: URL, handler: Handler) throws
+    func unregister(_ route: URL) throws -> Handler
+
+    func route(_ route: URL) throws
+}
+
+final class TreeRouter<Handler: RouteHandler>: Router {
+
+    typealias Match = Route.Tree<Handler>.Match
+
+    private typealias Tree = Route.Tree<Handler>
+    private typealias AnnotatedParsedRoute = (scheme: Route.Scheme, components: [Route.Component])
+    private typealias ParsedRoute = (scheme: Route.Scheme, components: [Route.Component], queryItems: [URLQueryItem])
+
+    enum Error: Swift.Error {
+        case invalidRoute(InvalidRouteError)
+        case duplicateRoute
+        case routeNotFound
+
+        enum InvalidRouteError: Swift.Error {
+            case misplacedEmptyComponent
+            case conflictingVariableComponent(existing: String, new: String)
+            case invalidVariableComponent(String)
+            case invalidURL
+            case unexpected(Swift.Error)
+        }
+    }
+
+    private var routes: [Route.Scheme : Tree] = [:]
+    private let queue: DispatchQueue
+
+    init(qos: DispatchQoS = .default) {
+        queue = DispatchQueue(label: "com.mindera.Alicerce.\(type(of: self)).queue", qos: qos)
+    }
+
+    func register(_ route: URL, handler: Handler) throws {
+        let (scheme, routeComponents) = parseAnnotatedRoute(route)
+
+        try queue.sync { [unowned self] in
+
+            do {
+                if var schemeTree = self.routes[scheme] {
+                    try schemeTree.add(route: routeComponents, handler: handler)
+                    self.routes[scheme] = schemeTree
+                } else {
+                    self.routes[scheme] = try Tree(route: routeComponents, handler: handler)
+                }
+            } catch Tree.Error.duplicateEmptyComponent {
+                throw Error.duplicateRoute 
+            } catch Tree.Error.invalidRoute {
+                 // empty route elements are only allowed at the end of the route
+                throw Error.invalidRoute(.misplacedEmptyComponent)
+            } catch let Tree.Error.conflictingParameterName(existing, new) {
+                throw Error.invalidRoute(.conflictingVariableComponent(existing: existing, new: new))
+            } catch {
+                throw Error.invalidRoute(.unexpected(error))
+            }
+        }
+    }
+
+    func unregister(_ route: URL) throws -> Handler {
+        let (scheme, routeComponents) = parseAnnotatedRoute(route)
+
+        return try queue.sync { [unowned self] in
+            guard var schemeTree = self.routes[scheme] else { throw Error.routeNotFound }
+
+            let handler: Handler
+
+            do {
+                handler = try schemeTree.remove(route: routeComponents)
+            } catch Tree.Error.routeNotFound {
+                throw Error.routeNotFound
+            } catch {
+                assertionFailure("🔥: unexpected Route.Tree.Error type!")
+                // FIXME: add logging
+                print("⚠️: unexpected error when unregistering \(route)! Error: \(error)")
+                throw Error.routeNotFound
+            }
+
+            self.routes[scheme] = schemeTree
+
+            return handler
+        }
+    }
+
+    func route(_ route: URL) throws {
+        let (scheme, routeComponents, queryItems) = try parseRoute(route)
+
+        let match: Match = try queue.sync { [unowned self] in
+            guard let schemeTree = self.routes[scheme] else { throw Error.routeNotFound }
+
+            let match: Match
+            do {
+                match = try schemeTree.match(route: routeComponents)
+            } catch Tree.Error.routeNotFound {
+                throw Error.routeNotFound
+            } catch let Tree.Error.invalidComponent(component) {
+                throw Error.invalidRoute(.invalidVariableComponent(component.description))
+            } catch {
+                assertionFailure("🔥: unexpected Route.Tree.Error type!")
+                // FIXME: add logging
+                print("⚠️: unexpected error when routing \(route)! Error: \(error)")
+                throw Error.invalidRoute(.unexpected(error))
+            }
+
+            return match
+        }
+
+        match.handler.handle(route: route, parameters: match.parameters, queryItems: queryItems)
+    }
+
+    private func parseAnnotatedRoute(_ route: URL, appendEmpty: Bool = true) -> AnnotatedParsedRoute {
+        let scheme = route.scheme ?? ""
+
+        // use a wildcard for empty hosts, since we can't use an .empty component unless it's terminating a route
+        // TODO: evaluate if we should use a dummy value here too, e.g. "|empty|" (which crashes URL and URLComponent)
+        let hostComponent = Route.Component(component: route.host ?? "*")
+        let pathComponents = route.pathComponents.filter { $0 != "/" }.map(Route.Component.init(component:))
+
+        assert(route.query == nil, "🔥: URL query items are ignored when registering/unregistering routes!")
+
+        return (scheme: scheme, components: [hostComponent] + pathComponents)
+    }
+
+    private func parseRoute(_ route: URL, appendEmpty: Bool = true) throws -> ParsedRoute {
+        let scheme = route.scheme ?? ""
+
+        // use a dummy value for empty hosts, since we can't use an .empty component unless it's terminating a route
+        // and it will match registered wildcard routes (empty routes). "|empty|" should be safe since it crashes URL 
+        //and URLComponents creation, which should avoid collisions
+        let hostComponent = Route.Component(component: route.host ?? "|empty|") // this should be
+        var pathComponents = route.pathComponents.filter { $0 != "/" }.map(Route.Component.init(component:))
+
+        // add an empty path component if not already on the last position (to match leafs and empty nodes)
+        if pathComponents.last != .empty {
+            pathComponents.append(.empty)
+        }
+
+        let routeComponents = [hostComponent] + pathComponents
+
+        guard let urlComponents = URLComponents(url: route, resolvingAgainstBaseURL: false) else {
+            throw Error.invalidRoute(.invalidURL)
+        }
+
+        return (scheme: scheme, components: routeComponents, queryItems: urlComponents.queryItems ?? [])
+    }
+}

--- a/Alicerce/Sources/DeepLinking/Router.swift
+++ b/Alicerce/Sources/DeepLinking/Router.swift
@@ -8,11 +8,11 @@
 
 import UIKit
 
-protocol RouteHandler {
+public protocol RouteHandler {
     func handle(route: URL, parameters: [String : String], queryItems: [URLQueryItem])
 }
 
-protocol Router {
+public protocol Router {
     associatedtype Handler: RouteHandler
 
     func register(_ route: URL, handler: Handler) throws
@@ -50,7 +50,7 @@ final class TreeRouter<Handler: RouteHandler>: Router {
         queue = DispatchQueue(label: "com.mindera.Alicerce.\(type(of: self)).queue", qos: qos)
     }
 
-    func register(_ route: URL, handler: Handler) throws {
+    public func register(_ route: URL, handler: Handler) throws {
         let (scheme, routeComponents) = parseAnnotatedRoute(route)
 
         try queue.sync { [unowned self] in
@@ -75,7 +75,7 @@ final class TreeRouter<Handler: RouteHandler>: Router {
         }
     }
 
-    func unregister(_ route: URL) throws -> Handler {
+    public func unregister(_ route: URL) throws -> Handler {
         let (scheme, routeComponents) = parseAnnotatedRoute(route)
 
         return try queue.sync { [unowned self] in
@@ -100,15 +100,14 @@ final class TreeRouter<Handler: RouteHandler>: Router {
         }
     }
 
-    func route(_ route: URL) throws {
+    public func route(_ route: URL) throws {
         let (scheme, routeComponents, queryItems) = try parseRoute(route)
 
         let match: Match = try queue.sync { [unowned self] in
             guard let schemeTree = self.routes[scheme] else { throw Error.routeNotFound }
 
-            let match: Match
             do {
-                match = try schemeTree.match(route: routeComponents)
+                return try schemeTree.match(route: routeComponents)
             } catch Tree.Error.routeNotFound {
                 throw Error.routeNotFound
             } catch let Tree.Error.invalidComponent(component) {
@@ -119,8 +118,6 @@ final class TreeRouter<Handler: RouteHandler>: Router {
                 print("⚠️: unexpected error when routing \(route)! Error: \(error)")
                 throw Error.invalidRoute(.unexpected(error))
             }
-
-            return match
         }
 
         match.handler.handle(route: route, parameters: match.parameters, queryItems: queryItems)

--- a/AlicerceTests/Sources/DeepLinking/Route+ComponentTests.swift
+++ b/AlicerceTests/Sources/DeepLinking/Route+ComponentTests.swift
@@ -1,0 +1,368 @@
+//
+//  Route+ComponentTests.swift
+//  Alicerce
+//
+//  Created by André Pacheco Neves on 17/04/2017.
+//  Copyright © 2017 Mindera. All rights reserved.
+//
+
+import XCTest
+@testable import Alicerce
+
+class Route_ComponentTests: XCTestCase {
+
+    // MARK: init
+    
+    func testInit_WithEmptyString_ShouldCreateEmptyComponent() {
+
+        let testValue = ""
+        guard case .empty = Route.Component(component:testValue) else {
+            return XCTFail("🔥: unexpected component!")
+        }
+        guard case .empty = Route.Component(stringLiteral: testValue) else {
+            return XCTFail("🔥: unexpected component!")
+        }
+        guard case .empty = Route.Component(extendedGraphemeClusterLiteral: testValue) else {
+            return XCTFail("🔥: unexpected component!")
+        }
+        guard case .empty = Route.Component(unicodeScalarLiteral: testValue) else {
+            return XCTFail("🔥: unexpected component!")
+        }
+    }
+
+    func testInit_WithConstantString_ShouldCreateConstantComponent() {
+
+        let testValue = "test"
+        guard case let .constant(valueA) = Route.Component(component:testValue) else {
+            return XCTFail("🔥: unexpected component!")
+        }
+        guard case let .constant(valueB) = Route.Component(stringLiteral: testValue) else {
+            return XCTFail("🔥: unexpected component!")
+        }
+        guard case let .constant(valueC) = Route.Component(extendedGraphemeClusterLiteral: testValue) else {
+            return XCTFail("🔥: unexpected component!")
+        }
+        guard case let .constant(valueD) = Route.Component(unicodeScalarLiteral: testValue) else {
+            return XCTFail("🔥: unexpected component!")
+        }
+
+        XCTAssertEqual(valueA, testValue)
+        XCTAssertEqual(valueB, testValue)
+        XCTAssertEqual(valueC, testValue)
+        XCTAssertEqual(valueD, testValue)
+    }
+
+    func testInit_WithParameterString_ShouldCreateVariableComponentWithMatchingParameterName() {
+
+        let testParameterName = "test"
+        let testValue = ":" + testParameterName
+        guard case let .variable(parameterNameA) = Route.Component(component:testValue) else {
+            return XCTFail("🔥: unexpected component!")
+        }
+        guard case let .variable(parameterNameB) = Route.Component(stringLiteral: testValue) else {
+            return XCTFail("🔥: unexpected component!")
+        }
+        guard case let .variable(parameterNameC) = Route.Component(extendedGraphemeClusterLiteral: testValue) else {
+            return XCTFail("🔥: unexpected component!")
+        }
+        guard case let .variable(parameterNameD) = Route.Component(unicodeScalarLiteral: testValue) else {
+            return XCTFail("🔥: unexpected component!")
+        }
+
+        XCTAssertEqual(parameterNameA, testParameterName)
+        XCTAssertEqual(parameterNameB, testParameterName)
+        XCTAssertEqual(parameterNameC, testParameterName)
+        XCTAssertEqual(parameterNameD, testParameterName)
+    }
+
+    func testInit_WithWildcardString_ShouldCreateVariableComponentWithNilParameterName() {
+
+        let testValue = "*"
+        guard case let .variable(parameterNameA) = Route.Component(component:testValue) else {
+            return XCTFail("🔥: unexpected component!")
+        }
+        guard case let .variable(parameterNameB) = Route.Component(stringLiteral: testValue) else {
+            return XCTFail("🔥: unexpected component!")
+        }
+        guard case let .variable(parameterNameC) = Route.Component(extendedGraphemeClusterLiteral: testValue) else {
+            return XCTFail("🔥: unexpected component!")
+        }
+        guard case let .variable(parameterNameD) = Route.Component(unicodeScalarLiteral: testValue) else {
+            return XCTFail("🔥: unexpected component!")
+        }
+
+        XCTAssertNil(parameterNameA)
+        XCTAssertNil(parameterNameB)
+        XCTAssertNil(parameterNameC)
+        XCTAssertNil(parameterNameD)
+    }
+
+    // MARK: key
+
+    func testKey_WithEmptyComponent_ShouldReturnEmptyKey() {
+
+        let testComponent: Route.Component = ""
+
+        guard case .empty = testComponent.key else {
+            return XCTFail("🔥: unexpected key!")
+        }
+    }
+
+    func testKey_WithConstantComponent_ShouldReturnConstantKey() {
+
+        let testConstantName = "constant"
+        let testComponent = Route.Component(component:testConstantName)
+
+        guard case let .constant(value) = testComponent.key else {
+            return XCTFail("🔥: unexpected key!")
+        }
+
+        XCTAssertEqual(value, testConstantName)
+    }
+
+    func testKey_WithVariableComponent_ShouldReturnVariableKey() {
+
+        var testComponent: Route.Component = ":variable"
+
+        guard case .variable = testComponent.key else {
+            return XCTFail("🔥: unexpected key!")
+        }
+
+        testComponent = "*"
+
+        guard case .variable = testComponent.key else {
+            return XCTFail("🔥: unexpected key!")
+        }
+    }
+
+    // MARK: edge
+
+    func testEdge_WithEmptyComponent_ShouldReturnSimpleEdge() {
+
+        let testHandler: String = "test"
+        let testTree: Route.Tree<String> = .leaf(testHandler)
+        let testComponent: Route.Component = ""
+
+        guard case let .simple(.leaf(handler)) = testComponent.edge(for: testTree) else {
+            return XCTFail("🔥: unexpected edge!")
+        }
+
+        XCTAssertEqual(handler, testHandler)
+    }
+
+    func testEdge_WithConstantComponent_ShouldReturnSimpleEdge() {
+
+        let testHandler: String = "test"
+        let testTree: Route.Tree<String> = .leaf(testHandler)
+        let testComponent: Route.Component = "constant"
+
+        guard case let .simple(.leaf(handler)) = testComponent.edge(for: testTree) else {
+            return XCTFail("🔥: unexpected edge!")
+        }
+
+        XCTAssertEqual(handler, testHandler)
+    }
+
+    func testEdge_WithValueVariableComponent_ShouldReturnVariableEdgeWithMatchingParameter() {
+
+        let testHandler: String = "test"
+        let testTree: Route.Tree<String> = .leaf(testHandler)
+        let testParameterName = "parameter"
+        let testComponent = Route.Component(component:":" + testParameterName)
+
+        guard case let .parameter(parameterName, .leaf(handler)) = testComponent.edge(for: testTree) else {
+            return XCTFail("🔥: unexpected edge!")
+        }
+
+        XCTAssertEqual(handler, testHandler)
+        XCTAssertEqual(parameterName, testParameterName)
+    }
+
+    func testEdge_WithWildcardVariableComponent_ShouldReturnVariableEdgeWithNilParameter() {
+
+        let testHandler: String = "test"
+        let testTree: Route.Tree<String> = .leaf(testHandler)
+        let testComponent: Route.Component = "*"
+
+        guard case let .parameter(parameterName, .leaf(handler)) = testComponent.edge(for: testTree) else {
+            return XCTFail("🔥: unexpected edge!")
+        }
+
+        XCTAssertEqual(handler, testHandler)
+        XCTAssertNil(parameterName)
+    }
+
+    // MARK: description
+
+    func testDescription_ShouldMatchValue() {
+
+        let empty: Route.Component = ""
+        XCTAssertEqual(empty.description, "")
+
+        let constant: Route.Component = "constant"
+        XCTAssertEqual(constant.description, "constant")
+
+        let valueVariable: Route.Component = ":variable"
+        XCTAssertEqual(valueVariable.description, ":variable")
+
+        let wildcardVariable: Route.Component = "*"
+        XCTAssertEqual(wildcardVariable.description, "*")
+    }
+
+    // MARK: debugDescription
+
+    func testDebugDescription_ShouldMatchValue() {
+
+        let empty: Route.Component = ""
+        XCTAssertEqual(empty.debugDescription, ".empty")
+
+        let constant: Route.Component = "constant"
+        XCTAssertEqual(constant.debugDescription, ".constant(constant)")
+
+        let valueVariable: Route.Component = ":variable"
+        XCTAssertEqual(valueVariable.debugDescription, ".variable(variable)")
+
+        let wildcardVariable: Route.Component = "*"
+        XCTAssertEqual(wildcardVariable.debugDescription, ".variable(*)")
+    }
+
+    // MARK: hashValue
+
+    func testHashValue_ShouldMatchSameValues() {
+
+        let empty: Route.Component = ""
+        let empty2: Route.Component = ""
+
+        let constant: Route.Component = "constant"
+        let constant2: Route.Component = "constant"
+
+        let valueVariable: Route.Component = ":variable"
+        let valueVariable2: Route.Component = ":variable"
+
+        let wildcardVariable: Route.Component = "*"
+        let wildcardVariable2: Route.Component = "*"
+
+        XCTAssertEqual(empty.hashValue, empty2.hashValue)
+        XCTAssertEqual(constant.hashValue, constant2.hashValue)
+        XCTAssertEqual(valueVariable.hashValue, valueVariable2.hashValue)
+        XCTAssertEqual(wildcardVariable.hashValue, wildcardVariable2.hashValue)
+    }
+
+    func testHashValue_ShouldNotMatchDifferentValues() {
+
+        let empty: Route.Component = ""
+
+        let constant: Route.Component = "constant"
+        let constant2: Route.Component = "constant2"
+
+        let valueVariable: Route.Component = ":variable"
+        let valueVariable2: Route.Component = ":variable2"
+
+        let wildcardVariable: Route.Component = "*"
+
+        XCTAssertNotEqual(empty.hashValue, constant.hashValue)
+        XCTAssertNotEqual(empty.hashValue, valueVariable.hashValue)
+        XCTAssertNotEqual(empty.hashValue, wildcardVariable.hashValue)
+
+        XCTAssertNotEqual(constant.hashValue, constant2.hashValue)
+        XCTAssertNotEqual(constant.hashValue, valueVariable.hashValue)
+        XCTAssertNotEqual(constant.hashValue, wildcardVariable.hashValue)
+
+        XCTAssertNotEqual(valueVariable.hashValue, valueVariable2.hashValue)
+        XCTAssertNotEqual(valueVariable.hashValue, wildcardVariable.hashValue)
+    }
+
+    // MARK: ==
+
+    func testEquals_ShouldMatchSameValues() {
+
+        let empty: Route.Component = ""
+        let constant: Route.Component = "constant"
+        let valueVariable: Route.Component = ":variable"
+        let wildcardVariable: Route.Component = "*"
+
+        XCTAssertEqual(empty, empty)
+        XCTAssertEqual(constant, constant)
+        XCTAssertEqual(valueVariable, valueVariable)
+        XCTAssertEqual(wildcardVariable, wildcardVariable)
+    }
+
+    func testEquals_ShouldNotMatchDifferentValues() {
+
+        let empty: Route.Component = ""
+        let constant: Route.Component = "constant"
+        let constant2: Route.Component = "constant2"
+        let valueVariable: Route.Component = ":variable"
+        let valueVariable2: Route.Component = ":variable2"
+        let wildcardVariable: Route.Component = "*"
+
+        XCTAssertNotEqual(empty, constant)
+        XCTAssertNotEqual(empty, valueVariable)
+        XCTAssertNotEqual(empty, wildcardVariable)
+
+        XCTAssertNotEqual(constant, constant2)
+        XCTAssertNotEqual(constant, valueVariable)
+        XCTAssertNotEqual(constant, wildcardVariable)
+
+        XCTAssertNotEqual(valueVariable, valueVariable2)
+        XCTAssertNotEqual(valueVariable, wildcardVariable)
+    }
+
+    // MARK: - Key
+
+    func testKeyHashValue_ShouldMatchSameValues() {
+
+        let empty: Route.Component.Key = .empty
+        let empty2: Route.Component.Key = .empty
+        let constant: Route.Component.Key = .constant("constant")
+        let constant2: Route.Component.Key = .constant("constant")
+        let variable: Route.Component.Key = .variable
+        let variable2: Route.Component.Key = .variable
+
+        XCTAssertEqual(empty.hashValue, empty2.hashValue)
+        XCTAssertEqual(constant.hashValue, constant2.hashValue)
+        XCTAssertEqual(variable.hashValue, variable2.hashValue)
+    }
+
+    func testKeyHashValue_ShouldNotMatchDifferentValues() {
+
+        let empty: Route.Component.Key = .empty
+        let constant: Route.Component.Key = .constant("constant")
+        let constant2: Route.Component.Key = .constant("constant2")
+        let variable: Route.Component.Key = .variable
+
+        XCTAssertNotEqual(empty.hashValue, constant.hashValue)
+        XCTAssertNotEqual(empty.hashValue, variable.hashValue)
+
+        XCTAssertNotEqual(constant.hashValue, constant2.hashValue)
+        XCTAssertNotEqual(constant.hashValue, variable.hashValue)
+    }
+
+    // MARK: ==
+
+    func testKeyEquals_ShouldMatchSameValues() {
+
+        let empty: Route.Component.Key = .empty
+        let constant: Route.Component.Key = .constant("constant")
+        let variable: Route.Component.Key = .variable
+
+        XCTAssertEqual(empty, empty)
+        XCTAssertEqual(constant, constant)
+        XCTAssertEqual(variable, variable)
+    }
+
+    func testKeyEquals_ShouldNotMatchDifferentValues() {
+
+        let empty: Route.Component.Key = .empty
+        let constant: Route.Component.Key = .constant("constant")
+        let constant2: Route.Component.Key = .constant("constant2")
+        let variable: Route.Component.Key = .variable
+
+        XCTAssertNotEqual(empty, constant)
+        XCTAssertNotEqual(empty, variable)
+
+        XCTAssertNotEqual(constant, constant2)
+        XCTAssertNotEqual(constant, variable)
+    }
+
+}

--- a/AlicerceTests/Sources/DeepLinking/Route+Tree_AddTests.swift
+++ b/AlicerceTests/Sources/DeepLinking/Route+Tree_AddTests.swift
@@ -1,0 +1,403 @@
+//
+//  Route+Tree_AddTests.swift
+//  Alicerce
+//
+//  Created by André Pacheco Neves on 16/04/2017.
+//  Copyright © 2017 Mindera. All rights reserved.
+//
+
+import XCTest
+@testable import Alicerce
+
+class Route_Tree_AddTests: XCTestCase {
+    
+    typealias TestTree = Route.Tree<String>
+
+    let testHandler = "test"
+
+    // MARK: - Error cases
+
+    func testAdd_WithEmptyRouteOnLeaf_ShouldFail() {
+
+        var testTree: TestTree = .leaf(testHandler)
+
+        do {
+            try testTree.add(route: [], handler: "💥")
+            XCTFail("🔥: unexpected success!")
+        } catch TestTree.Error.duplicateEmptyComponent {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testAdd_WithEmptyRouteOnTree_ShouldFail() {
+
+        var testTree: TestTree = .node([.empty : .simple(.leaf(testHandler))])
+
+        do {
+            try testTree.add(route: [], handler: "💥")
+            XCTFail("🔥: unexpected success!")
+        } catch TestTree.Error.duplicateEmptyComponent {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testAdd_WithEmptyComponentRouteOnLeaf_ShouldFail() {
+
+        var testTree: TestTree = .leaf(testHandler)
+
+        do {
+            try testTree.add(route: [.empty], handler: "💥")
+            XCTFail("🔥: unexpected success!")
+        } catch TestTree.Error.duplicateEmptyComponent {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testAdd_WithEmptyComponentRouteOnTreeWithEmptyChildEdge_ShouldFail() {
+
+        var testTree: TestTree = .node([.empty : .simple(.leaf(testHandler))])
+
+        do {
+            try testTree.add(route: [.empty], handler: "💥")
+            XCTFail("🔥: unexpected success!")
+        } catch TestTree.Error.duplicateEmptyComponent {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testAdd_WithParameterVariableComponentRouteOnTreeWithVariableParameterChildEdgeWithConflictingName_ShouldFail() {
+
+        let testParameterName = "testParameterName"
+        var testTree: TestTree = .node([.variable : .parameter(testParameterName, .leaf(testHandler))])
+
+        let newParameterName = "newParameterName"
+        let newComponent = Route.Component(component: ":" + newParameterName)
+
+        do {
+            try testTree.add(route: [newComponent], handler: "💥")
+            XCTFail("🔥: unexpected success!")
+        } catch let TestTree.Error.conflictingParameterName(existing, new) {
+            XCTAssertEqual(existing, testParameterName)
+            XCTAssertEqual(new, newParameterName)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testAdd_WithWildcardVariableComponentRouteOnTreeWithVariableParameterChildEdge_ShouldFail() {
+
+        let testParameterName = "testParameterName"
+        var testTree: TestTree = .node([.variable : .parameter(testParameterName, .leaf(testHandler))])
+
+        let newComponent = Route.Component(component: "*")
+
+        do {
+            try testTree.add(route: [newComponent], handler: "💥")
+            XCTFail("🔥: unexpected success!")
+        } catch let TestTree.Error.conflictingParameterName(existing, new) {
+            XCTAssertEqual(existing, testParameterName)
+            XCTAssertEqual(new, "*")
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testAdd_WithParameterVariableComponentRouteOnTreeWithWildcardVariableParameterChildEdge_ShouldFail() {
+
+        var testTree: TestTree = .node([.variable : .parameter(nil, .leaf(testHandler))])
+
+        let newParameterName = "newParameterName"
+        let newComponent = Route.Component(component: ":" + newParameterName)
+
+        do {
+            try testTree.add(route: [newComponent], handler: "💥")
+            XCTFail("🔥: unexpected success!")
+        } catch let TestTree.Error.conflictingParameterName(existing, new) {
+            XCTAssertEqual(existing, "*")
+            XCTAssertEqual(new, newParameterName)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    // MARK: - Success cases
+
+    // MARK: on leaf
+
+    func testAdd_WithSingleComponentRouteOnLeaf_ShouldUpdateLeafToTreeWithNewRouteLeafAndEmptyLeaf() {
+
+        var testTree: TestTree = .leaf(testHandler)
+
+        let newHandler = "newHandler"
+        let newComponent = Route.Component(component: "a")
+        let newRoute = [newComponent]
+
+        do {
+            try testTree.add(route: newRoute, handler: newHandler)
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(newChildEdges) = testTree else {
+            return XCTFail("🔥: unexpected node type!")
+        }
+        guard case let .simple(.leaf(emptyLeafHandler))? = newChildEdges[.empty] else {
+            return XCTFail("🔥: unexpected empty child edge!")
+        }
+        guard case let .simple(.leaf(handler))? = newChildEdges[newComponent.key] else {
+            return XCTFail("🔥: unexpected new child edge!")
+        }
+
+        XCTAssertEqual(emptyLeafHandler, testHandler)
+        XCTAssertEqual(handler, newHandler)
+    }
+
+    func testAdd_WithMultiComponentRouteOnLeaf_ShouldUpdateLeafToTreeWithNewRouteTreesAndLastComponentLeafAndEmptyLeaf() {
+
+        var testTree: TestTree = .leaf(testHandler)
+
+        let newHandler = "newHandler"
+        let newComponentA = Route.Component(component: "a")
+        let newComponentB = Route.Component(component: "b")
+        let newRoute = [newComponentA, newComponentB]
+
+        do {
+            try testTree.add(route: newRoute, handler: newHandler)
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(newChildEdges) = testTree else {
+            return XCTFail("🔥: unexpected node type!")
+        }
+        guard case let .simple(.leaf(emptyLeafHandler))? = newChildEdges[.empty] else {
+            return XCTFail("🔥: unexpected empty child edge!")
+        }
+        guard case let .simple(.node(newChildEdgesA))? = newChildEdges[newComponentA.key] else {
+            return XCTFail("🔥: unexpected new child A edge!")
+        }
+        guard case let .simple(.leaf(handler))? = newChildEdgesA[newComponentB.key] else {
+            return XCTFail("🔥: unexpected new child B edge!")
+        }
+
+        XCTAssertEqual(emptyLeafHandler, testHandler)
+        XCTAssertEqual(handler, newHandler)
+    }
+
+    // MARK: on single child node
+
+    func testAdd_WithSingleComponentRouteOnTree_ShouldUpdateTreeWithNewRouteLeaf() {
+
+        var testTree: TestTree = .node([.empty : .simple(.leaf(testHandler))])
+
+        let newHandler = "newHandler"
+        let newComponent = Route.Component(component: "a")
+        let newRoute = [newComponent]
+
+        do {
+            try testTree.add(route: newRoute, handler: newHandler)
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(newChildEdges) = testTree else {
+            return XCTFail("🔥: unexpected node type!")
+        }
+        guard case let .simple(.leaf(emptyLeafHandler))? = newChildEdges[.empty] else {
+            return XCTFail("🔥: unexpected empty child edge!")
+        }
+        guard case let .simple(.leaf(handler))? = newChildEdges[newComponent.key] else {
+            return XCTFail("🔥: unexpected new child edge!")
+        }
+
+        XCTAssertEqual(emptyLeafHandler, testHandler)
+        XCTAssertEqual(handler, newHandler)
+    }
+
+    func testAdd_WithMultiComponentRouteOnTree_ShouldUpdateTreeWithNewRouteTreesAndLastComponentLeaf() {
+
+        var testTree: TestTree = .node([.empty : .simple(.leaf(testHandler))])
+
+        let newHandler = "newHandler"
+        let newComponentA = Route.Component(component: "a")
+        let newComponentB = Route.Component(component: "b")
+        let newRoute = [newComponentA, newComponentB]
+
+        do {
+            try testTree.add(route: newRoute, handler: newHandler)
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(newChildEdges) = testTree else {
+            return XCTFail("🔥: unexpected node type!")
+        }
+        guard case let .simple(.leaf(emptyLeafHandler))? = newChildEdges[.empty] else {
+            return XCTFail("🔥: unexpected empty child edge!")
+        }
+        guard case let .simple(.node(newChildEdgesA))? = newChildEdges[newComponentA.key] else {
+            return XCTFail("🔥: unexpected new child A edge!")
+        }
+        guard case let .simple(.leaf(handler))? = newChildEdgesA[newComponentB.key] else {
+            return XCTFail("🔥: unexpected new child B edge!")
+        }
+
+        XCTAssertEqual(emptyLeafHandler, testHandler)
+        XCTAssertEqual(handler, newHandler)
+    }
+
+    func testAdd_WithMultiComponentRouteOnTreeMatchingSimpleExistingLeaf_ShouldUpdateTreeWithNewRouteTreesMakeEmptyLeafAndLastComponentLeaf() {
+
+        var testTree: TestTree = .node([.constant("a") : .simple(.leaf(testHandler))])
+
+        let newHandler = "newHandler"
+        let newComponentA = Route.Component(component: "a")
+        let newComponentB = Route.Component(component: "b")
+        let newRoute = [newComponentA, newComponentB]
+
+        do {
+            try testTree.add(route: newRoute, handler: newHandler)
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(newChildEdges) = testTree else {
+            return XCTFail("🔥: unexpected node type!")
+        }
+        guard case let .simple(.node(newChildEdgesA))? = newChildEdges[newComponentA.key] else {
+            return XCTFail("🔥: unexpected child A edge!")
+        }
+        guard case let .simple(.leaf(existingHandler))? = newChildEdgesA[.empty] else {
+            return XCTFail("🔥: unexpected existing child A empty edge!")
+        }
+        guard case let .simple(.leaf(handler))? = newChildEdgesA[newComponentB.key] else {
+            return XCTFail("🔥: unexpected new child A B edge!")
+        }
+
+        XCTAssertEqual(existingHandler, testHandler)
+        XCTAssertEqual(handler, newHandler)
+    }
+
+    func testAdd_WithMultiComponentRouteOnTreeMatchingVariableExistingLeaf_ShouldUpdateTreeWithNewRouteTreesMakeEmptyLeafAndLastComponentLeaf() {
+
+        let testParameterName = "a"
+        var testTree: TestTree = .node([.variable : .parameter(testParameterName, .leaf(testHandler))])
+
+        let newHandler = "newHandler"
+        let newComponentA = Route.Component(component: ":" + testParameterName)
+        let newComponentB = Route.Component(component: "b")
+        let newRoute = [newComponentA, newComponentB]
+
+        do {
+            try testTree.add(route: newRoute, handler: newHandler)
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(newChildEdges) = testTree else {
+            return XCTFail("🔥: unexpected node type!")
+        }
+        guard case let .parameter(parameterName, .node(newChildEdgesA))? = newChildEdges[newComponentA.key] else {
+            return XCTFail("🔥: unexpected child A edge!")
+        }
+        guard case let .simple(.leaf(existingHandler))? = newChildEdgesA[.empty] else {
+            return XCTFail("🔥: unexpected existing child A empty edge!")
+        }
+        guard case let .simple(.leaf(handler))? = newChildEdgesA[newComponentB.key] else {
+            return XCTFail("🔥: unexpected new child A B edge!")
+        }
+
+        XCTAssertEqual(parameterName, testParameterName)
+        XCTAssertEqual(existingHandler, testHandler)
+        XCTAssertEqual(handler, newHandler)
+    }
+
+    // MARK: on multi child node
+
+    func testAdd_WithNonEmptyMultiComponentRouteOnTreeMatchingSimpleExistingTree_ShouldUpdateTreeWithNewRouteTreesMakeEmptyLeafAndLastComponentLeaf() {
+
+        let nestedTree: TestTree = .node([.constant("b") : .simple(.leaf(testHandler))])
+        var testTree: TestTree = .node([.constant("a") : .simple(nestedTree)])
+
+        let newHandler = "newHandler"
+        let newComponentA = Route.Component(component: "a")
+        let newComponentB = Route.Component(component: "b")
+        let newComponentC = Route.Component(component: "c")
+        let newRoute = [newComponentA, newComponentB, newComponentC]
+
+        do {
+            try testTree.add(route: newRoute, handler: newHandler)
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(newChildEdges) = testTree else {
+            return XCTFail("🔥: unexpected node type!")
+        }
+        guard case let .simple(.node(newChildEdgesA))? = newChildEdges[newComponentA.key] else {
+            return XCTFail("🔥: unexpected child A edge!")
+        }
+        guard case let .simple(.node(newChildEdgesB))? = newChildEdgesA[newComponentB.key] else {
+            return XCTFail("🔥: unexpected child B edge!")
+        }
+        guard case let .simple(.leaf(existingHandler))? = newChildEdgesB[.empty] else {
+            return XCTFail("🔥: unexpected existing child B empty edge!")
+        }
+        guard case let .simple(.leaf(handler))? = newChildEdgesB[newComponentC.key] else {
+            return XCTFail("🔥: unexpected new child B C edge!")
+        }
+
+        XCTAssertEqual(existingHandler, testHandler)
+        XCTAssertEqual(handler, newHandler)
+    }
+
+    func testAdd_WithNonEmptyMultiComponentRouteOnTreeMatchingVariableExistingTree_ShouldUpdateTreeWithNewRouteTreesMakeEmptyLeafAndLastComponentLeaf() {
+
+        let testParameterNameA = "a"
+        let testParameterNameB = "b"
+
+        let nestedTree: TestTree = .node([.variable : .parameter(testParameterNameB, .leaf(testHandler))])
+        var testTree: TestTree = .node([.variable : .parameter(testParameterNameA, nestedTree)])
+
+        let newHandler = "newHandler"
+        let newComponentA = Route.Component(component: ":" + testParameterNameA)
+        let newComponentB = Route.Component(component: ":" + testParameterNameB)
+        let newComponentC = Route.Component(component: "c")
+        let newRoute = [newComponentA, newComponentB, newComponentC]
+
+        do {
+            try testTree.add(route: newRoute, handler: newHandler)
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(newChildEdges) = testTree else {
+            return XCTFail("🔥: unexpected node type!")
+        }
+        guard case let .parameter(parameterNameA, .node(newChildEdgesA))? = newChildEdges[newComponentA.key] else {
+            return XCTFail("🔥: unexpected child A edge!")
+        }
+        guard case let .parameter(parameterNameB, .node(newChildEdgesB))? = newChildEdgesA[newComponentB.key] else {
+            return XCTFail("🔥: unexpected child A B edge!")
+        }
+        guard case let .simple(.leaf(existingHandler))? = newChildEdgesB[.empty] else {
+            return XCTFail("🔥: unexpected existing child B empty edge!")
+        }
+        guard case let .simple(.leaf(handler))? = newChildEdgesB[newComponentC.key] else {
+            return XCTFail("🔥: unexpected new child B C edge!")
+        }
+        
+        XCTAssertEqual(parameterNameA, testParameterNameA)
+        XCTAssertEqual(parameterNameB, testParameterNameB)
+        XCTAssertEqual(existingHandler, testHandler)
+        XCTAssertEqual(handler, newHandler)
+    }
+}

--- a/AlicerceTests/Sources/DeepLinking/Route+Tree_InitTests.swift
+++ b/AlicerceTests/Sources/DeepLinking/Route+Tree_InitTests.swift
@@ -1,0 +1,242 @@
+//
+//  Route+Tree_InitTests.swift
+//  Alicerce
+//
+//  Created by André Pacheco Neves on 16/04/2017.
+//  Copyright © 2017 Mindera. All rights reserved.
+//
+
+import XCTest
+@testable import Alicerce
+
+class Route_Tree_InitTests: XCTestCase {
+
+    typealias TestTree = Route.Tree<String>
+
+    let testHandler = "test"
+
+    // MARK: errors
+
+    func testInit_WithRouteWithComponentAfterEmptyElement_ShouldFail() {
+
+        do {
+            let _ = try TestTree(route: [.empty, .empty], handler: testHandler)
+            XCTFail("🔥: unexpected success!")
+        } catch Route.Tree<String>.Error.invalidRoute {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let _ = try TestTree(route: [.empty, .constant("a")], handler: testHandler)
+            XCTFail("🔥: unexpected success!")
+        } catch Route.Tree<String>.Error.invalidRoute {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let _ = try TestTree(route: [.empty, .variable("a")], handler: testHandler)
+            XCTFail("🔥: unexpected success!")
+        } catch Route.Tree<String>.Error.invalidRoute {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let _ = try TestTree(route: [.empty, .variable(nil)], handler: testHandler)
+            XCTFail("🔥: unexpected success!")
+        } catch Route.Tree<String>.Error.invalidRoute {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    // MARK: success
+
+    // MARK: single level node
+
+    func testInit_WithEmptyRoute_ShouldCreateLeaf() {
+
+        do {
+            guard case let .leaf(handler) = try TestTree(route: [], handler: testHandler) else {
+                return XCTFail("🔥: unexpected node type!")
+            }
+
+            XCTAssertEqual(handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testInit_WithNonEmptyRouteAndEmptyComponent_ShouldCreateLeaf() {
+
+        let testComponent = Route.Component(component: "")
+        let testRoute = [testComponent]
+
+        do {
+            guard case let .leaf(handler) = try TestTree(route: testRoute, handler: testHandler) else {
+                return XCTFail("🔥: unexpected node type!")
+            }
+
+            XCTAssertEqual(handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testInit_WithNonEmptyRouteAndConstantComponent_ShouldCreateTreeWithSimpleEdge() {
+
+        let testComponent = Route.Component(component: "a")
+        let testRoute = [testComponent]
+
+        do {
+            guard case let .node(childEdges) = try TestTree(route: testRoute, handler: testHandler) else {
+                return XCTFail("🔥: unexpected node type!")
+            }
+            guard case let .simple(.leaf(handler))? = childEdges[testComponent.key] else {
+                return XCTFail("🔥: unexpected child A edge!")
+            }
+
+            XCTAssertEqual(handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testInit_WithNonEmptyRouteAndWildcardVariableComponent_ShouldCreateTreeWithSimpleEdge() {
+
+        let testComponent = Route.Component(component: "*")
+        let testRoute = [testComponent]
+
+        do {
+            guard case let .node(childEdges) = try TestTree(route: testRoute, handler: testHandler) else {
+                return XCTFail("🔥: unexpected node type!")
+            }
+            guard case let .parameter(nil, .leaf(handler))? = childEdges[testComponent.key] else {
+                return XCTFail("🔥: unexpected child A edge!")
+            }
+
+            XCTAssertEqual(handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testInit_WithNonEmptyRouteAndParameterVariableComponent_ShouldCreateTreeWithParameterEdge() {
+
+        let testParameterName = "a"
+        let testComponent = Route.Component(component: ":" + testParameterName)
+        let testRoute = [testComponent]
+
+        do {
+            guard case let .node(childEdges) = try TestTree(route: testRoute, handler: testHandler) else {
+                return XCTFail("🔥: unexpected node type!")
+            }
+            guard case let .parameter(parameterName, .leaf(handler))? = childEdges[testComponent.key] else {
+                return XCTFail("🔥: unexpected child A edge!")
+            }
+
+            XCTAssertEqual(parameterName, testParameterName)
+            XCTAssertEqual(handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    // MARK: multi level node
+
+    func testInit_WithNonEmptyRouteAndConstantComponents_ShouldCreateTreesWithSimpleEdges() {
+
+        let componentA = Route.Component(component: "a")
+        let componentB = Route.Component(component: "b")
+        let componentC = Route.Component(component: "c")
+
+        let testRoute = [componentA, componentB, componentC]
+
+        do {
+            guard case let .node(childEdges) = try TestTree(route: testRoute, handler: testHandler) else {
+                return XCTFail("🔥: unexpected node type!")
+            }
+            guard case let .simple(.node(nodeAChildEdges))? = childEdges[componentA.key] else {
+                return XCTFail("🔥: unexpected child A edge!")
+            }
+            guard case let .simple(.node(nodeBChildEdges))? = nodeAChildEdges[componentB.key] else {
+                return XCTFail("🔥: unexpected child B edge!")
+            }
+            guard case let .simple(.leaf(handler))? = nodeBChildEdges[componentC.key] else {
+                return XCTFail("🔥: unexpected child C edge!")
+            }
+
+            XCTAssertEqual(handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testInit_WithNonEmptyRouteAndParameterVariableComponents_ShouldCreateTreesWithParameterEdges() {
+
+        let parameterA = "a"
+        let parameterB = "b"
+        let parameterC = "c"
+
+        let componentA = Route.Component(component: ":" + parameterA)
+        let componentB = Route.Component(component: ":" + parameterB)
+        let componentC = Route.Component(component: ":" + parameterC)
+
+        let testRoute = [componentA, componentB, componentC]
+
+        do {
+            guard case let .node(childEdges) = try TestTree(route: testRoute, handler: testHandler) else {
+                return XCTFail("🔥: unexpected node type!")
+            }
+            guard case let .parameter(parameterAName, .node(nodeAChildEdges))? = childEdges[componentA.key] else {
+                return XCTFail("🔥: unexpected child A edge!")
+            }
+            guard case let .parameter(parameterBName, .node(nodeBChildEdges))? = nodeAChildEdges[componentB.key] else {
+                return XCTFail("🔥: unexpected child B edge!")
+            }
+            guard case let .parameter(parameterCName, .leaf(handler))? = nodeBChildEdges[componentC.key] else {
+                return XCTFail("🔥: unexpected child C edge!")
+            }
+
+            XCTAssertEqual(parameterAName, parameterA)
+            XCTAssertEqual(parameterBName, parameterB)
+            XCTAssertEqual(parameterCName, parameterC)
+            XCTAssertEqual(handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testInit_WithNonEmptyRouteAndWildcardVariableComponents_ShouldCreateTreesWithNilParameterEdges() {
+
+        let componentA = Route.Component(component: "*")
+        let componentB = Route.Component(component: "*")
+        let componentC = Route.Component(component: "*")
+
+        let testRoute = [componentA, componentB, componentC]
+
+        do {
+            guard case let .node(childEdges) = try TestTree(route: testRoute, handler: testHandler) else {
+                return XCTFail("🔥: unexpected node type!")
+            }
+            guard case let .parameter(nil, .node(nodeAChildEdges))? = childEdges[componentA.key] else {
+                return XCTFail("🔥: unexpected child A edge!")
+            }
+            guard case let .parameter(nil, .node(nodeBChildEdges))? = nodeAChildEdges[componentB.key] else {
+                return XCTFail("🔥: unexpected child B edge!")
+            }
+            guard case let .parameter(nil, .leaf(handler))? = nodeBChildEdges[componentC.key] else {
+                return XCTFail("🔥: unexpected child C edge!")
+            }
+            XCTAssertEqual(handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+}

--- a/AlicerceTests/Sources/DeepLinking/Route+Tree_MatchTests.swift
+++ b/AlicerceTests/Sources/DeepLinking/Route+Tree_MatchTests.swift
@@ -1,0 +1,972 @@
+//
+//  Route+Tree_MatchTests.swift
+//  Alicerce
+//
+//  Created by André Pacheco Neves on 16/04/2017.
+//  Copyright © 2017 Mindera. All rights reserved.
+//
+
+import XCTest
+@testable import Alicerce
+
+class Route_Tree_MatchTests: XCTestCase {
+
+    typealias TestTree = Route.Tree<String>
+
+    let testHandler = "test"
+
+    // MARK: - Error cases
+
+    // MARK: leaf node
+
+    func testMatch_WithNonMatchingRouteContainingNonEmptyElementOnLeaf_ShouldFailWithRouteNotFound() {
+
+        let testTree: TestTree = .leaf(testHandler)
+
+        do {
+            let _ = try testTree.match(route: [.constant("a")])
+        } catch TestTree.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let _ = try testTree.match(route: [.variable("a")])
+        } catch TestTree.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let _ = try testTree.match(route: [.variable(nil)])
+        } catch TestTree.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testMatch_WithRouteContainingMultipleComponentsOnLeaf_ShouldFailWithRouteNotFound() {
+
+        let testTree: TestTree = .leaf(testHandler)
+
+        do {
+            let _ = try testTree.match(route: [.empty, .constant("a")])
+        } catch TestTree.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let _ = try testTree.match(route: [.variable(nil), .constant("a")])
+        } catch TestTree.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let _ = try testTree.match(route: [.variable("a"), .constant("b")])
+        } catch TestTree.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let _ = try testTree.match(route: [.constant("a"), .variable("b")])
+        } catch TestTree.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    // MARK: single child node
+
+    func testMatch_WithRouteWithWildcardParameterComponent_ShouldFailWithInvalidComponent() {
+
+        let testTree: TestTree = .node([.empty : .simple(.leaf(testHandler))])
+
+        let variableComponent: Route.Component = .variable(nil)
+        let matchRoute = [variableComponent]
+
+        do {
+            let _ = try testTree.match(route: matchRoute)
+            XCTFail("🔥: unexpected success!")
+        } catch let TestTree.Error.invalidComponent(component) {
+            XCTAssertEqual(component, variableComponent)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testMatch_WithRouteWithValueParameterComponentOnSingleEmptyChildTree_ShouldFailWithInvalidComponent() {
+
+        let testTree: TestTree = .node([.empty : .simple(.leaf(testHandler))])
+
+        let variableComponent: Route.Component = .variable("a")
+        let matchRoute = [variableComponent]
+
+        do {
+            let _ = try testTree.match(route: matchRoute)
+            XCTFail("🔥: unexpected success!")
+        } catch let TestTree.Error.invalidComponent(component) {
+            XCTAssertEqual(component, variableComponent)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testMatch_WithNonMatchingSingleConstantElementRouteOnSingleEmptyChildTree_ShouldFailWithRouteNotFound() {
+
+        let testComponent: Route.Component = .empty
+        let testTree: TestTree = .node([testComponent.key : testComponent.edge(for: .leaf(testHandler))])
+
+        let nonMatchingComponent: Route.Component = .constant("a")
+        let matchRoute = [nonMatchingComponent]
+
+        do {
+            let _ = try testTree.match(route: matchRoute)
+        } catch TestTree.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testMatch_WithNonMatchingSingleConstantElementRouteOnSingleConstantChildTree_ShouldFailWithRouteNotFound() {
+
+        let testComponent: Route.Component = .constant("a")
+        let testTree: TestTree = .node([testComponent.key : testComponent.edge(for: .leaf(testHandler))])
+
+        let nonMatchingComponent: Route.Component = .constant("b")
+        let matchRoute = [nonMatchingComponent]
+
+        do {
+            let _ = try testTree.match(route: matchRoute)
+        } catch TestTree.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testMatch_WithEmptyElementRouteOnSingleConstantChildTree_ShouldFailWithRouteNotFound() {
+
+        let testComponent: Route.Component = .constant("a")
+        let testTree: TestTree = .node([testComponent.key : testComponent.edge(for: .leaf(testHandler))])
+
+        let nonMatchingComponent: Route.Component = .empty
+        let matchRoute = [nonMatchingComponent]
+
+        do {
+            let _ = try testTree.match(route: matchRoute)
+        } catch TestTree.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testMatch_WithEmptyElementRouteOnSingleValueParameterChildTree_ShouldFailWithRouteNotFound() {
+
+        let testComponent: Route.Component = .variable("a")
+        let testTree: TestTree = .node([testComponent.key : testComponent.edge(for: .leaf(testHandler))])
+
+        let nonMatchingComponent: Route.Component = .empty
+        let matchRoute = [nonMatchingComponent]
+
+        do {
+            // TODO: evaluate if it makes sense to consider .empty as a valid value parameter
+            // e.g.: should "/a/" match "/a/:p"?
+            let _ = try testTree.match(route: matchRoute)
+        } catch TestTree.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testMatch_WithEmptyElementRouteOnSingleWildcardParameterChildTree_ShouldFailWithRouteNotFound() {
+
+        let testComponent: Route.Component = .variable(nil)
+        let testTree: TestTree = .node([testComponent.key : testComponent.edge(for: .leaf(testHandler))])
+
+        let nonMatchingComponent: Route.Component = .empty
+        let matchRoute = [nonMatchingComponent]
+
+        do {
+            // TODO: evaluate if it makes sense to consider .empty as a valid wildcard parameter
+            // e.g.: should "/a/" match "/a/*"?
+            let _ = try testTree.match(route: matchRoute)
+        } catch TestTree.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    // MARK: multi child node
+
+    func testMatch_WithNonMatchingEmptyElementRouteOnMultiChildTree_ShouldFailWithRouteNotFound() {
+
+        let testComponentA: Route.Component = .constant("a")
+        let testComponentB: Route.Component = .constant("b")
+
+        let testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: .leaf("")),
+                                        testComponentB.key : testComponentB.edge(for: .leaf(""))])
+
+        let nonMatchingComponent: Route.Component = .empty
+        let matchRoute = [nonMatchingComponent]
+
+        do {
+            let _ = try testTree.match(route: matchRoute)
+        } catch TestTree.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testMatch_WithNonMatchingSingleConstantElementRouteOnMultiChildTree_ShouldFailWithRouteNotFound() {
+
+        let testComponentA: Route.Component = .empty
+        let testComponentB: Route.Component = .constant("a")
+
+        let testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: .leaf("")),
+                                        testComponentB.key : testComponentB.edge(for: .leaf(""))])
+
+        let nonMatchingComponent: Route.Component = .constant("b")
+        let matchRoute = [nonMatchingComponent]
+
+        do {
+            let _ = try testTree.match(route: matchRoute)
+        } catch TestTree.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    // MARK: multi level node
+
+    func testMatch_WithNonMatchingConstantElementRouteOnMultiLevelChildTreeWithConstantChild_ShouldFailWithRouteNotFoundError() {
+
+        let testComponentA: Route.Component = .constant("a")
+        let testComponentB: Route.Component = .constant("b")
+
+        let nestedTree: TestTree = .node([testComponentB.key : testComponentB.edge(for: .leaf(testHandler))])
+        let testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: nestedTree)])
+
+        let nonExistentComponent: Route.Component = .constant("c")
+
+        // non matching
+        var matchRoute = [nonExistentComponent]
+        do {
+            let _ = try testTree.match(route: matchRoute)
+        } catch TestTree.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        // partial match
+        matchRoute = [testComponentA, nonExistentComponent]
+        do {
+            let _ = try testTree.match(route: matchRoute)
+        } catch TestTree.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testMatch_WithNonMatchingConstantElementRouteOnMultiLevelChildTreeWithValueParameterChild_ShouldFailWithRouteNotFoundError() {
+
+        let testComponentA: Route.Component = .variable("a")
+        let testComponentB: Route.Component = .constant("b")
+
+        let nestedTree: TestTree = .node([testComponentB.key : testComponentB.edge(for: .leaf(testHandler))])
+        let testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: nestedTree)])
+
+        let matchingComponent: Route.Component = .constant("c")
+        let nonExistentComponent: Route.Component = .constant("d")
+        let matchRoute = [matchingComponent, nonExistentComponent]
+
+        do {
+            let _ = try testTree.match(route: matchRoute)
+        } catch TestTree.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testMatch_WithNonMatchingConstantElementRouteOnMultiLevelChildTreeWithWildcardParameterChild_ShouldFailWithRouteNotFoundError() {
+
+        let testComponentA: Route.Component = .variable(nil)
+        let testComponentB: Route.Component = .constant("a")
+
+        let nestedTree: TestTree = .node([testComponentB.key : testComponentB.edge(for: .leaf(testHandler))])
+        let testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: nestedTree)])
+
+        let matchingComponent: Route.Component = .constant("b")
+        let nonExistentComponent: Route.Component = .constant("c")
+        let matchRoute = [matchingComponent, nonExistentComponent]
+
+        do {
+            let _ = try testTree.match(route: matchRoute)
+        } catch TestTree.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testMatch_WithNonMatchingConstantAndEmptyElementRouteOnMultiLevelChildTreeWithConstantChild_ShouldFailWithRouteNotFoundError() {
+
+        let testComponentA: Route.Component = .constant("a")
+        let testComponentB: Route.Component = .constant("b")
+
+        let nestedTree: TestTree = .node([testComponentB.key : testComponentB.edge(for: .leaf(testHandler))])
+        let testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: nestedTree)])
+
+        let matchingComponent: Route.Component = .constant("a")
+        let matchRoute = [matchingComponent, .empty]
+
+        do {
+            let _ = try testTree.match(route: matchRoute)
+        } catch TestTree.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testMatch_WithNonMatchingConstantAndEmptyElementRouteOnMultiLevelChildTreeWithValueParameterChild_ShouldFailWithRouteNotFoundError() {
+
+        let testComponentA: Route.Component = .variable("a")
+        let testComponentB: Route.Component = .constant("b")
+
+        let nestedTree: TestTree = .node([testComponentB.key : testComponentB.edge(for: .leaf(testHandler))])
+        let testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: nestedTree)])
+
+        let matchingComponent: Route.Component = .constant("a")
+        let matchRoute = [matchingComponent, .empty]
+
+        do {
+            let _ = try testTree.match(route: matchRoute)
+        } catch TestTree.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testMatch_WithNonMatchingConstantAndEmptyElementRouteOnMultiLevelChildTreeWithWildcardParameterChild_ShouldFailWithRouteNotFoundError() {
+
+        let testComponentA: Route.Component = .variable(nil)
+        let testComponentB: Route.Component = .constant("a")
+
+        let nestedTree: TestTree = .node([testComponentB.key : testComponentB.edge(for: .leaf(testHandler))])
+        let testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: nestedTree)])
+
+        let matchingComponent: Route.Component = .constant("b")
+        let matchRoute = [matchingComponent, .empty]
+
+        do {
+            let _ = try testTree.match(route: matchRoute)
+        } catch TestTree.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    // MARK: - Success cases
+
+    // MARK: leaf node
+
+    func testMatch_WithEmptyRouteOnLeaf_ShouldReturnHandlerAndEmptyParameters() {
+
+        let testTree: TestTree = .leaf(testHandler)
+
+        do {
+            let match = try testTree.match(route: [])
+            XCTAssertEqual(match.parameters, [:])
+            XCTAssertEqual(match.handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testMatch_WithRouteContainingSingleEmptyComponentOnLeaf_ShouldReturnMatchWithEmptyParametersAndHandler() {
+
+        let testTree: TestTree = .leaf(testHandler)
+
+        do {
+            let match = try testTree.match(route: [.empty])
+            XCTAssertEqual(match.parameters, [:])
+            XCTAssertEqual(match.handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    // MARK: single child node
+
+    func testMatch_WithMatchingConstantElementRouteOnSingleConstantChildTree_ShouldReturnMatchWithEmptyParametersAndHandler() {
+
+        let testComponent: Route.Component = .constant("a")
+        let testTree: TestTree = .node([testComponent.key : testComponent.edge(for: .leaf(testHandler))])
+
+        let matchRoute = [testComponent]
+
+        do {
+            let match = try testTree.match(route: matchRoute)
+            XCTAssertEqual(match.parameters, [:])
+            XCTAssertEqual(match.handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testMatch_WithMatchingConstantElementRouteOnValueParameterChildTree_ShouldReturnMatchWithParametersAndHandler() {
+
+        let testParameterName = "a"
+        let testComponent: Route.Component = .variable(testParameterName)
+        let testTree: TestTree = .node([testComponent.key : testComponent.edge(for: .leaf(testHandler))])
+
+        let matchParameterValue = "value"
+        let matchComponent: Route.Component = .constant(matchParameterValue)
+        let matchRoute = [matchComponent]
+
+        do {
+            let match = try testTree.match(route: matchRoute)
+            XCTAssertEqual(match.parameters, [testParameterName : matchParameterValue])
+            XCTAssertEqual(match.handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testMatch_WithMatchingConstantElementRouteOnWildcardParameterChildTree_ShouldReturnMatchWithEmptyParametersAndHandler() {
+
+        let testComponent: Route.Component = .variable(nil)
+        let testTree: TestTree = .node([testComponent.key : testComponent.edge(for: .leaf(testHandler))])
+
+        let matchComponent: Route.Component = .constant("a")
+        let matchRoute = [matchComponent]
+
+        do {
+            let match = try testTree.match(route: matchRoute)
+            XCTAssertEqual(match.parameters, [:])
+            XCTAssertEqual(match.handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testMatch_WithMatchingConstantElementAndLastSingleEmptyElementRouteOnSingleConstantChildTree_ShouldReturnMatchWithEmptyParametersAndHandler() {
+
+        let testComponent: Route.Component = .constant("a")
+        let testTree: TestTree = .node([testComponent.key : testComponent.edge(for: .leaf(testHandler))])
+
+        let matchRoute = [testComponent, .empty]
+
+        do {
+            let match = try testTree.match(route: matchRoute)
+            XCTAssertEqual(match.parameters, [:])
+            XCTAssertEqual(match.handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testMatch_WithMatchingConstantElementAndLastSingleEmptyElementRouteOnSingleValueParameterChildTree_ShouldReturnMatchWithParameterAndHandler() {
+
+        let testParameterName = "a"
+        let testComponent: Route.Component = .variable(testParameterName)
+        let testTree: TestTree = .node([testComponent.key : testComponent.edge(for: .leaf(testHandler))])
+
+        let matchParameterValue = "value"
+        let matchComponent: Route.Component = .constant(matchParameterValue)
+        let matchRoute = [matchComponent, .empty]
+
+        do {
+            let match = try testTree.match(route: matchRoute)
+            XCTAssertEqual(match.parameters, [testParameterName : matchParameterValue])
+            XCTAssertEqual(match.handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testMatch_WithMatchingConstantElementAndLastSingleEmptyElementRouteOnWildcardParameterChildTree_ShouldReturnMatchWithEmptyParametersAndHandler() {
+
+        let testComponent: Route.Component = .variable(nil)
+        let testTree: TestTree = .node([testComponent.key : testComponent.edge(for: .leaf(testHandler))])
+
+        let matchComponent: Route.Component = .constant("a")
+        let matchRoute = [matchComponent, .empty]
+
+        do {
+            let match = try testTree.match(route: matchRoute)
+            XCTAssertEqual(match.parameters, [:])
+            XCTAssertEqual(match.handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testMatch_WithMatchingEmptyElementAndLastSingleEmptyElementRouteOnEmptyChildTree_ShouldReturnMatchWithEmptyParametersAndHandler() {
+
+        let testComponent: Route.Component = .empty
+        let testTree: TestTree = .node([testComponent.key : testComponent.edge(for: .leaf(testHandler))])
+
+        do {
+            // TODO: evaluate if this makes sense, because it can have an unexpected behaviour on some silly routes:
+            // e.g. "/<empty>/<empty>" would match a route for "/<empty>"
+            let match = try testTree.match(route: [.empty, .empty])
+            XCTAssertEqual(match.parameters, [:])
+            XCTAssertEqual(match.handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    // MARK: multi child node
+
+    func testMatch_WithMatchingEmptyElementRouteOnMultiChildTreeWithEmptyChild_ShouldReturnMatchWithEmptyParametersAndHandler() {
+
+        let testComponentA: Route.Component = .empty
+        let testComponentB: Route.Component = .constant("a")
+
+        let testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: .leaf(testHandler)),
+                                        testComponentB.key : testComponentB.edge(for: .leaf(""))])
+
+        let nonMatchingComponent: Route.Component = .empty
+        let matchRoute = [nonMatchingComponent]
+
+        do {
+            let match = try testTree.match(route: matchRoute)
+            XCTAssertEqual(match.parameters, [:])
+            XCTAssertEqual(match.handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testMatch_WithMatchingConstantElementRouteOnMultiChildTreeWithConstantChild_ShouldReturnMatchWithEmptyParametersAndHandler() {
+
+        let testComponentA: Route.Component = .constant("a")
+        let testComponentB: Route.Component = .empty
+
+        let testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: .leaf(testHandler)),
+                                        testComponentB.key : testComponentB.edge(for: .leaf(""))])
+
+        let matchRoute = [testComponentA]
+
+        do {
+            let match = try testTree.match(route: matchRoute)
+
+            XCTAssertEqual(match.parameters, [:])
+            XCTAssertEqual(match.handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testMatch_WithMatchingConstantElementRouteOnMultiChildTreeWithValueParameterChild_ShouldReturnMatchWithParameterAndHandler() {
+
+        let testParameterA = "a"
+        let testComponentA: Route.Component = .variable(testParameterA)
+        let testComponentB: Route.Component = .constant("b")
+
+        let testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: .leaf(testHandler)),
+                                        testComponentB.key : testComponentB.edge(for: .leaf(""))])
+
+        let matchParameterValue = "value"
+        let matchComponent: Route.Component = .constant(matchParameterValue)
+        let matchRoute = [matchComponent]
+
+        do {
+            let match = try testTree.match(route: matchRoute)
+            XCTAssertEqual(match.parameters, [testParameterA : matchParameterValue])
+            XCTAssertEqual(match.handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testMatch_WithMatchingConstantElementRouteOnMultiChildTreeWithWildcardParameterChild_ShouldReturnMatchWithEmptyParametersAndHandler() {
+
+        let testComponentA: Route.Component = .variable(nil)
+        let testComponentB: Route.Component = .constant("a")
+
+        let testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: .leaf(testHandler)),
+                                        testComponentB.key : testComponentB.edge(for: .leaf(""))])
+
+        let matchComponent: Route.Component = .constant("value")
+        let matchRoute = [matchComponent]
+
+        do {
+            let match = try testTree.match(route: matchRoute)
+            XCTAssertEqual(match.parameters, [:])
+            XCTAssertEqual(match.handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testMatch_WithMatchingConstantElementRouteOnMultiChildTreeWithConstantAndValueParameterChild_ShouldMatchConstantAndReturnMatchWithEmptyParametersAndHandler() {
+
+        let testComponentA: Route.Component = .constant("a")
+        let testComponentB: Route.Component = .variable("b")
+
+        let testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: .leaf(testHandler)),
+                                        testComponentB.key : testComponentB.edge(for: .leaf(""))])
+
+        let matchRoute = [testComponentA]
+
+        do {
+            let match = try testTree.match(route: matchRoute)
+            XCTAssertEqual(match.parameters, [:])
+            XCTAssertEqual(match.handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testMatch_WithMatchingConstantElementRouteOnMultiChildTreeWithConstantAndWildcardParameterChild_ShouldMatchConstantAndReturnMatchWithEmptyParametersAndHandler() {
+
+        let testComponentA: Route.Component = .constant("a")
+        let testComponentB: Route.Component = .variable(nil)
+
+        let testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: .leaf(testHandler)),
+                                        testComponentB.key : testComponentB.edge(for: .leaf(""))])
+
+        let matchRoute = [testComponentA]
+
+        do {
+            let match = try testTree.match(route: matchRoute)
+            XCTAssertEqual(match.parameters, [:])
+            XCTAssertEqual(match.handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    // MARK: multi level node
+
+    func testMatch_WithMatchingConstantElementRouteOnMultiLevelChildTreeWithConstantChild_ShouldMatchAndReturnMatchWithEmptyParametersAndHandler() {
+
+        let testComponentA: Route.Component = .constant("a")
+        let testComponentB: Route.Component = .constant("b")
+
+        let nestedTree: TestTree = .node([testComponentB.key : testComponentB.edge(for: .leaf(testHandler))])
+        let testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: nestedTree)])
+
+        // without terminating .empty
+        var matchRoute = [testComponentA, testComponentB]
+        do {
+            let match = try testTree.match(route: matchRoute)
+            XCTAssertEqual(match.parameters, [:])
+            XCTAssertEqual(match.handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        // with terminating .empty
+        matchRoute = [testComponentA, testComponentB, .empty]
+
+        do {
+            let match = try testTree.match(route: matchRoute)
+            XCTAssertEqual(match.parameters, [:])
+            XCTAssertEqual(match.handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testMatch_WithMatchingConstantElementRouteOnMultiLevelChildTreeWithValueParameterChild_ShouldMatchAndReturnMatchWithEmptyParametersAndHandler() {
+
+        let testParameterName = "a"
+        let testComponentA: Route.Component = .variable(testParameterName)
+        let testComponentB: Route.Component = .constant("b")
+
+        let nestedTree: TestTree = .node([testComponentB.key : testComponentB.edge(for: .leaf(testHandler))])
+        let testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: nestedTree)])
+
+        let parameterValue = "value"
+        let matchingComponent: Route.Component = .constant(parameterValue)
+
+        // without terminating .empty
+        var matchRoute = [matchingComponent, testComponentB]
+        do {
+            let match = try testTree.match(route: matchRoute)
+            XCTAssertEqual(match.parameters, [testParameterName : parameterValue])
+            XCTAssertEqual(match.handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        // with terminating .empty
+        matchRoute = [matchingComponent, testComponentB, .empty]
+        do {
+            let match = try testTree.match(route: matchRoute)
+            XCTAssertEqual(match.parameters, [testParameterName : parameterValue])
+            XCTAssertEqual(match.handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testMatch_WithMatchingConstantElementRouteOnMultiLevelChildTreeWithMultiValueParameterChild_ShouldMatchAndReturnMatchWithEmptyParametersAndHandler() {
+
+        let testParameterNameA = "a"
+        let testParameterNameB = "b"
+        let testComponentA: Route.Component = .variable(testParameterNameA)
+        let testComponentB: Route.Component = .variable(testParameterNameB)
+
+        let nestedTree: TestTree = .node([testComponentB.key : testComponentB.edge(for: .leaf(testHandler))])
+        let testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: nestedTree)])
+
+        let parameterValueA = "valueA"
+        let parameterValueB = "valueB"
+        let matchingComponentA: Route.Component = .constant(parameterValueA)
+        let matchingComponentB: Route.Component = .constant(parameterValueB)
+
+        // without terminating .empty
+        var matchRoute = [matchingComponentA, matchingComponentB]
+        do {
+            let match = try testTree.match(route: matchRoute)
+            XCTAssertEqual(match.parameters, [testParameterNameA : parameterValueA,
+                                              testParameterNameB : parameterValueB])
+            XCTAssertEqual(match.handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        // with terminating .empty
+        matchRoute = [matchingComponentA, matchingComponentB, .empty]
+        do {
+            let match = try testTree.match(route: matchRoute)
+            XCTAssertEqual(match.parameters, [testParameterNameA : parameterValueA,
+                                              testParameterNameB : parameterValueB])
+            XCTAssertEqual(match.handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testMatch_WithMatchingConstantElementRouteOnMultiLevelChildTreeWithWildcardParameterChild_ShouldMatchAndReturnMatchWithEmptyParametersAndHandler() {
+
+        let testComponentA: Route.Component = .variable(nil)
+        let testComponentB: Route.Component = .constant("a")
+
+        let nestedTree: TestTree = .node([testComponentB.key : testComponentB.edge(for: .leaf(testHandler))])
+        let testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: nestedTree)])
+
+        let matchingComponent: Route.Component = .constant("b")
+
+        // without terminating .empty
+        var matchRoute = [matchingComponent, testComponentB]
+        do {
+            let match = try testTree.match(route: matchRoute)
+            XCTAssertEqual(match.parameters, [:])
+            XCTAssertEqual(match.handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        // with terminating .empty
+        matchRoute = [matchingComponent, testComponentB, .empty]
+        do {
+            let match = try testTree.match(route: matchRoute)
+            XCTAssertEqual(match.parameters, [:])
+            XCTAssertEqual(match.handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testMatch_WithMatchingConstantElementRouteOnMultiLevelChildTreeWithConstantChildAndEmptyLeaf_ShouldMatchAndReturnMatchWithEmptyParametersAndHandler() {
+
+        let testComponentA: Route.Component = .constant("a")
+        let testComponentB: Route.Component = .constant("b")
+        let testComponentC: Route.Component = .empty
+
+        let subNestedTree: TestTree = .node([testComponentC.key : testComponentC.edge(for: .leaf(testHandler))])
+        let nestedTree: TestTree = .node([testComponentB.key : testComponentB.edge(for: subNestedTree)])
+        let testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: nestedTree)])
+
+        // without terminating .empty
+        var matchRoute = [testComponentA, testComponentB]
+        do {
+            let match = try testTree.match(route: matchRoute)
+            XCTAssertEqual(match.parameters, [:])
+            XCTAssertEqual(match.handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        // with terminating .empty
+        matchRoute = [testComponentA, testComponentB, .empty]
+
+        do {
+            let match = try testTree.match(route: matchRoute)
+            XCTAssertEqual(match.parameters, [:])
+            XCTAssertEqual(match.handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testMatch_WithMatchingConstantElementRouteOnMultiLevelChildTreeWithSingleValueParameterChildAndEmptyLeaf_ShouldMatchAndReturnMatchWithParametersAndHandler() {
+
+        let testParameterNameA = "a"
+        let testComponentA: Route.Component = .variable(testParameterNameA)
+        let testComponentB: Route.Component = .constant("b")
+        let testComponentC: Route.Component = .empty
+
+        let subNestedTree: TestTree = .node([testComponentC.key : testComponentC.edge(for: .leaf(testHandler))])
+        let nestedTree: TestTree = .node([testComponentB.key : testComponentB.edge(for: subNestedTree)])
+        let testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: nestedTree)])
+
+        let parameterValueA = "valueA"
+        let matchingComponentA: Route.Component = .constant(parameterValueA)
+
+        // without terminating .empty
+        var matchRoute = [matchingComponentA, testComponentB]
+        do {
+            let match = try testTree.match(route: matchRoute)
+            XCTAssertEqual(match.parameters, [testParameterNameA : parameterValueA])
+            XCTAssertEqual(match.handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        // with terminating .empty
+        matchRoute = [matchingComponentA, testComponentB, .empty]
+        do {
+            let match = try testTree.match(route: matchRoute)
+            XCTAssertEqual(match.parameters, [testParameterNameA : parameterValueA])
+            XCTAssertEqual(match.handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testMatch_WithMatchingConstantElementRouteOnMultiLevelChildTreeWithMultiValueParameterChildAndEmptyLeaf_ShouldMatchAndReturnMatchWithParametersAndHandler() {
+
+        let testParameterNameA = "a"
+        let testParameterNameB = "b"
+        let testComponentA: Route.Component = .variable(testParameterNameA)
+        let testComponentB: Route.Component = .variable(testParameterNameB)
+        let testComponentC: Route.Component = .empty
+
+        let subNestedTree: TestTree = .node([testComponentC.key : testComponentC.edge(for: .leaf(testHandler))])
+        let nestedTree: TestTree = .node([testComponentB.key : testComponentB.edge(for: subNestedTree)])
+        let testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: nestedTree)])
+
+        let parameterValueA = "valueA"
+        let parameterValueB = "valueB"
+        let matchingComponentA: Route.Component = .constant(parameterValueA)
+        let matchingComponentB: Route.Component = .constant(parameterValueB)
+
+        // without terminating .empty
+        var matchRoute = [matchingComponentA, matchingComponentB]
+        do {
+            let match = try testTree.match(route: matchRoute)
+            XCTAssertEqual(match.parameters, [testParameterNameA : parameterValueA,
+                                              testParameterNameB : parameterValueB])
+            XCTAssertEqual(match.handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        // with terminating .empty
+        matchRoute = [matchingComponentA, matchingComponentB, .empty]
+        do {
+            let match = try testTree.match(route: matchRoute)
+            XCTAssertEqual(match.parameters, [testParameterNameA : parameterValueA,
+                                              testParameterNameB : parameterValueB])
+            XCTAssertEqual(match.handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testMatch_WithMatchingConstantElementRouteOnMultiLevelChildTreeWithSingleWildcardParameterChildAndEmptyLeaf_ShouldMatchAndReturnMatchWithEmptyParametersAndHandler() {
+
+        let testComponentA: Route.Component = .variable(nil)
+        let testComponentB: Route.Component = .constant("b")
+        let testComponentC: Route.Component = .empty
+
+        let subNestedTree: TestTree = .node([testComponentC.key : testComponentC.edge(for: .leaf(testHandler))])
+        let nestedTree: TestTree = .node([testComponentB.key : testComponentB.edge(for: subNestedTree)])
+        let testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: nestedTree)])
+
+        let matchingComponent: Route.Component = .constant("c")
+
+        // without terminating .empty
+        var matchRoute = [matchingComponent, testComponentB]
+        do {
+            let match = try testTree.match(route: matchRoute)
+            XCTAssertEqual(match.parameters, [:])
+            XCTAssertEqual(match.handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        // with terminating .empty
+        matchRoute = [matchingComponent, testComponentB, .empty]
+        do {
+            let match = try testTree.match(route: matchRoute)
+            XCTAssertEqual(match.parameters, [:])
+            XCTAssertEqual(match.handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testMatch_WithMatchingConstantElementRouteOnMultiLevelChildTreeWithMultiWildcardParameterChildAndEmptyLeaf_ShouldMatchAndReturnMatchWithEmptyParametersAndHandler() {
+
+        let testComponentA: Route.Component = .variable(nil)
+        let testComponentB: Route.Component = .variable(nil)
+        let testComponentC: Route.Component = .empty
+
+        let subNestedTree: TestTree = .node([testComponentC.key : testComponentC.edge(for: .leaf(testHandler))])
+        let nestedTree: TestTree = .node([testComponentB.key : testComponentB.edge(for: subNestedTree)])
+        let testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: nestedTree)])
+
+        let matchingComponentA: Route.Component = .constant("a")
+        let matchingComponentB: Route.Component = .constant("b")
+
+        // without terminating .empty
+        var matchRoute = [matchingComponentA, matchingComponentB]
+        do {
+            let match = try testTree.match(route: matchRoute)
+            XCTAssertEqual(match.parameters, [:])
+            XCTAssertEqual(match.handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        // with terminating .empty
+        matchRoute = [matchingComponentA, matchingComponentB, .empty]
+        do {
+            let match = try testTree.match(route: matchRoute)
+            XCTAssertEqual(match.parameters, [:])
+            XCTAssertEqual(match.handler, testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+}
+

--- a/AlicerceTests/Sources/DeepLinking/Route+Tree_RemoveTests.swift
+++ b/AlicerceTests/Sources/DeepLinking/Route+Tree_RemoveTests.swift
@@ -1,0 +1,776 @@
+//
+//  Route+Tree_RemoveTests.swift
+//  Alicerce
+//
+//  Created by André Pacheco Neves on 16/04/2017.
+//  Copyright © 2017 Mindera. All rights reserved.
+//
+
+import XCTest
+@testable import Alicerce
+
+class Route_Tree_RemoveTests: XCTestCase {
+
+    typealias TestTree = Route.Tree<String>
+
+    let testHandler = "test"
+
+    // MARK: - Error cases
+
+    // MARK: leaf node
+
+    func testRemove_WithRouteContainingFirstEmptyAndOtherComponentsWithEmptyElementOnLeaf_ShouldFailWithRouteNotFound() {
+
+        var testTree: TestTree = .leaf(testHandler)
+
+        do {
+            // TODO: perhaps removing an `.empty` from a leaf should behave as an empty route 🤔
+            let _ = try testTree.remove(route: [.empty, .constant("a")])
+        } catch TestTree.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .leaf(handler) = testTree, handler == testHandler else {
+            return XCTFail("🔥: expected leaf matching handler, got \(testTree)!")
+        }
+    }
+
+    // MARK: single child node
+
+    func testRemove_WithNonMatchingSingleConstantElementRouteOnSingleConstantChildTree_ShouldFailWithRouteNotFound() {
+
+        let testComponent: Route.Component = .constant("a")
+        var testTree: TestTree = .node([testComponent.key : testComponent.edge(for: .leaf(testHandler))])
+
+        let nonMatchingComponent: Route.Component = .constant("b")
+        let removeRoute = [nonMatchingComponent]
+
+        do {
+            let _ = try testTree.remove(route: removeRoute)
+        } catch TestTree.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(childEdges) = testTree else {
+            return XCTFail("🔥: expected empty node, got \(testTree)!")
+        }
+        guard case let .simple(.leaf(handler))? = childEdges[testComponent.key] else {
+            return XCTFail("🔥: expected simple leaf, got \(String(describing: childEdges[testComponent.key]))!")
+        }
+
+        XCTAssertEqual(handler, testHandler)
+    }
+
+    func testRemove_WithNonMatchingSingleValueParameterElementRouteOnSingleVariableChildTree_ShouldReturnFailWithRouteNotFound() {
+
+        let testComponent: Route.Component = .variable(nil)
+        var testTree: TestTree = .node([testComponent.key : testComponent.edge(for: .leaf(testHandler))])
+
+        let nonMatchingComponent: Route.Component = .variable("a")
+        let removeRoute = [nonMatchingComponent]
+
+        do {
+            let _ = try testTree.remove(route: removeRoute)
+        } catch TestTree.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(childEdges) = testTree else {
+            return XCTFail("🔥: expected empty node, got \(testTree)!")
+        }
+        guard case let .parameter(parameterName, .leaf(handler))? = childEdges[testComponent.key] else {
+            return XCTFail("🔥: expected parameter leaf, got \(String(describing: childEdges[testComponent.key]))!")
+        }
+
+        XCTAssertEqual(handler, testHandler)
+        XCTAssertNil(parameterName)
+    }
+
+    func testRemove_WithNonMatchingSingleValueParameterElementRouteOnSingleEmptyChildTree_ShouldFailWithRouteNotFound() {
+
+        let testComponent: Route.Component = .empty
+        var testTree: TestTree = .node([testComponent.key : testComponent.edge(for: .leaf(testHandler))])
+
+        do {
+            // test empty vs constant match
+            let _ = try testTree.remove(route: [.constant("a")])
+        } catch TestTree.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            // empty vs variable
+            let _ = try testTree.remove(route: [.variable("a")])
+        } catch TestTree.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(childEdges) = testTree else {
+            return XCTFail("🔥: expected empty node, got \(testTree)!")
+        }
+        guard case let .simple(.leaf(handler))? = childEdges[testComponent.key] else {
+            return XCTFail("🔥: expected simple leaf, got \(String(describing: childEdges[testComponent.key]))!")
+        }
+        
+        XCTAssertEqual(handler, testHandler)
+    }
+
+    // MARK: multi child node
+
+    func testRemove_WithNonMatchingSingleElementRouteOnMultiChildTree_ShouldFailWithRouteNotFound() {
+
+        let testComponentA: Route.Component = .empty
+        let testComponentB: Route.Component = .constant("b")
+
+        let testHandlerA = testHandler
+        let testHandlerB = "testB"
+
+        var testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: .leaf(testHandlerA)),
+                                        testComponentB.key : testComponentB.edge(for: .leaf(testHandlerB))])
+
+        let nonMatchingComponent: Route.Component = .constant("a")
+        let removeRoute = [nonMatchingComponent]
+
+        do {
+            let _ = try testTree.remove(route: removeRoute)
+        } catch TestTree.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(childEdges) = testTree else {
+            return XCTFail("🔥: expected node, got \(testTree)!")
+        }
+        guard case let .simple(.leaf(handlerA))? = childEdges[testComponentA.key] else {
+            return XCTFail("🔥: expected simple leaf, got \(String(describing: childEdges[testComponentA.key]))!")
+        }
+        guard case let .simple(.leaf(handlerB))? = childEdges[testComponentB.key] else {
+            return XCTFail("🔥: expected simple leaf, got \(String(describing: childEdges[testComponentB.key]))!")
+        }
+
+        XCTAssertEqual(handlerA, testHandlerA)
+        XCTAssertEqual(handlerB, testHandlerB)
+    }
+
+    func testRemove_WithNonMatchingRouteOnMultiLevelConstantTree_ShouldFailWithRouteNotFoundAndNotAlterTree() {
+
+        let testComponentA: Route.Component = .constant("a")
+        let testComponentB: Route.Component = .constant("b")
+
+        let nestedTree: TestTree = .node([testComponentB.key : testComponentB.edge(for: .leaf(testHandler))])
+        var testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: nestedTree)])
+
+        let nonExistentComponentC: Route.Component = .constant("c")
+        let removeRoute = [nonExistentComponentC]
+
+        do {
+            let _ = try testTree.remove(route: removeRoute)
+        } catch TestTree.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(childEdges) = testTree else {
+            return XCTFail("🔥: expected node, got \(testTree)!")
+        }
+        guard case let .simple(.node(childEdgesA))? = childEdges[testComponentA.key] else {
+            return XCTFail("🔥: expected simple node, got \(String(describing: childEdges[testComponentA.key]))!")
+        }
+        guard case let .simple(.leaf(existingHandler))? = childEdgesA[testComponentB.key] else {
+            return XCTFail("🔥: expected simple leaf, got \(String(describing: childEdges[testComponentB.key]))!")
+        }
+
+        XCTAssertEqual(existingHandler, testHandler)
+    }
+
+    // MARK: multi level node
+
+    func testRemove_WithNonMatchingValueParameterRouteOnMultiLevelValueParameteTree_ShouldFailWithRouteNotFoundAndNotAlterTree() {
+
+        let testParameterA = "a"
+        let testParameterB = "b"
+        let testComponentA: Route.Component = .variable(testParameterA)
+        let testComponentB: Route.Component = .variable(testParameterB)
+
+        let nestedTree: TestTree = .node([testComponentB.key : testComponentB.edge(for: .leaf(testHandler))])
+        var testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: nestedTree)])
+
+        let nonExistentComponentC: Route.Component = .variable("c")
+        let removeRoute = [nonExistentComponentC]
+
+        do {
+            let _ = try testTree.remove(route: removeRoute)
+        } catch TestTree.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(childEdges) = testTree else {
+            return XCTFail("🔥: expected node, got \(testTree)!")
+        }
+        guard case let .parameter(parameterA, .node(childEdgesA))? = childEdges[testComponentA.key] else {
+            return XCTFail("🔥: expected parameter node, got \(String(describing: childEdges[testComponentA.key]))!")
+        }
+        guard case let .parameter(parameterB, .leaf(existingHandler))? = childEdgesA[testComponentB.key] else {
+            return XCTFail("🔥: expected parameter leaf, got \(String(describing: childEdges[testComponentB.key]))!")
+        }
+
+        XCTAssertEqual(existingHandler, testHandler)
+        XCTAssertEqual(parameterA, testParameterA)
+        XCTAssertEqual(parameterB, testParameterB)
+    }
+
+    func testRemove_WithNonMatchingWildcardParameterRouteOnMultiLevelValueParameteTree_ShouldFailWithRouteNotFoundAndNotAlterTree() {
+
+        let testParameterA = "a"
+        let testParameterB = "b"
+        let testComponentA: Route.Component = .variable(testParameterA)
+        let testComponentB: Route.Component = .variable(testParameterB)
+
+        let nestedTree: TestTree = .node([testComponentB.key : testComponentB.edge(for: .leaf(testHandler))])
+        var testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: nestedTree)])
+
+        let nonExistentComponentC: Route.Component = .variable(nil)
+        let removeRoute = [nonExistentComponentC]
+
+        do {
+            let _ = try testTree.remove(route: removeRoute)
+        } catch TestTree.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(childEdges) = testTree else {
+            return XCTFail("🔥: expected node, got \(testTree)!")
+        }
+        guard case let .parameter(parameterA, .node(childEdgesA))? = childEdges[testComponentA.key] else {
+            return XCTFail("🔥: expected parameter node, got \(String(describing: childEdges[testComponentA.key]))!")
+        }
+        guard case let .parameter(parameterB, .leaf(existingHandler))? = childEdgesA[testComponentB.key] else {
+            return XCTFail("🔥: expected parameter leaf, got \(String(describing: childEdges[testComponentB.key]))!")
+        }
+
+        XCTAssertEqual(existingHandler, testHandler)
+        XCTAssertEqual(parameterA, testParameterA)
+        XCTAssertEqual(parameterB, testParameterB)
+    }
+
+    func testRemove_WithPartialMatchingRouteOnMultiLevelConstantTree_ShouldFailWithRouteNotFoundAndNotAlterTree() {
+
+        let testComponentA: Route.Component = .constant("a")
+        let testComponentB: Route.Component = .constant("b")
+
+        let nestedTree: TestTree = .node([testComponentB.key : testComponentB.edge(for: .leaf(testHandler))])
+        var testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: nestedTree)])
+
+        let nonExistentComponentC: Route.Component = .constant("c")
+        let removeRoute = [testComponentA, testComponentB, nonExistentComponentC]
+
+        do {
+            let _ = try testTree.remove(route: removeRoute)
+        } catch TestTree.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(childEdges) = testTree else {
+            return XCTFail("🔥: expected node, got \(testTree)!")
+        }
+        guard case let .simple(.node(childEdgesA))? = childEdges[testComponentA.key] else {
+            return XCTFail("🔥: expected simple node, got \(String(describing: childEdges[testComponentA.key]))!")
+        }
+        guard case let .simple(.leaf(existingHandler))? = childEdgesA[testComponentB.key] else {
+            return XCTFail("🔥: expected simple leaf, got \(String(describing: childEdges[testComponentB.key]))!")
+        }
+
+        XCTAssertEqual(existingHandler, testHandler)
+    }
+
+    func testRemove_WithPartialMatchingRouteAndNonMatchingTreeOnMultiLevelValueParameterTree_ShouldFailWithRouteNotFoundAndNotAlterTree() {
+
+        let testParameterA = "a"
+        let testParameterB = "b"
+
+        let testComponentA: Route.Component = .variable(testParameterA)
+        let testComponentB: Route.Component = .variable(testParameterB)
+
+        let nestedTree: TestTree = .node([testComponentB.key : testComponentB.edge(for: .leaf(testHandler))])
+        var testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: nestedTree)])
+
+        let nonExistentComponentC: Route.Component = .variable("c")
+        let removeRoute = [testComponentA, testComponentB, nonExistentComponentC]
+
+        do {
+            let _ = try testTree.remove(route: removeRoute)
+        } catch TestTree.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(childEdges) = testTree else {
+            return XCTFail("🔥: expected node, got \(testTree)!")
+        }
+        guard case let .parameter(parameterA, .node(childEdgesA))? = childEdges[testComponentA.key] else {
+            return XCTFail("🔥: expected parameter node, got \(String(describing: childEdges[testComponentA.key]))!")
+        }
+        guard case let .parameter(parameterB, .leaf(existingHandler))? = childEdgesA[testComponentB.key] else {
+            return XCTFail("🔥: expected parameter leaf, got \(String(describing: childEdges[testComponentB.key]))!")
+        }
+        
+        XCTAssertEqual(existingHandler, testHandler)
+        XCTAssertEqual(parameterA, testParameterA)
+        XCTAssertEqual(parameterB, testParameterB)
+    }
+
+    // MARK: - Success cases
+
+    // MARK: leaf node
+
+    func testRemove_WithEmptyRouteOnLeaf_ShouldReturnHandlerAndChangeLeafToEmptyTree() {
+
+        var testTree: TestTree = .leaf(testHandler)
+
+        do {
+            let handler = try testTree.remove(route: [])
+            XCTAssertEqual(handler, testHandler)
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(childs) = testTree, childs.isEmpty else {
+            return XCTFail("🔥: expected empty node, got \(testTree)!")
+        }
+    }
+
+    func testRemove_WithRouteContainingSingleEmptyComponentOnLeaf_ShouldReturnHandlerAndChangeLeafToEmptyTree() {
+
+        var testTree: TestTree = .leaf(testHandler)
+
+        do {
+            let handler = try testTree.remove(route: [.empty])
+            XCTAssertEqual(handler, testHandler)
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(childs) = testTree, childs.isEmpty else {
+            return XCTFail("🔥: expected empty node, got \(testTree)!")
+        }
+    }
+
+    // MARK: single child node
+
+    func testRemove_WithMatchingSingleEmptyElementRouteOnSingleChildTree_ShouldReturnHandlerAndChangeToEmptyTree() {
+
+        let testComponent: Route.Component = .empty
+        var testTree: TestTree = .node([testComponent.key : testComponent.edge(for: .leaf(testHandler))])
+
+        let removeRoute = [testComponent]
+
+        do {
+            let handler = try testTree.remove(route: removeRoute)
+            XCTAssertEqual(handler, testHandler)
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(childs) = testTree, childs.isEmpty else {
+            return XCTFail("🔥: expected empty node, got \(testTree)!")
+        }
+    }
+
+    func testRemove_WithMatchingElementAndLastSingleEmptyElementRouteOnSingleChildTree_ShouldReturnHandlerAndChangeToEmptyTree() {
+
+        let testComponent: Route.Component = .constant("a")
+        var testTree: TestTree = .node([testComponent.key : testComponent.edge(for: .leaf(testHandler))])
+
+        let removeRoute = [testComponent, .empty]
+
+        do {
+            let handler = try testTree.remove(route: removeRoute)
+            XCTAssertEqual(handler, testHandler)
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(childs) = testTree, childs.isEmpty else {
+            return XCTFail("🔥: expected empty node, got \(testTree)!")
+        }
+    }
+
+    func testRemove_WithMatchingSingleConstantElementRouteOnSingleChildTree_ShouldReturnHandlerAndChangeToEmptyTree() {
+
+        let testComponent: Route.Component = .constant("a")
+        var testTree: TestTree = .node([testComponent.key : testComponent.edge(for: .leaf(testHandler))])
+
+        let removeRoute = [testComponent]
+
+        do {
+            let handler = try testTree.remove(route: removeRoute)
+            XCTAssertEqual(handler, testHandler)
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(childs) = testTree, childs.isEmpty else {
+            return XCTFail("🔥: expected empty node, got \(testTree)!")
+        }
+    }
+
+    func testRemove_WithMatchingSingleValueParameterElementRouteOnSingleChildTree_ShouldReturnHandlerAndChangeToEmptyTree() {
+
+        let testComponent : Route.Component = .variable("a")
+        var testTree: TestTree = .node([testComponent.key : testComponent.edge(for: .leaf(testHandler))])
+
+        let removeRoute = [testComponent]
+
+        do {
+            let handler = try testTree.remove(route: removeRoute)
+            XCTAssertEqual(handler, testHandler)
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(childs) = testTree, childs.isEmpty else {
+            return XCTFail("🔥: expected empty node, got \(testTree)!")
+        }
+    }
+
+    func testRemove_WithMatchingSingleWildcardParameterElementRouteOnSingleChildTree_ShouldReturnHandlerAndChangeToEmptyTree() {
+
+        let testComponent: Route.Component = .variable(nil)
+        var testTree: TestTree = .node([testComponent.key : testComponent.edge(for: .leaf(testHandler))])
+
+        let removeRoute = [testComponent]
+
+        do {
+            let handler = try testTree.remove(route: removeRoute)
+            XCTAssertEqual(handler, testHandler)
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(childs) = testTree, childs.isEmpty else {
+            return XCTFail("🔥: expected empty node, got \(testTree)!")
+        }
+    }
+
+    // MARK: multi child node
+
+    func testRemove_WithMatchingSingleEmptyElementRouteOnMultiChildTree_ShouldReturnHandlerAndRemoveMatchedTree() {
+
+        let testComponentA: Route.Component = .empty
+        let testComponentB: Route.Component = .constant("b")
+
+        let testHandlerA = testHandler
+        let testHandlerB = "testB"
+
+        var testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: .leaf(testHandlerA)),
+                                        testComponentB.key : testComponentB.edge(for: .leaf(testHandlerB))])
+
+        let removeRoute = [testComponentA]
+
+        do {
+            let handler = try testTree.remove(route: removeRoute)
+            XCTAssertEqual(handler, testHandler)
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(childEdges) = testTree else {
+            return XCTFail("🔥: expected node, got \(testTree)!")
+        }
+        guard childEdges[testComponentA.key] == nil else {
+            return XCTFail("🔥: expected nil, got \(String(describing: childEdges[testComponentA.key]))!")
+        }
+        guard case let .simple(.leaf(handlerB))? = childEdges[testComponentB.key] else {
+            return XCTFail("🔥: expected simple leaf, got \(String(describing: childEdges[testComponentB.key]))!")
+        }
+        
+        XCTAssertEqual(handlerB, testHandlerB)
+    }
+
+    func testRemove_WithMatchingSingleConstantElementRouteOnMultiChildTree_ShouldReturnHandlerAndRemoveMatchedTree() {
+
+        let testComponentA: Route.Component = .constant("a")
+        let testComponentB: Route.Component = .constant("b")
+
+        let testHandlerA = testHandler
+        let testHandlerB = "testB"
+
+        var testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: .leaf(testHandlerA)),
+                                        testComponentB.key : testComponentB.edge(for: .leaf(testHandlerB))])
+
+        let removeRoute = [testComponentA]
+
+        do {
+            let handler = try testTree.remove(route: removeRoute)
+            XCTAssertEqual(handler, testHandler)
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(childEdges) = testTree else {
+            return XCTFail("🔥: expected node, got \(testTree)!")
+        }
+        guard childEdges[testComponentA.key] == nil else {
+            return XCTFail("🔥: expected nil, got \(String(describing: childEdges[testComponentA.key]))!")
+        }
+        guard case let .simple(.leaf(handlerB))? = childEdges[testComponentB.key] else {
+            return XCTFail("🔥: expected simple leaf, got \(String(describing: childEdges[testComponentB.key]))!")
+        }
+
+        XCTAssertEqual(handlerB, testHandlerB)
+    }
+
+    func testRemove_WithMatchingSingleValueParameterElementRouteOnMultiChildTree_ShouldReturnHandlerAndRemoveMatchedTree() {
+
+        let testParameterA = "a"
+
+        let testComponentA: Route.Component = .variable(testParameterA)
+        let testComponentB: Route.Component = .constant("b")
+
+        let testHandlerA = testHandler
+        let testHandlerB = "testB"
+
+        var testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: .leaf(testHandlerA)),
+                                        testComponentB.key : testComponentB.edge(for: .leaf(testHandlerB))])
+
+        let removeRoute = [testComponentA]
+
+        do {
+            let handler = try testTree.remove(route: removeRoute)
+            XCTAssertEqual(handler, testHandler)
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(childEdges) = testTree else {
+            return XCTFail("🔥: expected node, got \(testTree)!")
+        }
+        guard childEdges[testComponentA.key] == nil else {
+            return XCTFail("🔥: expected nil, got \(String(describing: childEdges[testComponentA.key]))!")
+        }
+        guard case let .simple(.leaf(handlerB))? = childEdges[testComponentB.key] else {
+            return XCTFail("🔥: expected simple leaf, got \(String(describing: childEdges[testComponentB.key]))!")
+        }
+        
+        XCTAssertEqual(handlerB, testHandlerB)
+    }
+
+    func testRemove_WithMatchingSingleWildcardParameterElementRouteOnMultiChildTree_ShouldReturnHandlerAndRemoveMatchedTree() {
+
+        let testComponentA: Route.Component = .variable(nil)
+        let testComponentB: Route.Component = .constant("b")
+
+        let testHandlerA = testHandler
+        let testHandlerB = "testB"
+
+        var testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: .leaf(testHandlerA)),
+                                        testComponentB.key : testComponentB.edge(for: .leaf(testHandlerB))])
+
+        let removeRoute = [testComponentA]
+
+        do {
+            let handler = try testTree.remove(route: removeRoute)
+            XCTAssertEqual(handler, testHandler)
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(childEdges) = testTree else {
+            return XCTFail("🔥: expected node, got \(testTree)!")
+        }
+        guard childEdges[testComponentA.key] == nil else {
+            return XCTFail("🔥: expected nil, got \(String(describing: childEdges[testComponentA.key]))!")
+        }
+        guard case let .simple(.leaf(handlerB))? = childEdges[testComponentB.key] else {
+            return XCTFail("🔥: expected simple leaf, got \(String(describing: childEdges[testComponentB.key]))!")
+        }
+        
+        XCTAssertEqual(handlerB, testHandlerB)
+    }
+
+    // MARK: multi level node
+
+    func testRemove_WithPartialMatchingWithFinalEmptyElementRouteOnMultiLevelConstantTree_ShouldReturnHandlerAndRemoveMatchedAndEmptyTrees() {
+
+        let testComponentA: Route.Component = .constant("a")
+        let testComponentB: Route.Component = .constant("b")
+
+        let nestedTree: TestTree = .node([testComponentB.key : testComponentB.edge(for: .leaf(testHandler))])
+        var testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: nestedTree)])
+
+        let emptyComponent: Route.Component = .empty
+        let removeRoute = [testComponentA, testComponentB, emptyComponent]
+
+        do {
+            let handler = try testTree.remove(route: removeRoute)
+            XCTAssertEqual(handler, testHandler)
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(childs) = testTree, childs.isEmpty else {
+            return XCTFail("🔥: expected empty node, got \(testTree)!")
+        }
+    }
+
+    func testRemove_WithPartialMatchingWithFinalEmptyElementRouteOnMultiLevelValueParameterTree_ShouldReturnHandlerAndRemoveMatchedAndEmptyTrees() {
+
+        let testComponentA: Route.Component = .variable("a")
+        let testComponentB: Route.Component = .variable("b")
+
+        let nestedTree: TestTree = .node([testComponentB.key : testComponentB.edge(for: .leaf(testHandler))])
+        var testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: nestedTree)])
+
+        let emptyComponent: Route.Component = .empty
+        let removeRoute = [testComponentA, testComponentB, emptyComponent]
+
+        do {
+            let handler = try testTree.remove(route: removeRoute)
+            XCTAssertEqual(handler, testHandler)
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(childs) = testTree, childs.isEmpty else {
+            return XCTFail("🔥: expected empty node, got \(testTree)!")
+        }
+    }
+
+    func testRemove_WithMatchingRouteOnMultiLevelConstantTreeWithNoMoreTrees_ShouldReturnHandlerAndSetEmptyTree() {
+        let testComponentA: Route.Component = .constant("a")
+        let testComponentB: Route.Component = .constant("b")
+
+        let nestedTree: TestTree = .node([testComponentB.key : testComponentB.edge(for: .leaf(testHandler))])
+        var testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: nestedTree)])
+
+        let removeRoute = [testComponentA, testComponentB]
+
+        do {
+            let handler = try testTree.remove(route: removeRoute)
+            XCTAssertEqual(handler, testHandler)
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(childs) = testTree, childs.isEmpty else {
+            return XCTFail("🔥: expected empty node, got \(testTree)!")
+        }
+    }
+
+    func testRemove_WithMatchingRouteOnMultiLevelVariableTreeWithNoMoreTrees_ShouldReturnHandlerAndSetEmptyTree() {
+        let testComponentA: Route.Component = .variable("a")
+        let testComponentB: Route.Component = .variable("b")
+
+        let nestedTree: TestTree = .node([testComponentB.key : testComponentB.edge(for: .leaf(testHandler))])
+        var testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: nestedTree)])
+
+        let removeRoute = [testComponentA, testComponentB]
+
+        do {
+            let handler = try testTree.remove(route: removeRoute)
+            XCTAssertEqual(handler, testHandler)
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(childs) = testTree, childs.isEmpty else {
+            return XCTFail("🔥: expected empty node, got \(testTree)!")
+        }
+    }
+    func testRemove_WithMatchingRouteOnMultiLevelConstantTreeWithMoreTrees_ShouldReturnHandlerAndRemoveMatchedAndLeaveNonEmptyTrees() {
+
+        let testComponentA: Route.Component = .constant("a")
+        let testComponentB: Route.Component = .constant("b")
+        let testComponentC: Route.Component = .constant("c")
+
+        let testHandlerC = "testC"
+
+        let nestedTree: TestTree = .node([testComponentB.key : testComponentB.edge(for: .leaf(testHandler)),
+                                          testComponentC.key : testComponentC.edge(for: .leaf(testHandlerC))])
+        var testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: nestedTree)])
+
+        let removeRoute = [testComponentA, testComponentB]
+
+        do {
+            let handler = try testTree.remove(route: removeRoute)
+            XCTAssertEqual(handler, testHandler)
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(childEdges) = testTree else {
+            return XCTFail("🔥: expected node, got \(testTree)!")
+        }
+        guard case let .simple(.node(childEdgesA))? = childEdges[testComponentA.key] else {
+            return XCTFail("🔥: expected simple node, got \(String(describing: childEdges[testComponentA.key]))!")
+        }
+        guard childEdgesA[testComponentB.key] == nil else {
+            return XCTFail("🔥: expected nil, got \(String(describing: childEdgesA[testComponentB.key]))!")
+        }
+        guard case let .simple(.leaf(handlerC))? = childEdgesA[testComponentC.key] else {
+            return XCTFail("🔥: expected simple leaf, got \(String(describing: childEdges[testComponentC.key]))!")
+        }
+
+        XCTAssertEqual(handlerC, testHandlerC)
+    }
+
+    func testRemove_WithMatchingRouteOnMultiLevelVariableTreeWithMoreTrees_ShouldReturnHandlerAndRemoveMatchedAndLeaveNonEmptyTrees() {
+
+        let testParameterA = "a"
+        let testParameterB = "b"
+
+        let testComponentA: Route.Component = .variable(testParameterA)
+        let testComponentB: Route.Component = .variable(testParameterB)
+        let testComponentC: Route.Component = .constant("c")
+
+        let testHandlerC = "testC"
+
+        let nestedTree: TestTree = .node([testComponentB.key : testComponentB.edge(for: .leaf(testHandler)),
+                                          testComponentC.key : testComponentC.edge(for: .leaf(testHandlerC))])
+        var testTree: TestTree = .node([testComponentA.key : testComponentA.edge(for: nestedTree)])
+
+        let removeRoute = [testComponentA, testComponentB]
+
+        do {
+            let handler = try testTree.remove(route: removeRoute)
+            XCTAssertEqual(handler, testHandler)
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        guard case let .node(childEdges) = testTree else {
+            return XCTFail("🔥: expected node, got \(testTree)!")
+        }
+        guard case let .parameter(parameterA, .node(childEdgesA))? = childEdges[testComponentA.key] else {
+            return XCTFail("🔥: expected parameter node, got \(String(describing: childEdges[testComponentA.key]))!")
+        }
+        guard childEdgesA[testComponentB.key] == nil else {
+            return XCTFail("🔥: expected nil, got \(String(describing: childEdgesA[testComponentB.key]))!")
+        }
+        guard case let .simple(.leaf(handlerC))? = childEdgesA[testComponentC.key] else {
+            return XCTFail("🔥: expected simple leaf, got \(String(describing: childEdges[testComponentC.key]))!")
+        }
+
+        XCTAssertEqual(handlerC, testHandlerC)
+        XCTAssertEqual(parameterA, testParameterA) 
+    }
+}

--- a/AlicerceTests/Sources/DeepLinking/TreeRouterTests.swift
+++ b/AlicerceTests/Sources/DeepLinking/TreeRouterTests.swift
@@ -1,0 +1,1508 @@
+//
+//  TreeRouterTests.swift
+//  Alicerce
+//
+//  Created by André Pacheco Neves on 17/04/2017.
+//  Copyright © 2017 Mindera. All rights reserved.
+//
+
+import XCTest
+@testable import Alicerce
+
+final class TestHandler: RouteHandler {
+
+    typealias HandleClosure = (URL, [String : String], [URLQueryItem]) -> Void
+
+    var didCallHandle: (HandleClosure)?
+
+    public func handle(route: URL, parameters: [String : String], queryItems: [URLQueryItem]) {
+        didCallHandle?(route, parameters, queryItems)
+    }
+}
+
+class TreeRouterTests: XCTestCase {
+
+    typealias TestRouter = TreeRouter<TestHandler>
+    typealias TestRouteTree = Route.Tree<TestHandler>
+
+    fileprivate let expectationTimeout: TimeInterval = 5
+    fileprivate let expectationHandler: XCWaitCompletionHandler = { error in
+        if let error = error {
+            XCTFail("🔥: Test expectation wait timed out: \(error)")
+        }
+    }
+
+    var router: TestRouter!
+    var testHandler: TestHandler!
+    
+    override func setUp() {
+        super.setUp()
+
+        router = TestRouter()
+        testHandler = TestHandler()
+    }
+    
+    override func tearDown() {
+        router = nil
+        testHandler = nil
+
+        super.tearDown()
+    }
+    
+    // MARK: - register
+
+    // MARK: error
+
+    func testRegister_WithDuplicateRouteEndingInEmptyComponentOnAlreadyExistentRoute_ShouldFailWithDuplicateRoute() {
+
+        let validRoute = URL(string: "scheme://host")!
+        let duplicateRoute = URL(string: "scheme://host/")!
+
+        do {
+            try router.register(validRoute, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            try router.register(duplicateRoute, handler: testHandler)
+            XCTFail("🔥: unexpected success!")
+        } catch TestRouter.Error.duplicateRoute {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testRegister_WithDuplicateRouteWithoutEndingEmptyComponentOnAlreadyExistentRouteWithEmptyComponent_ShouldFailWithDuplicateRoute() {
+
+        let validRoute = URL(string: "scheme://host/")!
+        let duplicateRoute = URL(string: "scheme://host")!
+
+        do {
+            try router.register(validRoute, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            try router.register(duplicateRoute, handler: testHandler)
+            XCTFail("🔥: unexpected success!")
+        } catch TestRouter.Error.duplicateRoute {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testRegister_WithDuplicateRouteWithPathEndingInEmptyComponentOnAlreadyExistentRoute_ShouldFailWithDuplicateRoute() {
+
+        let validRoute = URL(string: "scheme://host/path")!
+        let duplicateRoute = URL(string: "scheme://host/path/")!
+
+        do {
+            try router.register(validRoute, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            try router.register(duplicateRoute, handler: testHandler)
+            XCTFail("🔥: unexpected success!")
+        } catch TestRouter.Error.duplicateRoute {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testRegister_WithDuplicateRouteWithPathWithoutEndingEmptyComponentOnAlreadyExistentRouteWithEmptyComponent_ShouldFailWithDuplicateRoute() {
+
+        let validRoute = URL(string: "scheme://host/path/")!
+        let duplicateRoute = URL(string: "scheme://host/path")!
+
+        do {
+            try router.register(validRoute, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            try router.register(duplicateRoute, handler: testHandler)
+            XCTFail("🔥: unexpected success!")
+        } catch TestRouter.Error.duplicateRoute {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testRegister_WithConflictingVariableRouteOnAlreadyExistentVariableRoute_ShouldFailWithInvalidRoute() {
+
+        let existingParameterName = "variable"
+        let validRoute = URL(string: "scheme:///:" + existingParameterName)!
+
+        let conflictingParameterNameA = "conflict"
+        let conflictingParameterNameB = "*"
+        let invalidRouteA = URL(string: "scheme:///:" + conflictingParameterNameA)!
+        let invalidRouteB = URL(string: "scheme:///" + conflictingParameterNameB)!
+
+        do {
+            try router.register(validRoute, handler: testHandler)
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        // variable value vs variable value conflict
+        do {
+            try router.register(invalidRouteA, handler: testHandler)
+            XCTFail("🔥: unexpected success!")
+        } catch let TestRouter.Error.invalidRoute(.conflictingVariableComponent(existing, new)) {
+            // expected error 💪
+            XCTAssertEqual(existing, existingParameterName)
+            XCTAssertEqual(new, conflictingParameterNameA)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        // variable value vs variable wildcard conflict
+        do {
+            try router.register(invalidRouteB, handler: testHandler)
+            XCTFail("🔥: unexpected success!")
+        } catch let TestRouter.Error.invalidRoute(.conflictingVariableComponent(existing, new)) {
+            // expected error 💪
+            XCTAssertEqual(existing, existingParameterName)
+            XCTAssertEqual(new, conflictingParameterNameB)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    // MARK: success
+
+    func testRegister_WithValidRouteWithSchemeAndHost_ShouldSucceed() {
+
+        let validRoute = URL(string: "scheme://host/path/")!
+
+        do {
+            try router.register(validRoute, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testRegister_WithValidRouteWithEmptyHost_ShouldSucceed() {
+
+        let validRoute = URL(string: "scheme:///path/")!
+
+        do {
+            try router.register(validRoute, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testRegister_WithValidRouteWithEmptyScheme_ShouldSucceed() {
+
+        let validRoute = URL(string: "://host/path/")!
+
+        do {
+            try router.register(validRoute, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testRegister_WithValidRouteWithEmptySchemeAndHost_ShouldSucceed() {
+
+        let validRoute = URL(string: ":///path/")!
+
+        do {
+            try router.register(validRoute, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testRegister_WithTwoEqualRoutesOnDifferentSchemes_ShouldSucceed() {
+
+        let validRouteA = URL(string: "schemeA://host/path/")!
+        let validRouteB = URL(string: "schemeB://host/path/")!
+
+        do {
+            try router.register(validRouteA, handler: testHandler)
+            try router.register(validRouteB, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testRegister_WithTwoEqualRoutesOnDifferentSchemesWithEmptyHost_ShouldSucceed() {
+
+        let validRouteA = URL(string: "schemeA:///path/")!
+        let validRouteB = URL(string: "schemeB:///path/")!
+
+        do {
+            try router.register(validRouteA, handler: testHandler)
+            try router.register(validRouteB, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testRegister_WithTwoEqualRoutesOnDifferentHosts_ShouldSucceed() {
+
+        let validRouteA = URL(string: "scheme://hostA/path/")!
+        let validRouteB = URL(string: "scheme://hostB/path/")!
+
+        do {
+            try router.register(validRouteA, handler: testHandler)
+            try router.register(validRouteB, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    // MARK: - unregister
+
+    // MARK: error
+
+    // single path
+
+    func testUnregister_WithNonExistentRouteAndScheme_ShouldFailWithRouteNotFound() {
+
+        let route = URL(string: "scheme://host/path")!
+        do {
+            let _ = try router.unregister(route)
+            XCTFail("🔥: unexpected success!")
+        } catch TestRouter.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testUnregister_WithNonExistentRouteAndSchemeAndEmptyHost_ShouldFailWithRouteNotFound() {
+
+        let route = URL(string: "scheme:///path")!
+        do {
+            let _ = try router.unregister(route)
+            XCTFail("🔥: unexpected success!")
+        } catch TestRouter.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testUnregister_WithNonExistentRouteAndExistentScheme_ShouldFailWithRouteNotFound() {
+
+        let route = URL(string: "scheme://host/path")!
+        let nonExistentRoute = URL(string: "scheme://host/non-existent")!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let _ = try router.unregister(nonExistentRoute)
+            XCTFail("🔥: unexpected success!")
+        } catch TestRouter.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testUnregister_WithNonExistentRouteAndExistentSchemeAndEmptyHost_ShouldFailWithRouteNotFound() {
+
+        let route = URL(string: "scheme:///path")!
+        let nonExistentRoute = URL(string: "scheme:///non-existent")!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let _ = try router.unregister(nonExistentRoute)
+            XCTFail("🔥: unexpected success!")
+        } catch TestRouter.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testUnregister_WithNonExistentSchemeOnlyRouteAndExistentSchemeOnlyRoute_ShouldFailWithRouteNotFound() {
+
+        let route = URL(string: "schemeA://")!
+        let nonExistentRoute = URL(string: "schemeB://")!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let _ = try router.unregister(nonExistentRoute)
+            XCTFail("🔥: unexpected success!")
+        } catch TestRouter.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    // MARK: partial match
+
+    func testUnregister_WithPartialMatchingRoute_ShouldFailWithRouteNotFound() {
+
+        let route = URL(string: "scheme://host/path/to")!
+        let partialMatchRouteA = URL(string: "scheme:///host/path")!
+        let partialMatchRouteB = URL(string: "scheme:///host/path/")!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let _ = try router.unregister(partialMatchRouteA)
+            XCTFail("🔥: unexpected success!")
+        } catch TestRouter.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let _ = try router.unregister(partialMatchRouteB)
+            XCTFail("🔥: unexpected success!")
+        } catch TestRouter.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testUnregister_WithPartialMatchingRouteAndEmptyHost_ShouldFailWithRouteNotFound() {
+
+        let route = URL(string: "scheme:///path/to")!
+        let partialMatchRouteA = URL(string: "scheme:////path")!
+        let partialMatchRouteB = URL(string: "scheme:////path/")!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let _ = try router.unregister(partialMatchRouteA)
+            XCTFail("🔥: unexpected success!")
+        } catch TestRouter.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let _ = try router.unregister(partialMatchRouteB)
+            XCTFail("🔥: unexpected success!")
+        } catch TestRouter.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testUnregister_WithPartialMatchingRouteAndEmptyScheme_ShouldFailWithRouteNotFound() {
+
+        let route = URL(string: "://host/path/to")!
+        let partialMatchRouteA = URL(string: ":///host/path")!
+        let partialMatchRouteB = URL(string: ":///host/path/")!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let _ = try router.unregister(partialMatchRouteA)
+            XCTFail("🔥: unexpected success!")
+        } catch TestRouter.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let _ = try router.unregister(partialMatchRouteB)
+            XCTFail("🔥: unexpected success!")
+        } catch TestRouter.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testUnregister_WithPartialMatchingRouteAndEmptyHostAndEmptyScheme_ShouldFailWithRouteNotFound() {
+
+        let route = URL(string: ":///path/to")!
+        let partialMatchRouteA = URL(string: ":////path")!
+        let partialMatchRouteB = URL(string: ":////path/")!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let _ = try router.unregister(partialMatchRouteA)
+            XCTFail("🔥: unexpected success!")
+        } catch TestRouter.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let _ = try router.unregister(partialMatchRouteB)
+            XCTFail("🔥: unexpected success!")
+        } catch TestRouter.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    // MARK: success
+
+    func testUnregister_WithMatchingSchemeOnlyRoute_ShouldSucceed() {
+
+        let route = URL(string: "scheme://")!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let handler = try router.unregister(route)
+            XCTAssert(handler === testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testUnregister_WithMatchingRouteWithHost_ShouldSucceed() {
+
+        let route = URL(string: "scheme://host")!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let handler = try router.unregister(route)
+            XCTAssert(handler === testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testUnregister_WithMatchingRouteWithHostAndEmpty_ShouldSucceed() {
+
+        let route = URL(string: "scheme://host/")!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let handler = try router.unregister(route)
+            XCTAssert(handler === testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testUnregister_WithMatchingRouteWithHostAndPath_ShouldSucceed() {
+
+        let route = URL(string: "scheme://host/path")!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let handler = try router.unregister(route)
+            XCTAssert(handler === testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testUnregister_WithMatchingRouteWithEmptyHost_ShouldSucceed() {
+
+        let route = URL(string: "scheme:///")!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let handler = try router.unregister(route)
+            XCTAssert(handler === testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testUnregister_WithMatchingRouteWithEmptyHostAndEmpty_ShouldSucceed() {
+
+        let route = URL(string: "scheme:////")!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let handler = try router.unregister(route)
+            XCTAssert(handler === testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testUnregister_WithMatchingRouteWithHostAndPathAndEmpty_ShouldSucceed() {
+
+        let route = URL(string: "scheme://host/path/")!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let handler = try router.unregister(route)
+            XCTAssert(handler === testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testUnregister_WithMatchingRouteWithEmptyHostAndPath_ShouldSucceed() {
+
+        let route = URL(string: "scheme:///path")!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let handler = try router.unregister(route)
+            XCTAssert(handler === testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testUnregister_WithMatchingRouteWithEmptyHostAndPathAndEmpty_ShouldSucceed() {
+
+        let route = URL(string: "scheme:///path/")!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let handler = try router.unregister(route)
+            XCTAssert(handler === testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testUnregister_WithMatchingEmptySchemeOnlyRoute_ShouldSucceed() {
+
+        let route = URL(string: "://")!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let handler = try router.unregister(route)
+            XCTAssert(handler === testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testUnregister_WithMatchingEmptySchemeRouteWithHost_ShouldSucceed() {
+
+        let route = URL(string: "://host")!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let handler = try router.unregister(route)
+            XCTAssert(handler === testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testUnregister_WithMatchingEmptySchemeRouteWithHostAndEmpty_ShouldSucceed() {
+
+        let route = URL(string: "://host/")!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let handler = try router.unregister(route)
+            XCTAssert(handler === testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testUnregister_WithMatchingEmptySchemeRouteWithHostAndPath_ShouldSucceed() {
+
+        let route = URL(string: "://host/path")!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let handler = try router.unregister(route)
+            XCTAssert(handler === testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testUnregister_WithMatchingEmptySchemeRouteWithEmptyHost_ShouldSucceed() {
+
+        let route = URL(string: ":///")!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let handler = try router.unregister(route)
+            XCTAssert(handler === testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testUnregister_WithMatchingEmptySchemeRouteWithEmptyHostAndEmpty_ShouldSucceed() {
+
+        let route = URL(string: ":////")!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let handler = try router.unregister(route)
+            XCTAssert(handler === testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testUnregister_WithMatchingEmptySchemeRouteWithHostAndPathAndEmpty_ShouldSucceed() {
+
+        let route = URL(string: "://host/path/")!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let handler = try router.unregister(route)
+            XCTAssert(handler === testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testUnregister_WithMatchingEmptySchemeRouteWithEmptyHostAndPath_ShouldSucceed() {
+
+        let route = URL(string: ":///path")!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            let handler = try router.unregister(route)
+            XCTAssert(handler === testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testUnregister_WithMatchingEmptySchemeRouteWithEmptyHostAndPathAndEmpty_ShouldSucceed() {
+
+        let route = URL(string: ":///path/")!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+        
+        do {
+            let handler = try router.unregister(route)
+            XCTAssert(handler === testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    // MARK: route
+
+    // MARK: error
+
+    // route not found
+
+    func testRoute_WithNonExistentRouteAndEmptyHost_ShouldFailWithRouteNotFound() {
+
+        let route = URL(string: "scheme:///path")!
+        let invalidRoute = URL(string: "scheme:///non-existent")!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            try router.route(invalidRoute)
+            XCTFail("🔥: unexpected success!")
+        } catch TestRouter.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testRoute_WithNonExistentRouteAndScheme_ShouldFailWithRouteNotFound() {
+
+        let route = URL(string: "scheme://host/path")!
+        do {
+            try router.route(route)
+            XCTFail("🔥: unexpected success!")
+        } catch TestRouter.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testRoute_WithNonExistentRouteAndSchemeAndEmptyHost_ShouldFailWithRouteNotFound() {
+
+        let route = URL(string: "scheme:///path")!
+        do {
+            try router.route(route)
+            XCTFail("🔥: unexpected success!")
+        } catch TestRouter.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testRoute_WithNonExistentRouteAndExistentScheme_ShouldFailWithRouteNotFound() {
+
+        let route = URL(string: "scheme://host/path")!
+        let nonExistentRoute = URL(string: "scheme://host/non-existent")!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            try router.route(nonExistentRoute)
+            XCTFail("🔥: unexpected success!")
+        } catch TestRouter.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testRoute_WithNonExistentSchemeOnlyRouteAndExistentSchemeOnlyRoute_ShouldFailWithRouteNotFound() {
+
+        let route = URL(string: "schemeA://")!
+        let nonExistentRoute = URL(string: "schemeB://")!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            try router.route(nonExistentRoute)
+            XCTFail("🔥: unexpected success!")
+        } catch TestRouter.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    // MARK: partial match
+
+    func testRoute_WithPartialMatchingRoute_ShouldFailWithRouteNotFound() {
+
+        let route = URL(string: "scheme://host/path/to")!
+        let partialMatchRouteA = URL(string: "scheme://host/path")!
+        let partialMatchRouteB = URL(string: "scheme://host/path/")!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            try router.route(partialMatchRouteA)
+            XCTFail("🔥: unexpected success!")
+        } catch TestRouter.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            try router.route(partialMatchRouteB)
+            XCTFail("🔥: unexpected success!")
+        } catch TestRouter.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testRoute_WithPartialMatchingRouteAndEmptyHost_ShouldFailWithRouteNotFound() {
+
+        let route = URL(string: "scheme:///path/to")! // is equivalent to wildcard host (*)
+        let partialMatchRouteA = URL(string: "scheme://host/path")!
+        let partialMatchRouteB = URL(string: "scheme://host/path/")!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            try router.route(partialMatchRouteA)
+            XCTFail("🔥: unexpected success!")
+        } catch TestRouter.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            try router.route(partialMatchRouteB)
+            XCTFail("🔥: unexpected success!")
+        } catch TestRouter.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testRoute_WithPartialMatchingRouteAndEmptyScheme_ShouldFailWithRouteNotFound() {
+
+        let route = URL(string: "://host/path/to")!
+        let partialMatchRouteA = URL(string: "://host/path")!
+        let partialMatchRouteB = URL(string: "://host/path/")!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            try router.route(partialMatchRouteA)
+            XCTFail("🔥: unexpected success!")
+        } catch TestRouter.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            try router.route(partialMatchRouteB)
+            XCTFail("🔥: unexpected success!")
+        } catch TestRouter.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testRoute_WithPartialMatchingRouteAndEmptyHostAndEmptyScheme_ShouldFailWithRouteNotFound() {
+
+        let route = URL(string: ":///path/to")!
+        let partialMatchRouteA = URL(string: "://path")!
+        let partialMatchRouteB = URL(string: "://path/")!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            try router.route(partialMatchRouteA)
+            XCTFail("🔥: unexpected success!")
+        } catch TestRouter.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            try router.route(partialMatchRouteB)
+            XCTFail("🔥: unexpected success!")
+        } catch TestRouter.Error.routeNotFound {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    // invalid route
+
+    func testRoute_WithVariableComponentInHost_ShouldFailWithInvalidRoute() {
+
+        let route = URL(string: "scheme://host/path/to")!
+
+        let variableComponentA: Route.Component = ":variable"
+        let variableComponentB: Route.Component = "*"
+
+        let invalidRouteA = URL(string: "scheme://" + variableComponentA.description + "/path")!
+        let invalidRouteB = URL(string: "scheme://" + variableComponentB.description + "/path")!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            try router.route(invalidRouteA)
+            XCTFail("🔥: unexpected success!")
+        } catch TestRouter.Error.invalidRoute(.invalidURL) {
+            // expected error 💪
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            try router.route(invalidRouteB)
+            XCTFail("🔥: unexpected success!")
+        } catch let TestRouter.Error.invalidRoute(.invalidVariableComponent(component)) {
+            // expected error 💪
+            XCTAssertEqual(component, variableComponentB.description)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    func testRoute_WithVariableComponentInPath_ShouldFailWithInvalidRoute() {
+
+        let route = URL(string: "scheme://host/path/to")!
+
+        let variableComponentA: Route.Component = ":variable"
+        let variableComponentB: Route.Component = "*"
+
+        let invalidRouteA = URL(string: "scheme://host/" + variableComponentA.description)!
+        let invalidRouteB = URL(string: "scheme://host/" + variableComponentB.description)!
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            try router.route(invalidRouteA)
+            XCTFail("🔥: unexpected success!")
+        } catch let TestRouter.Error.invalidRoute(.invalidVariableComponent(component)) {
+            // expected error 💪
+            XCTAssertEqual(component, variableComponentA.description)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            try router.route(invalidRouteB)
+            XCTFail("🔥: unexpected success!")
+        } catch let TestRouter.Error.invalidRoute(.invalidVariableComponent(component)) {
+            // expected error 💪
+            XCTAssertEqual(component, variableComponentB.description)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    // MARK: success
+
+    func testRoute_WithMatchingSchemeAndEmptyRoute_ShouldSucceed() {
+
+        let route = URL(string: "scheme://")!
+
+        let expectation = self.expectation(description: "TreeRouter.route")
+        defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
+
+        testHandler.didCallHandle = { (url, parameters, queryItems) in
+            XCTAssertEqual(url, route)
+            XCTAssertEqual(parameters, [:])
+            XCTAssertEqual(queryItems, [])
+            expectation.fulfill()
+        }
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            try router.route(route)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+            expectation.fulfill()
+        }
+    }
+
+    func testRoute_WithMatchingSchemeAndWildcardHost_ShouldSucceed() {
+
+        let route = URL(string: "scheme:///")!
+
+        let expectation = self.expectation(description: "TreeRouter.route")
+        defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
+
+        testHandler.didCallHandle = { (url, parameters, queryItems) in
+            XCTAssertEqual(url, route)
+            XCTAssertEqual(parameters, [:])
+            XCTAssertEqual(queryItems, [])
+            expectation.fulfill()
+        }
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            try router.route(route)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+            expectation.fulfill()
+        }
+    }
+
+    func testRoute_WithMatchingEmptySchemeAndEmptyRoute_ShouldSucceed() {
+
+        let route = URL(string: "://")!
+
+        let expectation = self.expectation(description: "TreeRouter.route")
+        defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
+
+        testHandler.didCallHandle = { (url, parameters, queryItems) in
+            XCTAssertEqual(url, route)
+            XCTAssertEqual(parameters, [:])
+            XCTAssertEqual(queryItems, [])
+            expectation.fulfill()
+        }
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            try router.route(route)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+            expectation.fulfill()
+        }
+    }
+
+    func testRoute_WithMatchingEmptySchemeAndWildcardHost_ShouldSucceed() {
+
+        let route = URL(string: ":///")!
+
+        let expectation = self.expectation(description: "TreeRouter.route")
+        defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
+
+        testHandler.didCallHandle = { (url, parameters, queryItems) in
+            XCTAssertEqual(url, route)
+            XCTAssertEqual(parameters, [:])
+            XCTAssertEqual(queryItems, [])
+            expectation.fulfill()
+        }
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            try router.route(route)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+            expectation.fulfill()
+        }
+    }
+
+    func testRoute_WithMatchingSchemeAndHost_ShouldSucceed() {
+
+        let routeA = URL(string: "scheme://host")!
+        let routeB = URL(string: "scheme://host/")! // with terminating empty
+
+        let expectationA = self.expectation(description: "TreeRouter.route")
+        let expectationB = self.expectation(description: "TreeRouter.route")
+        defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
+
+        testHandler.didCallHandle = { (url, parameters, queryItems) in
+            XCTAssertEqual(url, routeA)
+            XCTAssertEqual(parameters, [:])
+            XCTAssertEqual(queryItems, [])
+            expectationA.fulfill()
+        }
+
+        do {
+            try router.register(routeA, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            try router.route(routeA)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+            expectationA.fulfill()
+        }
+
+        testHandler.didCallHandle = { (url, parameters, queryItems) in
+            XCTAssertEqual(url, routeB)
+            XCTAssertEqual(parameters, [:])
+            XCTAssertEqual(queryItems, [])
+            expectationB.fulfill()
+        }
+
+        do {
+            try router.route(routeB)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+            expectationB.fulfill()
+        }
+    }
+
+    func testRoute_WithMatchingSchemeHostAndPath_ShouldSucceed() {
+
+        let routeA = URL(string: "scheme://host/path/to/resource")!
+        let routeB = URL(string: "scheme://host/path/to/resource/")! // with terminating empty
+
+        let expectationA = self.expectation(description: "TreeRouter.route")
+        let expectationB = self.expectation(description: "TreeRouter.route")
+        defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
+
+        testHandler.didCallHandle = { (url, parameters, queryItems) in
+            XCTAssertEqual(url, routeA)
+            XCTAssertEqual(parameters, [:])
+            XCTAssertEqual(queryItems, [])
+            expectationA.fulfill()
+        }
+
+        do {
+            try router.register(routeA, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            try router.route(routeA)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+            expectationA.fulfill()
+        }
+
+        testHandler.didCallHandle = { (url, parameters, queryItems) in
+            XCTAssertEqual(url, routeB)
+            XCTAssertEqual(parameters, [:])
+            XCTAssertEqual(queryItems, [])
+            expectationB.fulfill()
+        }
+
+        do {
+            try router.route(routeB)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+            expectationB.fulfill()
+        }
+    }
+
+    func testRoute_WithMatchingSchemeHostAndEmptyPath_ShouldSucceed() {
+
+        let routeA = URL(string: "scheme://host/")!
+        let routeB = URL(string: "scheme://host//")! // with terminating empty
+
+        let expectationA = self.expectation(description: "TreeRouter.route")
+        let expectationB = self.expectation(description: "TreeRouter.route")
+        defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
+
+        testHandler.didCallHandle = { (url, parameters, queryItems) in
+            XCTAssertEqual(url, routeA)
+            XCTAssertEqual(parameters, [:])
+            XCTAssertEqual(queryItems, [])
+            expectationA.fulfill()
+        }
+
+        do {
+            try router.register(routeA, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            try router.route(routeA)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+            expectationA.fulfill()
+        }
+
+        testHandler.didCallHandle = { (url, parameters, queryItems) in
+            XCTAssertEqual(url, routeB)
+            XCTAssertEqual(parameters, [:])
+            XCTAssertEqual(queryItems, [])
+            expectationB.fulfill()
+        }
+
+        do {
+            try router.route(routeB)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+            expectationB.fulfill()
+        }
+    }
+
+    func testRoute_WithMatchingSchemeHostAndParameterPath_ShouldSucceedAndPassParametersToHandler() {
+
+        let parameterA = "parameterA"
+        let parameterB = "parameterB"
+
+        let parameterValueA = "valueA"
+        let parameterValueB = "valueB"
+
+        let route = URL(string: "scheme://host/:\(parameterA)/:\(parameterB)")!
+
+        let routeA = URL(string: "scheme://host/\(parameterValueA)/\(parameterValueB)")!
+        let routeB = URL(string: "scheme://host/\(parameterValueA)/\(parameterValueB)/")! // with terminating empty
+
+        let expectationA = self.expectation(description: "TreeRouter.route")
+        let expectationB = self.expectation(description: "TreeRouter.route")
+        defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
+
+        testHandler.didCallHandle = { (url, parameters, queryItems) in
+            XCTAssertEqual(url, routeA)
+            XCTAssertEqual(parameters, [parameterA.description : parameterValueA,
+                                        parameterB.description : parameterValueB])
+            XCTAssertEqual(queryItems, [])
+            expectationA.fulfill()
+        }
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            try router.route(routeA)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+            expectationA.fulfill()
+        }
+
+        testHandler.didCallHandle = { (url, parameters, queryItems) in
+            XCTAssertEqual(url, routeB)
+            XCTAssertEqual(parameters, [parameterA.description : parameterValueA,
+                                        parameterB.description : parameterValueB])
+            XCTAssertEqual(queryItems, [])
+            expectationB.fulfill()
+        }
+
+        do {
+            try router.route(routeB)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+            expectationB.fulfill()
+        }
+    }
+
+    func testRoute_WithMatchingSchemeHostAndWildcardPath_ShouldSucceedAndPassEmptyParametersToHandler() {
+
+        let route = URL(string: "scheme://host/*/*")!
+
+        let routeA = URL(string: "scheme://host/path/to")!
+        let routeB = URL(string: "scheme://host/path/to/")! // with terminating empty
+
+        let expectationA = self.expectation(description: "TreeRouter.route")
+        let expectationB = self.expectation(description: "TreeRouter.route")
+        defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
+
+        testHandler.didCallHandle = { (url, parameters, queryItems) in
+            XCTAssertEqual(url, routeA)
+            XCTAssertEqual(parameters, [:])
+            XCTAssertEqual(queryItems, [])
+            expectationA.fulfill()
+        }
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            try router.route(routeA)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+            expectationA.fulfill()
+        }
+
+        testHandler.didCallHandle = { (url, parameters, queryItems) in
+            XCTAssertEqual(url, routeB)
+            XCTAssertEqual(parameters, [:])
+            XCTAssertEqual(queryItems, [])
+            expectationB.fulfill()
+        }
+
+        do {
+            try router.route(routeB)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+            expectationB.fulfill()
+        }
+    }
+
+    func testRoute_WithMatchingSchemeHostAndPathAndQuery_ShouldSucceedAndPassQueryItemsToHandler() {
+
+        let testQueryItems = [URLQueryItem(name: "queryItemA", value: "valueA"),
+                              URLQueryItem(name: "queryItemB", value: "valueB")]
+
+        let route = URL(string: "scheme://host/path/to/resource")!
+
+        var routeAComponents = URLComponents(string: "scheme://host/path/to/resource")!
+        routeAComponents.queryItems = testQueryItems
+        let routeA = routeAComponents.url!
+
+        var routeBComponents = URLComponents(string: "scheme://host/path/to/resource/")! // with terminating empty
+        routeBComponents.queryItems = testQueryItems
+        let routeB = routeAComponents.url!
+
+        let expectationA = self.expectation(description: "TreeRouter.route")
+        let expectationB = self.expectation(description: "TreeRouter.route")
+        defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
+
+        testHandler.didCallHandle = { (url, parameters, queryItems) in
+            XCTAssertEqual(url, routeA)
+            XCTAssertEqual(parameters, [:])
+            XCTAssertEqual(queryItems, testQueryItems)
+            expectationA.fulfill()
+        }
+
+        do {
+            try router.register(route, handler: testHandler)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        do {
+            try router.route(routeA)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+            expectationA.fulfill()
+        }
+
+        testHandler.didCallHandle = { (url, parameters, queryItems) in
+            XCTAssertEqual(url, routeB)
+            XCTAssertEqual(parameters, [:])
+            XCTAssertEqual(queryItems, testQueryItems)
+            expectationB.fulfill()
+        }
+
+        do {
+            try router.route(routeB)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+            expectationB.fulfill()
+        }
+    }
+}


### PR DESCRIPTION
- Created `ApplicationRouter` protocol to handle `UIApplicationDelegate`
external route entry points.
- Created `ApplicationRoute` enum to represent a type of route received
by the `AppDelegate`.
- Created `Route` careless enum to namespace route specific types:
  + Created `Route.Component` enum to represent the different types of
path components in a route.
  + Created `Route.Tree` enum to represent a routing tree to efficiently
perform matching against.
- Created `Router` protocol to handle registration/unregistration/handle
of URL routes.
- Created `RouteHandler` protocol to represent a handler for a specific
route.
- Created `TreeRouter` that handles URL routes using an internal
`Route.Tree`.
- Added Unit Tests for `Route.Tree`