### PR TITLE
Add JSON parsing Utils

### DIFF
--- a/Alicerce.xcodeproj/project.pbxproj
+++ b/Alicerce.xcodeproj/project.pbxproj
@@ -108,6 +108,8 @@
 		0A3C2DE11EA7E5EF00EFB7D4 /* ServiceLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3C2D3C1EA7E1EE00EFB7D4 /* ServiceLocatorTests.swift */; };
 		0A3C2DE21EA7E5EF00EFB7D4 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3C2D3D1EA7E1EE00EFB7D4 /* Utils.swift */; };
 		0ABFFABA1EA7F25B00CFC8BD /* Alicerce.h in Headers */ = {isa = PBXBuildFile; fileRef = 0ABFFAB91EA7F25B00CFC8BD /* Alicerce.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0ABFFAC41EA8D08B00CFC8BD /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ABFFAC31EA8D08B00CFC8BD /* JSON.swift */; };
+		0ABFFAC61EA8FCA300CFC8BD /* JSONTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ABFFAC51EA8FCA300CFC8BD /* JSONTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -232,6 +234,8 @@
 		0A3C2D711EA7E3E800EFB7D4 /* Alicerce.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Alicerce.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0A3C2D791EA7E3E900EFB7D4 /* AlicerceTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AlicerceTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		0ABFFAB91EA7F25B00CFC8BD /* Alicerce.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Alicerce.h; path = Alicerce.xcodeproj/Alicerce.h; sourceTree = "<group>"; };
+		0ABFFAC31EA8D08B00CFC8BD /* JSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSON.swift; sourceTree = "<group>"; };
+		0ABFFAC51EA8FCA300CFC8BD /* JSONTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONTests.swift; sourceTree = "<group>"; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -312,6 +316,7 @@
 		0A3C2CA01EA7E18500EFB7D4 /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				0ABFFAC31EA8D08B00CFC8BD /* JSON.swift */,
 				0A3C2CA11EA7E18500EFB7D4 /* Mappable.swift */,
 				0A3C2CA21EA7E18500EFB7D4 /* Network.swift */,
 				0A3C2CA31EA7E18500EFB7D4 /* NetworkStack.swift */,
@@ -432,6 +437,7 @@
 		0A3C2D1E1EA7E1EE00EFB7D4 /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				0ABFFAC51EA8FCA300CFC8BD /* JSONTests.swift */,
 				0A3C2D1F1EA7E1EE00EFB7D4 /* MappableErrorTestCase.swift */,
 				0A3C2D201EA7E1EE00EFB7D4 /* MappableModel.swift */,
 				0A3C2D211EA7E1EE00EFB7D4 /* MappableTestCase.swift */,
@@ -761,6 +767,7 @@
 				0A3C2DB91EA7E5DD00EFB7D4 /* TableViewCell.swift in Sources */,
 				0A3C2D9B1EA7E5DD00EFB7D4 /* Log+NodeLogDestination.swift in Sources */,
 				0A3C2D9E1EA7E5DD00EFB7D4 /* LogDestination.swift in Sources */,
+				0ABFFAC41EA8D08B00CFC8BD /* JSON.swift in Sources */,
 				0A3C2DA31EA7E5DD00EFB7D4 /* Network.swift in Sources */,
 				0A3C2D8A1EA7E5DD00EFB7D4 /* Route+Tree.swift in Sources */,
 			);
@@ -795,6 +802,7 @@
 				0A3C2DE01EA7E5EF00EFB7D4 /* UIViewControllerTestCase.swift in Sources */,
 				0A3C2DC51EA7E5EF00EFB7D4 /* Route+Tree_MatchTests.swift in Sources */,
 				0A3C2DCD1EA7E5EF00EFB7D4 /* Log+StringLogDestination.swift in Sources */,
+				0ABFFAC61EA8FCA300CFC8BD /* JSONTests.swift in Sources */,
 				0A3C2DD71EA7E5EF00EFB7D4 /* ParseTestCase.swift in Sources */,
 				0A3C2DD81EA7E5EF00EFB7D4 /* URLSessionNetworkStackTestCase.swift in Sources */,
 				0A3C2DCA1EA7E5EF00EFB7D4 /* ThreadTests.swift in Sources */,

--- a/Sources/Network/JSON.swift
+++ b/Sources/Network/JSON.swift
@@ -1,0 +1,119 @@
+//
+//  JSON.swift
+//  Alicerce
+//
+//  Created by André Pacheco Neves on 20/04/2017.
+//  Copyright © 2017 Mindera. All rights reserved.
+//
+
+import Foundation
+
+/// A case less enum to contain generic JSON parsing logic and namespace related types and errors.
+public enum JSON {
+
+    /// A JSON dictionary.
+    public typealias Dictionary = [String : Any]
+
+    /// A JSON array.
+    public typealias Array = [Any]
+
+    /// A JSON attribute key.
+    public typealias AttributeKey = String
+
+    /// A closure to parse a domain specific API error when a parsing step fails.
+    public typealias ParseAPIErrorClosure = (JSON.Dictionary) -> Swift.Error?
+
+    /// A predicate to validate a value after successfully being parsed.
+    public typealias ParsePredicateClosure<T> = (T) -> Bool
+
+    /// An Error occurred when parsing JSON.
+    ///
+    /// - serialization: serialization from data to JSON failed.
+    /// - unexpectedType: unexpected type when casting the parsed raw JSON.
+    /// - unexpectedAttributeType: unexpected type when casting a JSON attribute value.
+    /// - unexpectedJSONAttributeValue: unexpected value when validating a JSON attribute's value with a predicate.
+    /// - missingAttribute: missing attribute key in the JSON.
+    public enum Error: Swift.Error {
+        case serialization(Swift.Error)
+        case unexpectedType(expected: Any.Type, found: Any.Type)
+        case unexpectedAttributeType(JSON.AttributeKey, expected: Any.Type, found: Any.Type, json: JSON.Dictionary)
+        case unexpectedAttributeValue(JSON.AttributeKey, json: JSON.Dictionary)
+        case missingAttribute(JSON.AttributeKey, json: JSON.Dictionary)
+    }
+
+    // MARK: - Public methods
+
+    /// Parse the given raw data into a JSON dictionary (`[String : Any]`).
+    ///
+    /// - Parameter data: The raw data to parse.
+    /// - Returns: A parsed JSON dictionary.
+    /// - Throws: An error of type `JSON.Error`.
+    public static func parseDictionary(from data: Data) throws -> JSON.Dictionary {
+        return try parse(from: data)
+    }
+
+    /// Parse the given raw data into a JSON array (`[Any]`).
+    ///
+    /// - Parameter data: The raw data to parse.
+    /// - Returns: A parsed JSON array.
+    /// - Throws: An error of type `JSON.Error`.
+    public static func parseArray(from data: Data) throws -> JSON.Array {
+        return try parse(from: data)
+    }
+
+    /// Parse an attribute of type `T` with the given attribute on the given JSON dictionary, and optionally validate 
+    /// the value using a `where` predicate closure. Additionally, an optional `parseAPIError` closure can be supplied
+    /// so that if a parsing step fails an attempt is made to extract a domain specific error and throw it.
+    ///
+    /// - Parameters:
+    ///   - attribute: The JSON attribute key to parse.
+    ///   - json: The JSON dictionary.
+    ///   - predicate: The validation predicate.
+    ///   - parseAPIError: The API error parsing closure.
+    /// - Returns: The attribute of type `T` asociated to the given key.
+    /// - Throws: An error of type `JSON.Error`, or a domain specific `Swift.Error` produced by `parseAPIError`.
+    static func parseAttribute<T>(_ key: JSON.AttributeKey,
+                                  json: JSON.Dictionary,
+                                  where predicate: ParsePredicateClosure<T>? = nil,
+                                  parseAPIError: ParseAPIErrorClosure? = nil) throws -> T {
+        guard let rawValue = json[key] else {
+            throw parseAPIError?(json) ?? Error.missingAttribute(key, json: json)
+        }
+
+        guard let value = rawValue as? T else {
+            throw parseAPIError?(json) ?? Error.unexpectedAttributeType(key,
+                                                                        expected: T.self,
+                                                                        found: type(of: rawValue),
+                                                                        json: json)
+        }
+
+        guard predicate?(value) ?? true else {
+            throw Error.unexpectedAttributeValue(key, json: json)
+        }
+        
+        return value
+    }
+
+    // MARK: - Private methods
+
+    /// Parse the given raw data into a type `T`.
+    ///
+    /// - Parameter data: The raw data to parse.
+    /// - Returns: A parsed `T` instance.
+    /// - Throws: An error of type `JSON.Error`.
+    private static func parse<T>(from data: Data) throws -> T {
+        let json: Any
+
+        do {
+            json = try JSONSerialization.jsonObject(with: data, options: [])
+        } catch {
+            throw Error.serialization(error)
+        }
+
+        guard let decoded = json as? T else {
+            throw Error.unexpectedType(expected: T.self, found: type(of: json))
+        }
+
+        return decoded
+    }
+}

--- a/Tests/AlicerceTests/Network/JSONTests.swift
+++ b/Tests/AlicerceTests/Network/JSONTests.swift
@@ -1,0 +1,340 @@
+//
+//  JSONTests.swift
+//  Alicerce
+//
+//  Created by André Pacheco Neves on 20/04/2017.
+//  Copyright © 2017 Mindera. All rights reserved.
+//
+
+import XCTest
+@testable import Alicerce
+
+class JSONTests: XCTestCase {
+
+    let testKeyA: JSON.AttributeKey = "keyA"
+    let testKeyB: JSON.AttributeKey = "keyB"
+
+    let testValueA = "valueA"
+    let testValueB = 1337
+
+    lazy var testJSONDict: JSON.Dictionary = {
+        return [self.testKeyA : self.testValueA,
+                self.testKeyB : self.testValueB]
+    }()
+
+    lazy var testJSONDictData: Data = {
+        return try! JSONSerialization.data(withJSONObject: self.testJSONDict,
+                                           options: JSONSerialization.WritingOptions(rawValue: 0))
+    }()
+
+    lazy var testJSONArray: JSON.Array = {
+        return [self.testKeyA,
+                self.testKeyB]
+    }()
+
+    lazy var testJSONArrayData: Data = {
+        return try! JSONSerialization.data(withJSONObject: self.testJSONArray,
+                                           options: JSONSerialization.WritingOptions(rawValue: 0))
+    }()
+
+    // MARK: parseDictionary
+
+    func testParseDictionary_WithValidJSONDictionaryData_ShouldSucceed() {
+
+        do {
+            let jsonDict = try JSON.parseDictionary(from: testJSONDictData)
+
+            assertEqualJSONDictionaries(jsonDict, testJSONDict)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)")
+        }
+    }
+
+    func testParseDictionary_WithInvalidJSONData_ShouldFailWithSerializationError() {
+
+        let invalidJSONData = "💥".data(using: .utf8)!
+
+        do {
+            let _ = try JSON.parseDictionary(from: invalidJSONData)
+            XCTFail("🔥: unexpected success!")
+        } catch JSON.Error.serialization {
+            // expected error 🎉
+        } catch {
+            XCTFail("🔥: unexpected error \(error)")
+        }
+    }
+
+    func testParseDictionary_WithUnexpectedJSONType_ShouldFailWithUnexpectedTypeError() {
+
+        do {
+            let _ = try JSON.parseDictionary(from: testJSONArrayData)
+            XCTFail("🔥: unexpected success!")
+        } catch let JSON.Error.unexpectedType(expected, _) {
+            // expected error 🎉
+            XCTAssert(expected == JSON.Dictionary.self)
+            // still not sending in `Array`, and also doesn't match `NSArray` (it returns an `__NSArrayI`), so... 🤷‍♂️
+            // XCTAssert(found == type(of: testJSONArray))
+        } catch {
+            XCTFail("🔥: unexpected error \(error)")
+        }
+    }
+
+    // MARK: parseArray
+
+    func testParseArray_WithValidJSONArrayData_ShouldSucceed() {
+
+        do {
+            let jsonArray = try JSON.parseArray(from: testJSONArrayData)
+
+            XCTAssertEqual(jsonArray.count, testJSONArray.count)
+
+            for (element, testElement) in zip(jsonArray, testJSONArray) {
+                switch (element, testElement) {
+                case let (e as Int, t as Int): XCTAssertEqual(e, t)
+                case let (e as String, t as String): XCTAssertEqual(e, t)
+                default: return XCTFail("🔥: unexpected types!")
+                }
+            }
+        } catch {
+            XCTFail("🔥: unexpected error \(error)")
+        }
+    }
+
+    func testParseArray_WithInvalidJSONData_ShouldFailWithSerializationError() {
+
+        let invalidJSONData = "💥".data(using: .utf8)!
+
+        do {
+            let _ = try JSON.parseArray(from: invalidJSONData)
+            XCTFail("🔥: unexpected success!")
+        } catch JSON.Error.serialization {
+            // expected error 🎉
+        } catch {
+            XCTFail("🔥: unexpected error \(error)")
+        }
+    }
+
+    func testParseArray_WithUnexpectedJSONType_ShouldFailWithUnexpectedTypeError() {
+
+        do {
+            let _ = try JSON.parseArray(from: testJSONDictData)
+            XCTFail("🔥: unexpected success!")
+        } catch let JSON.Error.unexpectedType(expected, _) {
+            // expected error 🎉
+            XCTAssert(expected == JSON.Array.self)
+            // still not sending in `Dictionary`, and also doesn't match `NSDictionary` (it returns an `__NSDictionaryI`), so... 🤷‍♂️
+            // XCTAssert(found == type(of: testJSONDict))
+        } catch {
+            XCTFail("🔥: unexpected error \(error)")
+        }
+    }
+
+    // MARK: parseAttribute
+
+    func testParseAttribute_WithExistingAndExpectedType_ShouldSucceed() {
+
+        do {
+            let json = try JSON.parseDictionary(from: testJSONDictData)
+
+            let valueA: String = try JSON.parseAttribute(testKeyA, json: json)
+            let valueB: Int = try JSON.parseAttribute(testKeyB, json: json)
+
+            XCTAssertEqual(valueA, testValueA)
+            XCTAssertEqual(valueB, testValueB)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)")
+        }
+    }
+
+
+    func testParseAttribute_WithExistingAndExpectedAndValidType_ShouldSucceed() {
+
+        let json = try! JSON.parseDictionary(from: testJSONDictData)
+
+        do {
+            var didValidateA = false
+            var didValidateB = false
+
+            let startsWithValue: JSON.ParsePredicateClosure<String> = {
+                didValidateA = true
+                return $0.contains("value")
+            }
+
+            let isOdd: JSON.ParsePredicateClosure<Int> = {
+                didValidateB = true
+                return $0 % 2 == 1
+            }
+
+            let valueA: String = try JSON.parseAttribute(testKeyA, json: json, where: startsWithValue)
+            let valueB: Int = try JSON.parseAttribute(testKeyB, json: json, where: isOdd)
+
+            XCTAssertEqual(valueA, testValueA)
+            XCTAssertEqual(valueB, testValueB)
+
+            XCTAssert(didValidateA)
+            XCTAssert(didValidateB)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)")
+        }
+    }
+
+    func testParseAttribute_WithNonExistentAttributeKey_ShouldFailWithMissingAttribute() {
+
+        let nonExistentKey = "nonExistent"
+        let json = try! JSON.parseDictionary(from: testJSONDictData)
+
+        do {
+            let _ : String = try JSON.parseAttribute(nonExistentKey, json: json)
+            XCTFail("🔥: unexpected success!")
+        } catch let JSON.Error.missingAttribute(key, json: errorJSON) {
+            // expected error 🎉
+            assertEqualJSONDictionaries(json, errorJSON)
+            XCTAssertEqual(key, nonExistentKey)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)")
+        }
+    }
+
+    func testParseAttribute_WithUnexpectedAttributeType_ShouldFailWithUnexpectedAttributeType() {
+
+        let json = try! JSON.parseDictionary(from: testJSONDictData)
+
+        do {
+            let _ : Double = try JSON.parseAttribute(testKeyA, json: json)
+            XCTFail("🔥: unexpected success!")
+        } catch let JSON.Error.unexpectedAttributeType(key, expected, _, errorJSON) {
+            // expected error 🎉
+            XCTAssertEqual(key, testKeyA)
+            XCTAssert(expected == Double.self)
+
+            // still not sending in `String`, and the returned `NSTaggedPointerString` is private API, so... 🤷‍♂️
+            // XCTAssert(found == String.self)
+            assertEqualJSONDictionaries(json, errorJSON)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)")
+        }
+    }
+
+    func testParseAttribute_WithUnexpectedAttributeValue_ShouldFailWithUnexpectedAttributeValue() {
+
+        let json = try! JSON.parseDictionary(from: testJSONDictData)
+
+        var didValidate = false
+
+        let isEmpty: JSON.ParsePredicateClosure<String> = {
+            didValidate = true
+            return $0.isEmpty
+        }
+
+        do {
+            let _ : String = try JSON.parseAttribute(testKeyA, json: json, where: isEmpty)
+            XCTFail("🔥: unexpected success!")
+        } catch let JSON.Error.unexpectedAttributeValue(key, errorJSON) {
+            // expected error 🎉
+            XCTAssertEqual(key, testKeyA)
+            assertEqualJSONDictionaries(json, errorJSON)
+            XCTAssert(didValidate)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)")
+        }
+    }
+
+    // non nil returning parseAPIError
+
+    func testParseAttribute_WithNonExistentAttributeKeyAndParseAPIClosureReturningError_ShouldFailWithError() {
+
+        let nonExistentKey = "nonExistent"
+        let json = try! JSON.parseDictionary(from: testJSONDictData)
+
+        enum APIError: Swift.Error { case 💥 }
+        let parseAPIError: JSON.ParseAPIErrorClosure = { _ in APIError.💥 }
+
+        do {
+            let _ : String = try JSON.parseAttribute(nonExistentKey, json: json, parseAPIError: parseAPIError)
+            XCTFail("🔥: unexpected success!")
+        } catch APIError.💥 {
+            // expected error 🎉
+        } catch {
+            XCTFail("🔥: unexpected error \(error)")
+        }
+    }
+
+    func testParseAttribute_WithUnexpectedAttributeTypeAndParseAPIClosureReturningError_ShouldFailWithUnexpectedAttributeType() {
+
+        let json = try! JSON.parseDictionary(from: testJSONDictData)
+
+        enum APIError: Swift.Error { case 💩 }
+        let parseAPIError: JSON.ParseAPIErrorClosure = { _ in APIError.💩 }
+
+        do {
+            let _ : Double = try JSON.parseAttribute(testKeyA, json: json, parseAPIError: parseAPIError)
+            XCTFail("🔥: unexpected success!")
+        } catch APIError.💩 {
+            // expected error 🎉
+        } catch {
+            XCTFail("🔥: unexpected error \(error)")
+        }
+    }
+
+    // nil returning parseAPIError
+
+    func testParseAttribute_WithNonExistentAttributeKeyAndParseAPIClosureReturningNil_ShouldFailWithMissingAttribute() {
+
+        let nonExistentKey = "nonExistent"
+        let json = try! JSON.parseDictionary(from: testJSONDictData)
+
+        let parseAPIError: JSON.ParseAPIErrorClosure = { _ in nil }
+
+        do {
+            let _ : String = try JSON.parseAttribute(nonExistentKey, json: json, parseAPIError: parseAPIError)
+            XCTFail("🔥: unexpected success!")
+        } catch let JSON.Error.missingAttribute(key, json: errorJSON) {
+            // expected error 🎉
+            assertEqualJSONDictionaries(json, errorJSON)
+            XCTAssertEqual(key, nonExistentKey)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)")
+        }
+    }
+
+    func testParseAttribute_WithUnexpectedAttributeTypeAndParseAPIClosureReturningNil_ShouldFailWithUnexpectedAttributeType() {
+
+        let json = try! JSON.parseDictionary(from: testJSONDictData)
+
+        let parseAPIError: JSON.ParseAPIErrorClosure = { _ in nil }
+
+        do {
+            let _ : Double = try JSON.parseAttribute(testKeyA, json: json, parseAPIError: parseAPIError)
+            XCTFail("🔥: unexpected success!")
+        } catch let JSON.Error.unexpectedAttributeType(key, expected, _, errorJSON) {
+            // expected error 🎉
+            XCTAssertEqual(key, testKeyA)
+            XCTAssert(expected == Double.self)
+
+            // still not sending in `String`, and the returned `NSTaggedPointerString` is private API, so... 🤷‍♂️
+            // XCTAssert(found == String.self)
+            assertEqualJSONDictionaries(json, errorJSON)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)")
+        }
+    }
+
+    // MARK: - Auxiliary
+
+    private func assertEqualJSONDictionaries(_ lhs: JSON.Dictionary, _ rhs: JSON.Dictionary) {
+
+        XCTAssertEqual(lhs.count, rhs.count)
+
+        guard
+            let lhsValueA = lhs[testKeyA] as? String,
+            let lhsValueB = lhs[testKeyB] as? Int,
+            let rhsValueA = rhs[testKeyA] as? String,
+            let rhsValueB = rhs[testKeyB] as? Int
+        else {
+            return XCTFail("🔥: unexpected json dictionaries!")
+        }
+
+        XCTAssertEqual(lhsValueA, rhsValueA)
+        XCTAssertEqual(lhsValueB, rhsValueB)
+    }
+}


### PR DESCRIPTION
- Created a `JSON` enum to namespace JSON parsing related types and
logic:
  + Created `JSON.Dictionary` type alias for `[String : Any]`.
  + Created `JSON.Array` type alias for `[Any]`.
  + Created static methods `parseDictionary` and `parseArray` to parse
JSON dictionaries and arrays, respectively.
  + Created static method to parse a specified attributed from a JSON
dictionary, using the attribute’s `String` key (`JSON.AttributeKey`),
And optionally validating its value and converting the received error to
a custom domain specific API error.
- Added Unit Tests