### PR TITLE
Set Travis' SDK version to always be the `latest` 🙈

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
     - XCODE_PROJECT_NAME=Alicerce
     - XCODE_SDK=iphonesimulator
     - XCODE_ACTION='build test'
-    - XCODE_DESTINATION='platform=iOS Simulator,name=iPhone 6s,OS=10.3'
+    - XCODE_DESTINATION='platform=iOS Simulator,name=iPhone 6s,OS=latest'
     - XCODE_DERIVED_DATA_PATH=build
   matrix:
     - XCODE_SCHEME=Alicerce


### PR DESCRIPTION
Every time a new Xcode version comes out, the available simulator list
can change, as well as the available simulator iOS SDK versions.

By using `OS=latest` when specifying Xcode's simulator destination, the
configuration becomes more adaptable to these type of changes. 💪