### PR TITLE
Improve `URLSessionNetworkStack`

### DIFF
--- a/Sources/Network/Network.swift
+++ b/Sources/Network/Network.swift
@@ -13,6 +13,8 @@ public enum Network {
     // MARK: - TypeAlias
 
     public typealias CompletionClosure = (_ inner: () throws -> Data) -> Void
+    public typealias AuthenticationCompletionClosure = (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    public typealias AuthenticationChallengeValidatorClosure = (URLAuthenticationChallenge, AuthenticationCompletionClosure) -> Void
 
     // MARK: - Network Error
 
@@ -27,16 +29,13 @@ public enum Network {
     
     public struct Configuration {
         let baseURL: URL
-        let sessionConfiguration: URLSessionConfiguration
-        let delegateQueue: OperationQueue?
 
-        public init(baseURL: URL,
-                    sessionConfiguration: URLSessionConfiguration = URLSessionConfiguration.default,
-                    delegateQueue: OperationQueue? = nil) {
+        // TODO: add better server trust validator
+        let authenticationChallengeValidator: AuthenticationChallengeValidatorClosure?
 
+        public init(baseURL: URL, authenticationChallengeValidator: AuthenticationChallengeValidatorClosure? = nil) {
             self.baseURL = baseURL
-            self.sessionConfiguration = sessionConfiguration
-            self.delegateQueue = delegateQueue
+            self.authenticationChallengeValidator = authenticationChallengeValidator
         }
     }
 }

--- a/Tests/AlicerceTests/Network/NetworkTestCase.swift
+++ b/Tests/AlicerceTests/Network/NetworkTestCase.swift
@@ -16,34 +16,9 @@ final class NetworkTestCase: XCTestCase {
 
         let url = URL(string: "http://localhost")!
 
-        let sessionConfiguration = MockURLSessionConfiguration()
-
-        let delegateQueue: OperationQueue = {
-            $0.name = "📱"
-            return $0
-        }(OperationQueue())
-
-
-        let networkConfiguration = Network.Configuration(baseURL: url,
-                                                         sessionConfiguration: sessionConfiguration,
-                                                         delegateQueue: delegateQueue)
-
-        XCTAssertEqual(networkConfiguration.baseURL, url)
-        XCTAssertEqual(networkConfiguration.sessionConfiguration, networkConfiguration.sessionConfiguration)
-        XCTAssertEqual(networkConfiguration.sessionConfiguration.httpAdditionalHeaders?["👉"] as! String, "👈")
-        XCTAssertEqual(networkConfiguration.delegateQueue, delegateQueue)
-        XCTAssertEqual(networkConfiguration.delegateQueue?.name, delegateQueue.name)
-    }
-
-    func testConfiguration_WhenCreateWithBaseURLInit_ItShouldPopulateTheBaseURLAndTheDefaultValues() {
-
-        let url = URL(string: "http://localhost")!
-
         let networkConfiguration = Network.Configuration(baseURL: url)
 
         XCTAssertEqual(networkConfiguration.baseURL, url)
-        XCTAssertEqual(networkConfiguration.sessionConfiguration, URLSessionConfiguration.default)
-        XCTAssertNil(networkConfiguration.delegateQueue)
     }
 }
 


### PR DESCRIPTION
In order to define `self` as the session's delegate while preserving
dependency injection, the session must be injected via property. This
is because the session's delegate is only defined on its `init`. 🤷‍♂️

The session's delegate could be set to `self` using a lazy var (since
`self` is already defined), but then the session couldn't be injected
for unit testing.

Added a new optional property to the `Network.Configuration` to perform
authentication challenge validations. This is a closure property which
receives the `URLAuthenticationChallenge` from the session’s
`URLSessionDelegate`’s
`urlSession(:didReceive challenge:completionhandler:)` method and
invokes the supplied `completionHandler`.

Until we have a proper server trust validator, this closure can be used
to perform any validations like allowing servers using expired and
self-signed certificates.