### PR TITLE
Allow tabBarItem helper to customize rendering mode

### DIFF
--- a/Sources/UIKit/UIViewController.swift
+++ b/Sources/UIKit/UIViewController.swift
@@ -34,8 +34,11 @@ public extension UIViewController {
     /// - Parameters:
     ///   - selectedImage: UIImage to show when tab is active
     ///   - unselectedImage: UIImage to show when tab is inactive
-    public func tabBarItem(withSelectedImage selectedImage: UIImage?, unselectedImage: UIImage?) {
-        tabBarItem.image = unselectedImage?.withRenderingMode(.alwaysOriginal)
-        tabBarItem.selectedImage = selectedImage?.withRenderingMode(.alwaysOriginal)
+    public func tabBarItem(withSelectedImage selectedImage: UIImage?,
+                           unselectedImage: UIImage?,
+                           selectRenderMode: UIImageRenderingMode = .alwaysOriginal,
+                           unselectRenderMode: UIImageRenderingMode = .alwaysOriginal) {
+        tabBarItem.image = unselectedImage?.withRenderingMode(unselectRenderMode)
+        tabBarItem.selectedImage = selectedImage?.withRenderingMode(selectRenderMode)
     }
 }

--- a/Sources/UIKit/UIViewController.swift
+++ b/Sources/UIKit/UIViewController.swift
@@ -30,15 +30,19 @@ public extension UIViewController {
 public extension UIViewController {
     
     /// Helper method to set tabBarItem images with correct rendering mode
+    /// You can change the render mode if you want to render the image
+    /// as a template.
     ///
     /// - Parameters:
     ///   - selectedImage: UIImage to show when tab is active
     ///   - unselectedImage: UIImage to show when tab is inactive
+    ///   - selectedRenderMode: UIImageRenderingMode to the selected image. Default .alwaysOriginal
+    ///   - unselectedRenderMode: UIImageRenderingMode to the unselected image. Default .alwaysOriginal
     public func tabBarItem(withSelectedImage selectedImage: UIImage?,
                            unselectedImage: UIImage?,
-                           selectRenderMode: UIImageRenderingMode = .alwaysOriginal,
-                           unselectRenderMode: UIImageRenderingMode = .alwaysOriginal) {
-        tabBarItem.image = unselectedImage?.withRenderingMode(unselectRenderMode)
-        tabBarItem.selectedImage = selectedImage?.withRenderingMode(selectRenderMode)
+                           selectedRenderMode: UIImageRenderingMode = .alwaysOriginal,
+                           unselectedRenderMode: UIImageRenderingMode = .alwaysOriginal) {
+        tabBarItem.image = unselectedImage?.withRenderingMode(unselectedRenderMode)
+        tabBarItem.selectedImage = selectedImage?.withRenderingMode(selectedRenderMode)
     }
 }


### PR DESCRIPTION
I think we should provide a way to customize the render mode in the tabBarItem helper so we can toggle if the system should tint the icon or not.