### PR TITLE
Remove `init()` requirement from `View`

### DIFF
--- a/Sources/View/View.swift
+++ b/Sources/View/View.swift
@@ -9,8 +9,6 @@
 import UIKit
 
 public protocol View {
-    init()
-
     func setUpSubviews()
     func setUpConstraints()
 }


### PR DESCRIPTION
Removed `init()` from `View` protocol since it no longer brings any
benefit and introduces noise when using the protocol and its derivates
(e.g. `ReusableViewModelView`).