### PR TITLE
`public`, `public` everywhere 🙌

### DIFF
--- a/Alicerce.xcodeproj/project.pbxproj
+++ b/Alicerce.xcodeproj/project.pbxproj
@@ -71,7 +71,6 @@
 		0A3C2DBC1EA7E5DD00EFB7D4 /* UIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3C2CBF1EA7E18500EFB7D4 /* UIViewController.swift */; };
 		0A3C2DBD1EA7E5DD00EFB7D4 /* ApplicationMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3C2CC11EA7E18500EFB7D4 /* ApplicationMode.swift */; };
 		0A3C2DBE1EA7E5DD00EFB7D4 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3C2CC21EA7E18500EFB7D4 /* Box.swift */; };
-		0A3C2DBF1EA7E5DD00EFB7D4 /* HTTP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3C2CC31EA7E18500EFB7D4 /* HTTP.swift */; };
 		0A3C2DC01EA7E5DD00EFB7D4 /* Placeholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3C2CC41EA7E18500EFB7D4 /* Placeholder.swift */; };
 		0A3C2DC11EA7E5DD00EFB7D4 /* ServiceLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3C2CC51EA7E18500EFB7D4 /* ServiceLocator.swift */; };
 		0A3C2DC21EA7E5EF00EFB7D4 /* Route+ComponentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3C2D0A1EA7E1EE00EFB7D4 /* Route+ComponentTests.swift */; };
@@ -109,6 +108,7 @@
 		0ABFFABA1EA7F25B00CFC8BD /* Alicerce.h in Headers */ = {isa = PBXBuildFile; fileRef = 0ABFFAB91EA7F25B00CFC8BD /* Alicerce.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0ABFFAC41EA8D08B00CFC8BD /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ABFFAC31EA8D08B00CFC8BD /* JSON.swift */; };
 		0ABFFAC61EA8FCA300CFC8BD /* JSONTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ABFFAC51EA8FCA300CFC8BD /* JSONTests.swift */; };
+		0ABFFAE21EAA6ED400CFC8BD /* HTTP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ABFFAE11EAA6ED400CFC8BD /* HTTP.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -177,7 +177,6 @@
 		0A3C2CBF1EA7E18500EFB7D4 /* UIViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIViewController.swift; sourceTree = "<group>"; };
 		0A3C2CC11EA7E18500EFB7D4 /* ApplicationMode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApplicationMode.swift; sourceTree = "<group>"; };
 		0A3C2CC21EA7E18500EFB7D4 /* Box.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Box.swift; sourceTree = "<group>"; };
-		0A3C2CC31EA7E18500EFB7D4 /* HTTP.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTP.swift; sourceTree = "<group>"; };
 		0A3C2CC41EA7E18500EFB7D4 /* Placeholder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Placeholder.swift; sourceTree = "<group>"; };
 		0A3C2CC51EA7E18500EFB7D4 /* ServiceLocator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServiceLocator.swift; sourceTree = "<group>"; };
 		0A3C2D001EA7E1B500EFB7D4 /* .codecov.yml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = .codecov.yml; sourceTree = "<group>"; };
@@ -234,6 +233,7 @@
 		0ABFFAB91EA7F25B00CFC8BD /* Alicerce.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Alicerce.h; path = Alicerce.xcodeproj/Alicerce.h; sourceTree = "<group>"; };
 		0ABFFAC31EA8D08B00CFC8BD /* JSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSON.swift; sourceTree = "<group>"; };
 		0ABFFAC51EA8FCA300CFC8BD /* JSONTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONTests.swift; sourceTree = "<group>"; };
+		0ABFFAE11EAA6ED400CFC8BD /* HTTP.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTP.swift; sourceTree = "<group>"; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -314,6 +314,7 @@
 		0A3C2CA01EA7E18500EFB7D4 /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				0ABFFAE11EAA6ED400CFC8BD /* HTTP.swift */,
 				0ABFFAC31EA8D08B00CFC8BD /* JSON.swift */,
 				0A3C2CA11EA7E18500EFB7D4 /* Mappable.swift */,
 				0A3C2CA21EA7E18500EFB7D4 /* Network.swift */,
@@ -379,7 +380,6 @@
 			children = (
 				0A3C2CC11EA7E18500EFB7D4 /* ApplicationMode.swift */,
 				0A3C2CC21EA7E18500EFB7D4 /* Box.swift */,
-				0A3C2CC31EA7E18500EFB7D4 /* HTTP.swift */,
 				0A3C2CC41EA7E18500EFB7D4 /* Placeholder.swift */,
 				0A3C2CC51EA7E18500EFB7D4 /* ServiceLocator.swift */,
 			);
@@ -710,6 +710,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0A3C2DA81EA7E5DD00EFB7D4 /* CoreDataStack+ManagedObjectReflectable.swift in Sources */,
+				0ABFFAE21EAA6ED400CFC8BD /* HTTP.swift in Sources */,
 				0A3C2D971EA7E5DD00EFB7D4 /* Log+DefaultLogItemLevelFormatter.swift in Sources */,
 				0A3C2DAF1EA7E5DD00EFB7D4 /* NSPersistentStoreDescription+CoreDataStack.swift in Sources */,
 				0A3C2DAB1EA7E5DD00EFB7D4 /* ManagedObjectReflectable.swift in Sources */,
@@ -748,7 +749,6 @@
 				0A3C2D8E1EA7E5DD00EFB7D4 /* Dictionary.swift in Sources */,
 				0A3C2DA61EA7E5DD00EFB7D4 /* URLSessionNetworkStack.swift in Sources */,
 				0A3C2DA41EA7E5DD00EFB7D4 /* NetworkStack.swift in Sources */,
-				0A3C2DBF1EA7E5DD00EFB7D4 /* HTTP.swift in Sources */,
 				0A3C2D931EA7E5DD00EFB7D4 /* Thread.swift in Sources */,
 				0A3C2DB71EA7E5DD00EFB7D4 /* CollectionReusableView.swift in Sources */,
 				0A3C2DB41EA7E5DD00EFB7D4 /* View.swift in Sources */,

--- a/Sources/DeepLinking/ApplicationRouter.swift
+++ b/Sources/DeepLinking/ApplicationRouter.swift
@@ -15,6 +15,6 @@ public enum ApplicationRoute {
     case userActivity(NSUserActivity, restoration: ([Any]?) -> Void)
 }
 
-protocol ApplicationRouter {
+public protocol ApplicationRouter {
     func route(_ route: ApplicationRoute)
 }

--- a/Sources/DeepLinking/Route+Component.swift
+++ b/Sources/DeepLinking/Route+Component.swift
@@ -15,7 +15,7 @@ public extension Route {
         case constant(String)
         case variable(String?) // variables and wildcard (*)
 
-        init(component: String) {
+        public init(component: String) {
             precondition(component.contains("/") == false, "💥: path components can't have any \"/\" characters!")
 
             switch component.characters.first {

--- a/Sources/DeepLinking/Route+Tree.swift
+++ b/Sources/DeepLinking/Route+Tree.swift
@@ -35,7 +35,7 @@ public extension Route {
         case node(ChildEdges)
         case leaf(Handler)
 
-        init(route: [Component], handler: Handler) throws {
+        public init(route: [Component], handler: Handler) throws {
             switch route.first {
             case nil:
                 self = .leaf(handler)

--- a/Sources/DeepLinking/Router.swift
+++ b/Sources/DeepLinking/Router.swift
@@ -21,20 +21,20 @@ public protocol Router {
     func route(_ route: URL) throws
 }
 
-final class TreeRouter<Handler: RouteHandler>: Router {
+public final class TreeRouter<Handler: RouteHandler>: Router {
 
-    typealias Match = Route.Tree<Handler>.Match
+    public typealias Match = Route.Tree<Handler>.Match
 
     private typealias Tree = Route.Tree<Handler>
     private typealias AnnotatedParsedRoute = (scheme: Route.Scheme, components: [Route.Component])
     private typealias ParsedRoute = (scheme: Route.Scheme, components: [Route.Component], queryItems: [URLQueryItem])
 
-    enum Error: Swift.Error {
+    public enum Error: Swift.Error {
         case invalidRoute(InvalidRouteError)
         case duplicateRoute
         case routeNotFound
 
-        enum InvalidRouteError: Swift.Error {
+        public enum InvalidRouteError: Swift.Error {
             case misplacedEmptyComponent
             case conflictingVariableComponent(existing: String, new: String)
             case invalidVariableComponent(String)
@@ -46,7 +46,7 @@ final class TreeRouter<Handler: RouteHandler>: Router {
     private var routes: [Route.Scheme : Tree] = [:]
     private let queue: DispatchQueue
 
-    init(qos: DispatchQoS = .default) {
+    public init(qos: DispatchQoS = .default) {
         queue = DispatchQueue(label: "com.mindera.Alicerce.\(type(of: self)).queue", qos: qos)
     }
 
@@ -122,6 +122,8 @@ final class TreeRouter<Handler: RouteHandler>: Router {
 
         match.handler.handle(route: route, parameters: match.parameters, queryItems: queryItems)
     }
+
+    // MARK: - Private methods
 
     private func parseAnnotatedRoute(_ route: URL, appendEmpty: Bool = true) -> AnnotatedParsedRoute {
         let scheme = route.scheme ?? ""

--- a/Sources/Extensions/Sequence.swift
+++ b/Sources/Extensions/Sequence.swift
@@ -11,7 +11,7 @@ import Foundation
 // Credits to @AirspeedVelocity 🙏
 // https://stackoverflow.com/a/28898790/1921751
 
-extension Sequence {
+public extension Sequence {
 
     /// Returns the result of combining the elements of the sequence using the given combining closure, grouped by keys
     /// generated using the a grouping closure. The result is a dictionary of type `[K : U]`. An initial value should

--- a/Sources/Extensions/Thread.swift
+++ b/Sources/Extensions/Thread.swift
@@ -8,9 +8,9 @@
 
 import Foundation
 
-extension Thread {
+public extension Thread {
 
-    // Returns the name of the thread or 'main-thread', if it's the application's main thread
+    /// Returns the name of the thread or 'main-thread', if it's the application's main thread
     public class func threadName() -> String {
 
         guard !isMainThread else { return "main-thread" }

--- a/Sources/Logging/Log+NodeLogDestination.swift
+++ b/Sources/Logging/Log+NodeLogDestination.swift
@@ -12,7 +12,7 @@ public extension Log {
 
     public class NodeLogDestination : LogDestination, LogDestinationFallible {
 
-        enum Error: Swift.Error {
+        public enum Error: Swift.Error {
             case httpError(statusCode: Int)
             case network(Swift.Error)
         }

--- a/Sources/Network/HTTP.swift
+++ b/Sources/Network/HTTP.swift
@@ -16,7 +16,7 @@ public enum HTTP {
     public typealias Query = [String : String]
 
     /// An enum describing the HTTP methods.
-    enum Method: String {
+    public enum Method: String {
         case GET
         case POST
         case PUT
@@ -26,7 +26,7 @@ public enum HTTP {
     /// An enum representing HTTP status codes, grouped by response class.
     ///
     /// - note: Based on https://en.wikipedia.org/wiki/List_of_HTTP_status_codes
-    enum StatusCode {
+    public enum StatusCode: RawRepresentable {
 
         /// 1xx Informational
         case informational(Int)
@@ -42,7 +42,7 @@ public enum HTTP {
         case unknownError(Int)
 
         /// The associated status code value.
-        var rawValue: Int {
+        public var rawValue: Int {
             switch self {
             case let .informational(statusCode): return statusCode
             case let .success(statusCode): return statusCode
@@ -55,10 +55,19 @@ public enum HTTP {
 
         /// Instantiate a new `StatusCode` with the given code and infer the response class automatically.
         ///
+        /// - parameter rawValue: the response's HTTP status code
+        ///
+        /// - returns: a newly instantiated `StatusCode` with the inferred class and associated status code.
+        public init?(rawValue: Int) {
+            self.init(rawValue)
+        }
+
+        /// Instantiate a new `StatusCode` with the given code and infer the response class automatically.
+        ///
         /// - parameter statusCode: the response's HTTP status code
         ///
         /// - returns: a newly instantiated `StatusCode` with the inferred class and associated status code.
-        init(_ statusCode: Int) {
+        public init(_ statusCode: Int) {
             self = {
                 switch statusCode {
                 case 100...199: return .informational(statusCode)

--- a/Sources/Network/Network.swift
+++ b/Sources/Network/Network.swift
@@ -16,7 +16,7 @@ public enum Network {
 
     // MARK: - Network Error
 
-    enum Error: Swift.Error {
+    public enum Error: Swift.Error {
         case http(code: HTTP.StatusCode, description: String?)
         case noData
         case url(Swift.Error)
@@ -25,7 +25,7 @@ public enum Network {
 
     // MARK: - Network Configuration
     
-    struct Configuration {
+    public struct Configuration {
         let baseURL: URL
         let sessionConfiguration: URLSessionConfiguration
         let delegateQueue: OperationQueue?

--- a/Sources/Network/Parse.swift
+++ b/Sources/Network/Parse.swift
@@ -23,7 +23,7 @@ public enum Parse {
     ///   - `serialization` if json serialization failed
     ///   - `mapping` if model mapping failed
     ///   - `other` an unknown error
-    static func json<T: Mappable>(data: Data) throws -> T {
+    public static func json<T: Mappable>(data: Data) throws -> T {
 
         let json: Any
 
@@ -46,7 +46,7 @@ public enum Parse {
     /// - Returns: An UIImage from the raw data
     /// - Throws: A Parse.Error that can be of type:
     ///   - `serialization` if json serialization failed
-    static func image(data: Data) throws -> UIImage {
+    public static func image(data: Data) throws -> UIImage {
 
         guard let image = UIImage(data: data) else {
             throw Error.image

--- a/Sources/Network/URLSessionNetworkStack.swift
+++ b/Sources/Network/URLSessionNetworkStack.swift
@@ -17,12 +17,12 @@ public extension Network {
         private let baseURL: URL
         private let session: URLSession
 
-        init(baseURL: URL, session: URLSession) {
+        public init(baseURL: URL, session: URLSession) {
             self.baseURL = baseURL
             self.session = session
         }
 
-        convenience init(configuration: Network.Configuration) {
+        public convenience init(configuration: Network.Configuration) {
             let urlSession = URLSession(configuration: configuration.sessionConfiguration,
                                         delegate: nil,
                                         delegateQueue: configuration.delegateQueue)

--- a/Sources/Persistence/CoreDataStack.swift
+++ b/Sources/Persistence/CoreDataStack.swift
@@ -24,14 +24,14 @@ public enum CoreDataStackStoreType {
     case inMemory
     case sqLite(storeURL: URL)
 
-    var nsStoreType: String {
+    public var nsStoreType: String {
         switch self {
         case .inMemory: return NSInMemoryStoreType
         case .sqLite: return NSSQLiteStoreType
         }
     }
 
-    var storeURL: URL? {
+    public var storeURL: URL? {
         switch self {
         case .inMemory: return nil
         case let .sqLite(url): return url

--- a/Sources/Persistence/DiskMemoryPersistence.swift
+++ b/Sources/Persistence/DiskMemoryPersistence.swift
@@ -38,7 +38,7 @@ public final class DiskMemoryPersistence: Persistence {
         }
     }
 
-    enum Error: Swift.Error {
+    public enum Error: Swift.Error {
         case diskCacheDisabled
         case failedToRemoveFile(Swift.Error?)
         case fileNotCreated
@@ -66,7 +66,7 @@ public final class DiskMemoryPersistence: Persistence {
 
     private var usedDiskSize: UInt64 = 0 // Size in bytes
 
-    init(configuration: Configuration) {
+    public init(configuration: Configuration) {
         self.configuration = configuration
 
         cache.totalCostLimit = Int(configuration.memLimit)

--- a/Sources/Persistence/NestedContextCoreDataStack.swift
+++ b/Sources/Persistence/NestedContextCoreDataStack.swift
@@ -23,15 +23,15 @@ open class NestedContextCoreDataStack: CoreDataStack {
                   shouldAddStoreAsynchronously: false)
     }
 
-    init(storeType: CoreDataStackStoreType,
-         storeName: String,
-         managedObjectModel: NSManagedObjectModel,
-         shouldAddStoreAsynchronously: Bool = false,
-         shouldMigrateStoreAutomatically: Bool = true,
-         shouldInferMappingModelAutomatically: Bool = true,
-         storeLoadCompletionHandler: @escaping (Any, Error?) -> Void = defaultStoreLoadCompletionHandler,
-         workContextConcurrencyType: NSManagedObjectContextConcurrencyType = .privateQueueConcurrencyType,
-         mergePolicy: NSMergePolicy = NSMergePolicy(merge: .mergeByPropertyStoreTrumpMergePolicyType)) {
+    public init(storeType: CoreDataStackStoreType,
+                storeName: String,
+                managedObjectModel: NSManagedObjectModel,
+                shouldAddStoreAsynchronously: Bool = false,
+                shouldMigrateStoreAutomatically: Bool = true,
+                shouldInferMappingModelAutomatically: Bool = true,
+                storeLoadCompletionHandler: @escaping (Any, Error?) -> Void = defaultStoreLoadCompletionHandler,
+                workContextConcurrencyType: NSManagedObjectContextConcurrencyType = .privateQueueConcurrencyType,
+                mergePolicy: NSMergePolicy = NSMergePolicy(merge: .mergeByPropertyStoreTrumpMergePolicyType)) {
 
         if #available(iOS 10.0, *) {
             let container = NestedContextCoreDataStack

--- a/Sources/Persistence/SiblingContextCoreDataStack.swift
+++ b/Sources/Persistence/SiblingContextCoreDataStack.swift
@@ -23,14 +23,14 @@ public final class SiblingContextCoreDataStack: CoreDataStack {
                   shouldAddStoreAsynchronously: false)
     }
 
-    init(storeType: CoreDataStackStoreType,
-         storeName: String,
-         managedObjectModel: NSManagedObjectModel,
-         shouldAddStoreAsynchronously: Bool = false,
-         shouldMigrateStoreAutomatically: Bool = true,
-         shouldInferMappingModelAutomatically: Bool = true,
-         storeLoadCompletionHandler: @escaping (Any, Error?) -> Void = defaultStoreLoadCompletionHandler,
-         mergePolicy: NSMergePolicy = NSMergePolicy(merge: .errorMergePolicyType)) {
+    public init(storeType: CoreDataStackStoreType,
+                storeName: String,
+                managedObjectModel: NSManagedObjectModel,
+                shouldAddStoreAsynchronously: Bool = false,
+                shouldMigrateStoreAutomatically: Bool = true,
+                shouldInferMappingModelAutomatically: Bool = true,
+                storeLoadCompletionHandler: @escaping (Any, Error?) -> Void = defaultStoreLoadCompletionHandler,
+                mergePolicy: NSMergePolicy = NSMergePolicy(merge: .errorMergePolicyType)) {
 
         if #available(iOS 10.0, *) {
             let container = NestedContextCoreDataStack

--- a/Sources/Resource/Resource.swift
+++ b/Sources/Resource/Resource.swift
@@ -18,12 +18,12 @@ public struct Resource<T> {
     let body: Data?
     let parser: ParseClosure
 
-    init(path: String,
-         method: HTTP.Method,
-         headers: HTTP.Headers? = nil,
-         query: HTTP.Query? = nil,
-         body: Data? = nil,
-         parser: @escaping ParseClosure) {
+    public init(path: String,
+                method: HTTP.Method,
+                headers: HTTP.Headers? = nil,
+                query: HTTP.Query? = nil,
+                body: Data? = nil,
+                parser: @escaping ParseClosure) {
 
         self.path = path
         self.method = method

--- a/Sources/Utils/ApplicationMode.swift
+++ b/Sources/Utils/ApplicationMode.swift
@@ -18,7 +18,7 @@ public enum ApplicationMode: String {
     case release
 
     /// The current application's mode.
-    static var current: ApplicationMode {
+    public static var current: ApplicationMode {
         #if DEBUG
             return .debug
         #else

--- a/Sources/Utils/Box.swift
+++ b/Sources/Utils/Box.swift
@@ -13,14 +13,14 @@
 public final class Box<T> {
 
     /// The encapsulated value.
-    let value: T
+    public let value: T
 
     /// Instantiate a new constant value box with the given value.
     ///
     /// - parameter value: the value to encapsulate.
     ///
     /// - returns: a newly instantiated box with the encapsulated value.
-    init(_ value: T) { self.value = value }
+    public init(_ value: T) { self.value = value }
 }
 
 /// An arbitrary container which stores a **variable** value of type `T`.
@@ -30,12 +30,12 @@ public final class Box<T> {
 public final class VarBox<T> {
     
     /// The encapsulated value.
-    var value: T
+    public var value: T
 
     /// Instantiate a new variable value box with the given value.
     ///
     /// - parameter value: the value to encapsulate.
     ///
     /// - returns: a newly instantiated box with the encapsulated value.
-    init(_ value: T) { self.value = value }
+    public init(_ value: T) { self.value = value }
 }

--- a/Sources/Utils/Placeholder.swift
+++ b/Sources/Utils/Placeholder.swift
@@ -13,7 +13,7 @@ import Foundation
 // https://twitter.com/shaps/status/836353195098189824
 
 @available(*, deprecated, message: "Implement this!")
-var TODO: Never { fatalError("💥: unimplemented!") }
+public var TODO: Never { fatalError("💥: unimplemented!") }
 
 @available(*, deprecated, message: "Fix this code!")
-var FIXME: Void { return }
+public var FIXME: Void { return }


### PR DESCRIPTION
- Revised all types and API’s to correctly define `public` access level
so that they can be used by framework users 😅

![tseverywhere-public-public-everywhere](https://cloud.githubusercontent.com/assets/1391324/25288571/dfe04280-26bd-11e7-863d-3bf9d21142cd.jpg)
