### PR TITLE
Remove spaces after colorForLevel

### DIFF
--- a/Sources/Logging/Protocols/LogItemLevelFormatter.swift
+++ b/Sources/Logging/Protocols/LogItemLevelFormatter.swift
@@ -28,11 +28,11 @@ public extension LogItemLevelFormatter {
     func colorString(for level: Log.Level) -> String {
 
         switch level {
-        case .verbose: return "📓  "
-        case .debug: return "📗  "
-        case .info: return "📘  "
-        case .warning: return "📒  "
-        case .error: return "📕  "
+        case .verbose: return "📓"
+        case .debug: return "📗"
+        case .info: return "📘"
+        case .warning: return "📒"
+        case .error: return "📕"
         }
     }
 

--- a/Tests/AlicerceTests/Logging/ColoredLevelTests.swift
+++ b/Tests/AlicerceTests/Logging/ColoredLevelTests.swift
@@ -55,7 +55,7 @@ class ColoredLevelTests: XCTestCase {
         queue.dispatchQueue.async { [weak self] in
             guard let strongSelf = self else { return }
 
-            let expected = "📓  verbose message\n📗  debug message\n📘  info message\n📒  warning message\n📕  error message"
+            let expected = "📓verbose message\n📗debug message\n📘info message\n📒warning message\n📕error message"
             let content = strongSelf.logfileContent(logfileURL: logfileURL)
             XCTAssertEqual(content, expected)
             XCTAssertEqual(destination.writtenItems, 5)


### PR DESCRIPTION
We should avoid spaces or hardcoded separators in the framework.
This is responsibility for the formatter, i think.

If you guys don't agree, feel free to reject the PR 😉 