### PR TITLE
Added public initialiser for DiskMemoryPersistenceStack.Configuration…

### DIFF
--- a/Sources/Persistence/DiskMemoryPersistenceStack.swift
+++ b/Sources/Persistence/DiskMemoryPersistenceStack.swift
@@ -36,6 +36,17 @@ public final class DiskMemoryPersistenceStack: PersistenceStack {
                 }
             }
         }
+
+        public init(diskLimit: UInt64,
+                    memLimit: UInt64,
+                    path: String,
+                    qos: (read: QualityOfService, write: QualityOfService) = (read: .userInitiated, write: .utility)) {
+
+            self.diskLimit = diskLimit
+            self.memLimit = memLimit
+            self.path = path
+            self.qos = qos
+        }
     }
 
     public enum Error: Swift.Error {


### PR DESCRIPTION
Due to the internal struct properties there was no public struct initialiser automatically created, so it wasn’t possible to create a Configuration value from without the project. Added a public initialiser to solve this problem.