### PR TITLE
Keyboard Observer

### DIFF
--- a/Alicerce.xcodeproj/project.pbxproj
+++ b/Alicerce.xcodeproj/project.pbxproj
@@ -117,6 +117,7 @@
 		0ABFFAC61EA8FCA300CFC8BD /* JSONTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ABFFAC51EA8FCA300CFC8BD /* JSONTests.swift */; };
 		0ABFFAE21EAA6ED400CFC8BD /* HTTP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ABFFAE11EAA6ED400CFC8BD /* HTTP.swift */; };
 		0AE330961EBB71F8003E8506 /* Cancelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE330951EBB71F8003E8506 /* Cancelable.swift */; };
+		1B14CDC11ECCC84D00CFAC15 /* KeyboardObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B14CDC01ECCC84D00CFAC15 /* KeyboardObserver.swift */; };
 		1B57E97D1EB150C80027AB30 /* Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B57E97C1EB150C80027AB30 /* Analytics.swift */; };
 		1B57E97F1EB1510D0027AB30 /* AnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B57E97E1EB1510D0027AB30 /* AnalyticsTracker.swift */; };
 		1B57E9811EB155A30027AB30 /* Page.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B57E9801EB155A30027AB30 /* Page.swift */; };
@@ -258,6 +259,7 @@
 		0ABFFAC51EA8FCA300CFC8BD /* JSONTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONTests.swift; sourceTree = "<group>"; };
 		0ABFFAE11EAA6ED400CFC8BD /* HTTP.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTP.swift; sourceTree = "<group>"; };
 		0AE330951EBB71F8003E8506 /* Cancelable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cancelable.swift; sourceTree = "<group>"; };
+		1B14CDC01ECCC84D00CFAC15 /* KeyboardObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardObserver.swift; sourceTree = "<group>"; };
 		1B57E97C1EB150C80027AB30 /* Analytics.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Analytics.swift; sourceTree = "<group>"; };
 		1B57E97E1EB1510D0027AB30 /* AnalyticsTracker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnalyticsTracker.swift; sourceTree = "<group>"; };
 		1B57E9801EB155A30027AB30 /* Page.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Page.swift; sourceTree = "<group>"; };
@@ -596,6 +598,14 @@
 			path = Shared;
 			sourceTree = "<group>";
 		};
+		1B14CDBF1ECCC83200CFAC15 /* Observers */ = {
+			isa = PBXGroup;
+			children = (
+				1B14CDC01ECCC84D00CFAC15 /* KeyboardObserver.swift */,
+			);
+			path = Observers;
+			sourceTree = "<group>";
+		};
 		1B57E97B1EB150AB0027AB30 /* Analytics */ = {
 			isa = PBXGroup;
 			children = (
@@ -672,6 +682,7 @@
 				0A3C2C881EA7E18500EFB7D4 /* Extensions */,
 				0A3C2C911EA7E18500EFB7D4 /* Logging */,
 				0A3C2CA01EA7E18500EFB7D4 /* Network */,
+				1B14CDBF1ECCC83200CFAC15 /* Observers */,
 				0A3C2CA61EA7E18500EFB7D4 /* Persistence */,
 				0A3C2CB21EA7E18500EFB7D4 /* Protocols */,
 				0A3C2CB61EA7E18500EFB7D4 /* Resource */,
@@ -838,6 +849,7 @@
 				0A8388601EB1F6B000C1E835 /* SiblingContextCoreDataStack.swift in Sources */,
 				0A3C2DC01EA7E5DD00EFB7D4 /* Placeholder.swift in Sources */,
 				0A3C2DBA1EA7E5DD00EFB7D4 /* TableViewHeaderFooterView.swift in Sources */,
+				1B14CDC11ECCC84D00CFAC15 /* KeyboardObserver.swift in Sources */,
 				0A3C2D9F1EA7E5DD00EFB7D4 /* Logger.swift in Sources */,
 				0A3C2DC11EA7E5DD00EFB7D4 /* ServiceLocator.swift in Sources */,
 				0A3C2DB81EA7E5DD00EFB7D4 /* CollectionViewCell.swift in Sources */,

--- a/Sources/Observers/KeyboardObserver.swift
+++ b/Sources/Observers/KeyboardObserver.swift
@@ -6,12 +6,11 @@
 //  Copyright © 2017 Mindera. All rights reserved.
 //
 
-import Foundation
 import UIKit
 
 public final class KeyboardObserver: NSObject {
 
-    fileprivate var keyboardVisible = false
+    fileprivate var isKeyboardVisible = false
 
     private weak var window: UIWindow?
 
@@ -37,20 +36,16 @@ public final class KeyboardObserver: NSObject {
 
     // MARK: - Private Methods
 
-    @objc private func keyboardDidShow(_ notification: Notification) {
-        guard keyboardVisible == false else { return }
-
-        keyboardVisible = true
+    @objc private func keyboardDidShow() {
+        isKeyboardVisible = true
     }
 
-    @objc private func keyboardDidHide(_ notification: Notification) {
-        guard keyboardVisible == true else { return }
-
-        keyboardVisible = false
+    @objc private func keyboardDidHide() {
+        isKeyboardVisible = false
     }
 
     @objc private func didTapView() {
-        guard keyboardVisible == true else { return }
+        guard isKeyboardVisible == true else { return }
 
         window?.endEditing(true)
     }
@@ -58,6 +53,6 @@ public final class KeyboardObserver: NSObject {
 
 extension KeyboardObserver: UIGestureRecognizerDelegate {
     public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-        return keyboardVisible
+        return isKeyboardVisible
     }
 }

--- a/Sources/Observers/KeyboardObserver.swift
+++ b/Sources/Observers/KeyboardObserver.swift
@@ -1,0 +1,63 @@
+//
+//  KeyboardObserver.swift
+//  Alicerce
+//
+//  Created by Luís Portela on 17/05/2017.
+//  Copyright © 2017 Mindera. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+public final class KeyboardObserver: NSObject {
+
+    fileprivate var keyboardVisible = false
+
+    private weak var window: UIWindow?
+
+    init(window: UIWindow) {
+        self.window = window
+
+        super.init()
+
+        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(didTapView))
+        tapGestureRecognizer.delegate = self
+        self.window?.addGestureRecognizer(tapGestureRecognizer)
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(keyboardDidShow),
+                                               name: .UIKeyboardDidShow,
+                                               object: nil)
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(keyboardDidHide),
+                                               name: .UIKeyboardDidHide,
+                                               object: nil)
+    }
+
+    // MARK: - Private Methods
+
+    @objc private func keyboardDidShow(_ notification: Notification) {
+        guard keyboardVisible == false else { return }
+
+        keyboardVisible = true
+    }
+
+    @objc private func keyboardDidHide(_ notification: Notification) {
+        guard keyboardVisible == true else { return }
+
+        keyboardVisible = false
+    }
+
+    @objc private func didTapView() {
+        guard keyboardVisible == true else { return }
+
+        window?.endEditing(true)
+    }
+}
+
+extension KeyboardObserver: UIGestureRecognizerDelegate {
+    public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        return keyboardVisible
+    }
+}


### PR DESCRIPTION
On of the boring thing that iOS developers has to deal, is the keyboard dismissal and setup the location in view where to do it.

This is a simple observer that listens the keyboardDidShow and keyboardDidHide notifications from the `NotificationCenter`, adds a GestureRecognizer into UIWindow and dismisses the keyboard when you press a part of screen where there isn't other touchable elements.

Unfortunately i didn't find yet a way of test it.

The current way of use it, is:
* on you AppDelegate, just create a `private var keyboardObserver: KeyboardObserver!`
* init it in the didFinishLaunching...

If you have a better suggestion, like add a `startObserve()` or a `configureWindow()` 👈 don't like this one, please shout.

🍻