### PR TITLE
Make network and store fetches `Cancelable`

### DIFF
--- a/Alicerce.xcodeproj/project.pbxproj
+++ b/Alicerce.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		0ABFFAC41EA8D08B00CFC8BD /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ABFFAC31EA8D08B00CFC8BD /* JSON.swift */; };
 		0ABFFAC61EA8FCA300CFC8BD /* JSONTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ABFFAC51EA8FCA300CFC8BD /* JSONTests.swift */; };
 		0ABFFAE21EAA6ED400CFC8BD /* HTTP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ABFFAE11EAA6ED400CFC8BD /* HTTP.swift */; };
+		0AE330961EBB71F8003E8506 /* Cancelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE330951EBB71F8003E8506 /* Cancelable.swift */; };
 		1B57E97D1EB150C80027AB30 /* Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B57E97C1EB150C80027AB30 /* Analytics.swift */; };
 		1B57E97F1EB1510D0027AB30 /* AnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B57E97E1EB1510D0027AB30 /* AnalyticsTracker.swift */; };
 		1B57E9811EB155A30027AB30 /* Page.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B57E9801EB155A30027AB30 /* Page.swift */; };
@@ -256,6 +257,7 @@
 		0ABFFAC31EA8D08B00CFC8BD /* JSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSON.swift; sourceTree = "<group>"; };
 		0ABFFAC51EA8FCA300CFC8BD /* JSONTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONTests.swift; sourceTree = "<group>"; };
 		0ABFFAE11EAA6ED400CFC8BD /* HTTP.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTP.swift; sourceTree = "<group>"; };
+		0AE330951EBB71F8003E8506 /* Cancelable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cancelable.swift; sourceTree = "<group>"; };
 		1B57E97C1EB150C80027AB30 /* Analytics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Analytics.swift; sourceTree = "<group>"; };
 		1B57E97E1EB1510D0027AB30 /* AnalyticsTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyticsTracker.swift; sourceTree = "<group>"; };
 		1B57E9801EB155A30027AB30 /* Page.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Page.swift; sourceTree = "<group>"; };
@@ -527,29 +529,6 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		1B57E97B1EB150AB0027AB30 /* Analytics */ = {
-			isa = PBXGroup;
-			children = (
-				1B57E97C1EB150C80027AB30 /* Analytics.swift */,
-				1B57E97E1EB1510D0027AB30 /* AnalyticsTracker.swift */,
-				1B57E9841EB159640027AB30 /* Configuration.swift */,
-				1B57E9821EB155DB0027AB30 /* Event.swift */,
-				1B57E9801EB155A30027AB30 /* Page.swift */,
-			);
-			path = Analytics;
-			sourceTree = "<group>";
-		};
-		1B57E9861EB15F3C0027AB30 /* Analytics */ = {
-			isa = PBXGroup;
-			children = (
-				1B57E9871EB15F510027AB30 /* AnalyticsTestCase.swift */,
-				1B57E98C1EB2128F0027AB30 /* ConfigurationTestCase.swift */,
-				1B57E98E1EB22D860027AB30 /* EventTestCase.swift */,
-				1B57E9901EB22E970027AB30 /* PageTestCase.swift */,
-			);
-			path = Analytics;
-			sourceTree = "<group>";
-		};
 		0A83884E1EB1F6B000C1E835 /* CoreData */ = {
 			isa = PBXGroup;
 			children = (
@@ -609,6 +588,37 @@
 			path = "Support Files";
 			sourceTree = "<group>";
 		};
+		0AE330941EBB71ED003E8506 /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+				0AE330951EBB71F8003E8506 /* Cancelable.swift */,
+			);
+			path = Shared;
+			sourceTree = "<group>";
+		};
+		1B57E97B1EB150AB0027AB30 /* Analytics */ = {
+			isa = PBXGroup;
+			children = (
+				1B57E97C1EB150C80027AB30 /* Analytics.swift */,
+				1B57E97E1EB1510D0027AB30 /* AnalyticsTracker.swift */,
+				1B57E9841EB159640027AB30 /* Configuration.swift */,
+				1B57E9821EB155DB0027AB30 /* Event.swift */,
+				1B57E9801EB155A30027AB30 /* Page.swift */,
+			);
+			path = Analytics;
+			sourceTree = "<group>";
+		};
+		1B57E9861EB15F3C0027AB30 /* Analytics */ = {
+			isa = PBXGroup;
+			children = (
+				1B57E9871EB15F510027AB30 /* AnalyticsTestCase.swift */,
+				1B57E98C1EB2128F0027AB30 /* ConfigurationTestCase.swift */,
+				1B57E98E1EB22D860027AB30 /* EventTestCase.swift */,
+				1B57E9901EB22E970027AB30 /* PageTestCase.swift */,
+			);
+			path = Analytics;
+			sourceTree = "<group>";
+		};
 		OBJ_10 /* AlicerceTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -665,6 +675,7 @@
 				0A3C2CA61EA7E18500EFB7D4 /* Persistence */,
 				0A3C2CB21EA7E18500EFB7D4 /* Protocols */,
 				0A3C2CB61EA7E18500EFB7D4 /* Resource */,
+				0AE330941EBB71ED003E8506 /* Shared */,
 				0A8388611EB1F93800C1E835 /* Stores */,
 				0A3C2CB91EA7E18500EFB7D4 /* UIKit */,
 				0A3C2CC01EA7E18500EFB7D4 /* Utils */,
@@ -820,9 +831,9 @@
 				1B57E97F1EB1510D0027AB30 /* AnalyticsTracker.swift in Sources */,
 				0A3C2D991EA7E5DD00EFB7D4 /* Log+Item.swift in Sources */,
 				0A3C2DA21EA7E5DD00EFB7D4 /* Mappable.swift in Sources */,
-				0A3C2DAE1EA7E5DD00EFB7D4 /* NSPersistentStoreCoordinator+CoreDataStack.swift in Sources */,
 				1B57E9811EB155A30027AB30 /* Page.swift in Sources */,
 				0A3C2D981EA7E5DD00EFB7D4 /* Log+FileLogDestination.swift in Sources */,
+				0AE330961EBB71F8003E8506 /* Cancelable.swift in Sources */,
 				0A3C2DB31EA7E5DD00EFB7D4 /* ReusableView.swift in Sources */,
 				0A8388601EB1F6B000C1E835 /* SiblingContextCoreDataStack.swift in Sources */,
 				0A3C2DC01EA7E5DD00EFB7D4 /* Placeholder.swift in Sources */,
@@ -864,7 +875,6 @@
 				0A3C2D951EA7E5DD00EFB7D4 /* Log+BashLogItemLevelFormatter.swift in Sources */,
 				0A3C2DB51EA7E5DD00EFB7D4 /* NetworkResource.swift in Sources */,
 				0A8388581EB1F6B000C1E835 /* CoreDataEntity.swift in Sources */,
-				0A3C2DA91EA7E5DD00EFB7D4 /* CoreDataStack.swift in Sources */,
 				1B57E97D1EB150C80027AB30 /* Analytics.swift in Sources */,
 				0A3C2DBE1EA7E5DD00EFB7D4 /* Box.swift in Sources */,
 				0A3C2DB91EA7E5DD00EFB7D4 /* TableViewCell.swift in Sources */,
@@ -890,7 +900,6 @@
 				0A3C2DCF1EA7E5EF00EFB7D4 /* JSONLogItemFormatterTests.swift in Sources */,
 				0A3C2DE21EA7E5EF00EFB7D4 /* Utils.swift in Sources */,
 				0A3C2DD11EA7E5EF00EFB7D4 /* NodeLogDestinationTests.swift in Sources */,
-				0A067BDB1EA7ECB3007A370C /* CoreDataStackModel.xcdatamodeld in Sources */,
 				1B57E98D1EB2128F0027AB30 /* ConfigurationTestCase.swift in Sources */,
 				0A3C2DC71EA7E5EF00EFB7D4 /* TreeRouterTests.swift in Sources */,
 				0A3C2DC81EA7E5EF00EFB7D4 /* DataTestCase.swift in Sources */,

--- a/Sources/Network/NetworkStack.swift
+++ b/Sources/Network/NetworkStack.swift
@@ -9,5 +9,5 @@
 import Foundation
 
 public protocol NetworkStack {
-    func fetch<R: NetworkResource>(resource: R, _ completion: @escaping Network.CompletionClosure)
+    func fetch<R: NetworkResource>(resource: R, _ completion: @escaping Network.CompletionClosure) -> Cancelable
 }

--- a/Sources/Shared/Cancelable.swift
+++ b/Sources/Shared/Cancelable.swift
@@ -1,0 +1,11 @@
+//
+//  Cancelable.swift
+//  Alicerce
+//
+//  Created by André Pacheco Neves on 04/05/2017.
+//  Copyright © 2017 Mindera. All rights reserved.
+//
+
+public protocol Cancelable {
+    func cancel()
+}

--- a/Tests/AlicerceTests/Network/MockNetworkStack.swift
+++ b/Tests/AlicerceTests/Network/MockNetworkStack.swift
@@ -9,10 +9,23 @@
 import Foundation
 @testable import Alicerce
 
+final class MockNetworkCancelable: Cancelable {
+
+    var mockCancelClosure: (() -> Void)?
+
+    public func cancel() {
+        mockCancelClosure?()
+    }
+}
+
 final class MockNetworkStack: NetworkStack {
 
     var mockData: Data?
     var mockError: Network.Error?
+    var mockCancelable: MockNetworkCancelable = MockNetworkCancelable()
+
+    var beforeFetchCompletionClosure: (() -> Void)?
+    var afterFetchCompletionClosure: (() -> Void)?
 
     init(mockData: Data?, mockError: Network.Error?) {
         precondition(mockData != nil || mockError != nil)
@@ -21,13 +34,22 @@ final class MockNetworkStack: NetworkStack {
         self.mockError = mockError
     }
 
-    func fetch<R: NetworkResource>(resource: R, _ completion: @escaping Network.CompletionClosure) {
-        if let error = mockError {
-            completion( { throw error } )
-        } else if let data = mockData {
-            completion( { return data } )
-        } else {
-            fatalError("🔥: either `mockData` or `mockError` must be defined!")
+    func fetch<R: NetworkResource>(resource: R, _ completion: @escaping Network.CompletionClosure) -> Cancelable {
+        DispatchQueue.global(qos: .default).async {
+
+            self.beforeFetchCompletionClosure?()
+
+            if let error = self.mockError {
+                completion( { throw error } )
+            } else if let data = self.mockData {
+                completion( { return data } )
+            } else {
+                fatalError("🔥: either `mockData` or `mockError` must be defined!")
+            }
+
+            self.afterFetchCompletionClosure?()
         }
+
+        return mockCancelable
     }
 }

--- a/Tests/AlicerceTests/Persistence/MockPersistenceStack.swift
+++ b/Tests/AlicerceTests/Persistence/MockPersistenceStack.swift
@@ -19,15 +19,21 @@ final class MockPersistenceStack: PersistenceStack {
     var mockRemoveObjectCompletion: InnerCompletionClosure<Void> = { return () }
 
     func object(for key: Persistence.Key, completion: @escaping CompletionClosure<Data>) {
-        completion(mockObjectCompletion)
+        DispatchQueue.global(qos: .default).async {
+            completion(self.mockObjectCompletion)
+        }
     }
 
     func setObject(_ object: Data, for key: Persistence.Key, completion: @escaping CompletionClosure<Void>) {
-        completion(mockSetObjectCompletion)
+        DispatchQueue.global(qos: .default).async {
+            completion(self.mockSetObjectCompletion)
+        }
     }
 
     func removeObject(for key: String, completion: @escaping CompletionClosure<Void>) {
-        completion(mockRemoveObjectCompletion)
+        DispatchQueue.global(qos: .default).async {
+            completion(self.mockRemoveObjectCompletion)
+        }
     }
 }
  


### PR DESCRIPTION
- Created `Cancelable` protocol to allow canceling an arbitrary task.
- Updated `NetworkStack.fetch` and `Store.fetch` to return a
`Cancelable`
- Created a new `StoreCancelable` in `Store` to allow cancelling a
fetch when it hits the network (request, parse, persist)
- Created a new `CancelableTask` in `URLSessionNetworkStack` to allow
cancelling scheduled tasks.
- Updated relevant UT’s and added new test cases for cancelling.