### PR TITLE
Enhance cell helpers

### DIFF
--- a/Sources/Protocols/ReusableView.swift
+++ b/Sources/Protocols/ReusableView.swift
@@ -47,13 +47,13 @@ public extension UICollectionView {
     }
     
     func cell<T: UICollectionViewCell>(`for` indexPath: IndexPath) -> T
-        where T: ReusableView {
-            guard let cell = cellForItem(at: indexPath) as? T else {
-                assertionFailure("🔥 Cell at \(indexPath) is not of type: `\(T.self)`")
-                return T()
-            }
-            
-            return cell
+    where T: ReusableView {
+        guard let cell = cellForItem(at: indexPath) as? T else {
+            assertionFailure("🔥 Cell at \(indexPath) is not of type: `\(T.self)`")
+            return T()
+        }
+        
+        return cell
     }
 
     func register<T: UICollectionViewCell>(_ cellType: T.Type)
@@ -83,14 +83,14 @@ public extension UICollectionView {
     @available(iOS 9, *)
     func supplementaryView<T: UICollectionReusableView>(forElementKind elementKind: String,
                                   at indexPath: IndexPath) -> T
-        where T: ReusableView {
-            
-            guard let supplementaryView = supplementaryView(forElementKind: elementKind, at: indexPath) as? T else {
-                                                                            assertionFailure("🔥 SupplementaryView with identifier `\(T.reuseIdentifier)` not registered for type: `\(T.self)`!")
-                                                                            return T()
-            }
-            
-            return supplementaryView
+    where T: ReusableView {
+        
+        guard let supplementaryView = supplementaryView(forElementKind: elementKind, at: indexPath) as? T else {
+                                                                        assertionFailure("🔥 SupplementaryView with identifier `\(T.reuseIdentifier)` not registered for type: `\(T.self)`!")
+                                                                        return T()
+        }
+        
+        return supplementaryView
     }
 }
 
@@ -119,33 +119,33 @@ public extension UITableView {
     }
     
     func cell<T: UITableViewCell>(`for` indexPath: IndexPath) -> T
-        where T: ReusableView {
-            guard let cell = cellForRow(at: indexPath) as? T else {
-                assertionFailure("🔥 Cell for row at \(indexPath) is not of type: `\(T.self)`")
-                return T()
-            }
-            
-            return cell
+    where T: ReusableView {
+        guard let cell = cellForRow(at: indexPath) as? T else {
+            assertionFailure("🔥 Cell for row at \(indexPath) is not of type: `\(T.self)`")
+            return T()
+        }
+        
+        return cell
     }
     
     func headerView<T: UITableViewCell>(forSection section: Int) -> T
-        where T: ReusableView {
-            guard let view = headerView(forSection: section) as? T else {
-                assertionFailure("🔥 Header view at section \(section) is not of type: `\(T.self)`")
-                return T()
-            }
-            
-            return view
+    where T: ReusableView {
+        guard let view = headerView(forSection: section) as? T else {
+            assertionFailure("🔥 Header view at section \(section) is not of type: `\(T.self)`")
+            return T()
+        }
+        
+        return view
     }
     
     func footerView<T: UITableViewCell>(forSection section: Int) -> T
-        where T: ReusableView {
-            guard let view = footerView(forSection: section) as? T else {
-                assertionFailure("🔥 Footer view at section \(section) is not of type: `\(T.self)`")
-                return T()
-            }
-            
-            return view
+    where T: ReusableView {
+        guard let view = footerView(forSection: section) as? T else {
+            assertionFailure("🔥 Footer view at section \(section) is not of type: `\(T.self)`")
+            return T()
+        }
+        
+        return view
     }
 
     func register<T: UITableViewCell>(_ cellType: T.Type)

--- a/Sources/Protocols/ReusableView.swift
+++ b/Sources/Protocols/ReusableView.swift
@@ -46,7 +46,7 @@ public extension UICollectionView {
         return cell
     }
     
-    func Cell<T: UICollectionViewCell>(`for` indexPath: IndexPath) -> T
+    func cell<T: UICollectionViewCell>(`for` indexPath: IndexPath) -> T
         where T: ReusableView {
             guard let cell = cellForItem(at: indexPath) as? T else {
                 assertionFailure("🔥 Cell at \(indexPath) is not of type: `\(T.self)`")

--- a/Sources/Protocols/ReusableView.swift
+++ b/Sources/Protocols/ReusableView.swift
@@ -73,7 +73,7 @@ public extension UICollectionView {
         guard let supplementaryView = dequeueReusableSupplementaryView(ofKind: elementKind,
                                                                             withReuseIdentifier: T.reuseIdentifier,
                                                                             for: indexPath) as? T else {
-            assertionFailure("🔥 SupplementaryView at \(indexPath) is not of type: `\(T.self)`!")
+            assertionFailure("🔥 SupplementaryView with identifier `\(T.reuseIdentifier)` not registered for type: `\(T.self)`!")
             return T()
         }
 

--- a/Sources/Protocols/ReusableView.swift
+++ b/Sources/Protocols/ReusableView.swift
@@ -36,7 +36,7 @@ public extension ReusableView where Self: UITableViewHeaderFooterView {
 
 public extension UICollectionView {
 
-    func cell<T: UICollectionViewCell>(`for` indexPath: IndexPath) -> T
+    func dequeueCell<T: UICollectionViewCell>(`for` indexPath: IndexPath) -> T
     where T: ReusableView {
         guard let cell = dequeueReusableCell(withReuseIdentifier: T.reuseIdentifier, for: indexPath) as? T else {
             assertionFailure("🔥 Did you forget to register cell with identifier `\(T.reuseIdentifier)` for type: `\(T.self)`")
@@ -56,7 +56,7 @@ public extension UICollectionView {
         register(viewType, forSupplementaryViewOfKind: kind, withReuseIdentifier: viewType.reuseIdentifier)
     }
 
-    func supplementaryView<T: UICollectionReusableView>(forElementKind elementKind: String,
+    func dequeueSupplementaryView<T: UICollectionReusableView>(forElementKind elementKind: String,
                                                         at indexPath: IndexPath) -> T
     where T: ReusableView {
 
@@ -75,7 +75,7 @@ public extension UICollectionView {
 
 public extension UITableView {
 
-    func cell<T: UITableViewCell>(`for` indexPath: IndexPath) -> T
+    func dequeueCell<T: UITableViewCell>(`for` indexPath: IndexPath) -> T
     where T: ReusableView {
         guard let cell = dequeueReusableCell(withIdentifier: T.reuseIdentifier, for: indexPath) as? T else {
             assertionFailure("🔥 Did you forget to register cell with identifier `\(T.reuseIdentifier)` for type: `\(T.self)`")
@@ -85,7 +85,7 @@ public extension UITableView {
         return cell
     }
 
-    func headerFooterView<T: UITableViewCell>() -> T
+    func dequeueHeaderFooterView<T: UITableViewCell>() -> T
     where T: ReusableView {
         guard let view = dequeueReusableHeaderFooterView(withIdentifier: T.reuseIdentifier) as? T else {
             assertionFailure("🔥 Did you forget to register view with identifier `\(T.reuseIdentifier)` for type: `\(T.self)`")

--- a/Sources/Protocols/ReusableView.swift
+++ b/Sources/Protocols/ReusableView.swift
@@ -45,6 +45,16 @@ public extension UICollectionView {
 
         return cell
     }
+    
+    func Cell<T: UICollectionViewCell>(`for` indexPath: IndexPath) -> T
+        where T: ReusableView {
+            guard let cell = cellForItem(at: indexPath) as? T else {
+                assertionFailure("🔥 Cell at \(indexPath) is not of type: `\(T.self)`")
+                return T()
+            }
+            
+            return cell
+    }
 
     func register<T: UICollectionViewCell>(_ cellType: T.Type)
     where T: ReusableView {
@@ -63,11 +73,24 @@ public extension UICollectionView {
         guard let supplementaryView = dequeueReusableSupplementaryView(ofKind: elementKind,
                                                                             withReuseIdentifier: T.reuseIdentifier,
                                                                             for: indexPath) as? T else {
-            assertionFailure("🔥 SupplementaryView with identifier `\(T.reuseIdentifier)` not registered for type: `\(T.self)`!")
+            assertionFailure("🔥 SupplementaryView at \(indexPath) is not of type: `\(T.self)`!")
             return T()
         }
 
         return supplementaryView
+    }
+    
+    @available(iOS 9, *)
+    func supplementaryView<T: UICollectionReusableView>(forElementKind elementKind: String,
+                                  at indexPath: IndexPath) -> T
+        where T: ReusableView {
+            
+            guard let supplementaryView = supplementaryView(forElementKind: elementKind, at: indexPath) as? T else {
+                                                                            assertionFailure("🔥 SupplementaryView with identifier `\(T.reuseIdentifier)` not registered for type: `\(T.self)`!")
+                                                                            return T()
+            }
+            
+            return supplementaryView
     }
 }
 
@@ -93,6 +116,36 @@ public extension UITableView {
         }
 
         return view
+    }
+    
+    func cell<T: UITableViewCell>(`for` indexPath: IndexPath) -> T
+        where T: ReusableView {
+            guard let cell = cellForRow(at: indexPath) as? T else {
+                assertionFailure("🔥 Cell for row at \(indexPath) is not of type: `\(T.self)`")
+                return T()
+            }
+            
+            return cell
+    }
+    
+    func headerView<T: UITableViewCell>(forSection section: Int) -> T
+        where T: ReusableView {
+            guard let view = headerView(forSection: section) as? T else {
+                assertionFailure("🔥 Header view at section \(section) is not of type: `\(T.self)`")
+                return T()
+            }
+            
+            return view
+    }
+    
+    func footerView<T: UITableViewCell>(forSection section: Int) -> T
+        where T: ReusableView {
+            guard let view = footerView(forSection: section) as? T else {
+                assertionFailure("🔥 Footer view at section \(section) is not of type: `\(T.self)`")
+                return T()
+            }
+            
+            return view
     }
 
     func register<T: UITableViewCell>(_ cellType: T.Type)


### PR DESCRIPTION
The current naming of `cell(for indexPath: IndexPath)` could be confused with with `cellForRow(at...`. The call might be expecting our method to return an already dequeued cell, when instead we are dequeueing one. 

This PR prepends the "dequeue" word to the front of the current methods to make this action clear to the caller. It also includes methods to return already dequeued cells of a specific type (essentially calling `cellForRow(at:)` instead of `dequeueReusableCell`)