### PR TITLE
Add `assertDumpsEqual` helper function

### DIFF
--- a/Alicerce.xcodeproj/project.pbxproj
+++ b/Alicerce.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		0A266F0F1ED33B65009CD0D7 /* CAGradientLayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A266F0E1ED33B65009CD0D7 /* CAGradientLayer.swift */; };
 		0A266F121ED33CDE009CD0D7 /* CALayerTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A266F111ED33CDE009CD0D7 /* CALayerTestCase.swift */; };
 		0A266F141ED33D9F009CD0D7 /* CAGradientLayerTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A266F131ED33D9F009CD0D7 /* CAGradientLayerTestCase.swift */; };
+		0A266F201ED374F5009CD0D7 /* AssertDumpsEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A266F1F1ED374F5009CD0D7 /* AssertDumpsEqual.swift */; };
+		0A266F241ED37708009CD0D7 /* AssertDumpsEqualTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A266F231ED37708009CD0D7 /* AssertDumpsEqualTestCase.swift */; };
 		0A3C2D7A1EA7E3E900EFB7D4 /* Alicerce.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A3C2D711EA7E3E800EFB7D4 /* Alicerce.framework */; };
 		0A3C2D881EA7E5DD00EFB7D4 /* ApplicationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3C2C831EA7E18500EFB7D4 /* ApplicationRouter.swift */; };
 		0A3C2D891EA7E5DD00EFB7D4 /* Route+Component.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3C2C841EA7E18500EFB7D4 /* Route+Component.swift */; };
@@ -148,6 +150,8 @@
 		0A266F0E1ED33B65009CD0D7 /* CAGradientLayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CAGradientLayer.swift; sourceTree = "<group>"; };
 		0A266F111ED33CDE009CD0D7 /* CALayerTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CALayerTestCase.swift; sourceTree = "<group>"; };
 		0A266F131ED33D9F009CD0D7 /* CAGradientLayerTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CAGradientLayerTestCase.swift; sourceTree = "<group>"; };
+		0A266F1F1ED374F5009CD0D7 /* AssertDumpsEqual.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssertDumpsEqual.swift; sourceTree = "<group>"; };
+		0A266F231ED37708009CD0D7 /* AssertDumpsEqualTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssertDumpsEqualTestCase.swift; sourceTree = "<group>"; };
 		0A3C2C831EA7E18500EFB7D4 /* ApplicationRouter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApplicationRouter.swift; sourceTree = "<group>"; };
 		0A3C2C841EA7E18500EFB7D4 /* Route+Component.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Route+Component.swift"; sourceTree = "<group>"; };
 		0A3C2C851EA7E18500EFB7D4 /* Route+Tree.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Route+Tree.swift"; sourceTree = "<group>"; };
@@ -434,6 +438,7 @@
 			isa = PBXGroup;
 			children = (
 				0A3C2CC11EA7E18500EFB7D4 /* ApplicationMode.swift */,
+				0A266F1F1ED374F5009CD0D7 /* AssertDumpsEqual.swift */,
 				0A3C2CC21EA7E18500EFB7D4 /* Box.swift */,
 				0A3C2CC41EA7E18500EFB7D4 /* Placeholder.swift */,
 				0A3C2CC51EA7E18500EFB7D4 /* ServiceLocator.swift */,
@@ -533,6 +538,7 @@
 			isa = PBXGroup;
 			children = (
 				0A3C2D3C1EA7E1EE00EFB7D4 /* ServiceLocatorTests.swift */,
+				0A266F231ED37708009CD0D7 /* AssertDumpsEqualTestCase.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -905,6 +911,7 @@
 				0A3C2D931EA7E5DD00EFB7D4 /* Thread.swift in Sources */,
 				0A83885A1EB1F6B000C1E835 /* CoreDataStack.swift in Sources */,
 				0A3C2DB71EA7E5DD00EFB7D4 /* CollectionReusableView.swift in Sources */,
+				0A266F201ED374F5009CD0D7 /* AssertDumpsEqual.swift in Sources */,
 				1B57E9831EB155DB0027AB30 /* Event.swift in Sources */,
 				0A3C2DB41EA7E5DD00EFB7D4 /* View.swift in Sources */,
 				0A83885E1EB1F6B000C1E835 /* NSPersistentStoreCoordinator+CoreDataStack.swift in Sources */,
@@ -945,6 +952,7 @@
 				1B57E98D1EB2128F0027AB30 /* ConfigurationTestCase.swift in Sources */,
 				0A3C2DC71EA7E5EF00EFB7D4 /* TreeRouterTests.swift in Sources */,
 				0A3C2DC81EA7E5EF00EFB7D4 /* DataTestCase.swift in Sources */,
+				0A266F241ED37708009CD0D7 /* AssertDumpsEqualTestCase.swift in Sources */,
 				0A3C2DCE1EA7E5EF00EFB7D4 /* FileLogDestinationTests.swift in Sources */,
 				0A266F121ED33CDE009CD0D7 /* CALayerTestCase.swift in Sources */,
 				0A266F141ED33D9F009CD0D7 /* CAGradientLayerTestCase.swift in Sources */,

--- a/Sources/Extensions/String.swift
+++ b/Sources/Extensions/String.swift
@@ -50,3 +50,13 @@ public extension String {
         return NSLocalizedString(self, comment: "")
     }
 }
+
+
+public extension String {
+
+    /// Creates a string from the `dump` output of the given value.
+    init<T>(dumping x: T) {
+        self.init()
+        dump(x, to: &self)
+    }
+}

--- a/Sources/Utils/AssertDumpsEqual.swift
+++ b/Sources/Utils/AssertDumpsEqual.swift
@@ -1,0 +1,27 @@
+//
+//  AssertDumpsEqual.swift
+//  Alicerce
+//
+//  Created by André Pacheco Neves on 22/05/2017.
+//  Copyright © 2017 Mindera. All rights reserved.
+//
+
+import Foundation
+
+// Credits to Ole Begemann (@olebegemann) and Tim Vermeulen (@tim_vermeulen) 🙏
+// https://oleb.net/blog/2017/03/dump-as-equatable-safeguard/
+
+/// Asserts that two expressions have the same `dump` output.
+///
+/// - Note: Like the standard library's `assert`, the assertion is only active in playgrounds and `-Onone` builds.
+/// The function does nothing in optimized builds.
+///
+/// - Seealso: `dump(_:to:name:indent:maxDepth:maxItems)`
+///
+/// - Warning: `NSObject` subclasses' `dump` **include** a memory address and hence may cause false positives.
+public func assertDumpsEqual<T>(_ lhs: @autoclosure () -> T,
+                         _ rhs: @autoclosure () -> T,
+                         file: StaticString = #file,
+                         line: UInt = #line) {
+    assert(String(dumping: lhs()) == String(dumping: rhs()), "Expected dumps to be equal.", file: file, line: line)
+}

--- a/Tests/AlicerceTests/Utils/AssertDumpsEqualTestCase.swift
+++ b/Tests/AlicerceTests/Utils/AssertDumpsEqualTestCase.swift
@@ -1,0 +1,64 @@
+//
+//  AssertDumpsEqualTestCase.swift
+//  Alicerce
+//
+//  Created by André Pacheco Neves on 22/05/2017.
+//  Copyright © 2017 Mindera. All rights reserved.
+//
+
+import XCTest
+@testable import Alicerce
+
+class AssertDumpsEqualTestCase: XCTestCase {
+
+    func test_WithEqualString_ShouldSucceed() {
+        let s1 = "test"
+        let s2 = "test"
+
+        assertDumpsEqual(s1, s2)
+    }
+
+    func test_WithEqualInt_ShouldSucceed() {
+        let i1 = 1337
+        let i2 = 1337
+
+        assertDumpsEqual(i1, i2)
+    }
+
+    func test_WithEqualDate_ShouldSucceed() {
+        let d = Date()
+        let d1 = d
+        let d2 = d
+
+        assertDumpsEqual(d1, d2)
+    }
+
+    func test_WithEqualRange_ShouldSucceed() {
+        let r1 = 0..<1337
+        let r2 = 0..<1337
+
+        assertDumpsEqual(r1, r2)
+    }
+
+    func test_WithEqualStringArray_ShouldSucceed() {
+        let a1 = ["a", "b", "c"]
+        let a2 = ["a", "b", "c"]
+
+        assertDumpsEqual(a1, a2)
+    }
+
+    func test_WithEqualIntArray_ShouldSucceed() {
+        let a1 = [1, 2, 3]
+        let a2 = [1, 2, 3]
+
+        assertDumpsEqual(a1, a2)
+    }
+
+    func test_WithEqualDict_ShouldSucceed() {
+        let d1 = ["a" : 1, "b" : 2, "c" : 3]
+        let d2 = ["a" : 1, "b" : 2, "c" : 3]
+
+        assertDumpsEqual(d1, d2)
+    }
+    
+}


### PR DESCRIPTION
Added `assertDumpsEqual` function to help validate `Equatable`
conformances, as well as signal outdated implementations automatically
on debug builds.

Credits to Ole Begemann and Tim Vermeulen 🙏
https://oleb.net/blog/2017/03/dump-as-equatable-safeguard/