### PR TITLE
Add custom API Error parsing to `NetworkResource`

### DIFF
--- a/Sources/Network/Network.swift
+++ b/Sources/Network/Network.swift
@@ -19,7 +19,7 @@ public enum Network {
     // MARK: - Network Error
 
     public enum Error: Swift.Error {
-        case http(code: HTTP.StatusCode, description: String?)
+        case http(code: HTTP.StatusCode, apiError: Swift.Error?)
         case noData
         case url(Swift.Error)
         case badResponse

--- a/Sources/Resource/NetworkResource.swift
+++ b/Sources/Resource/NetworkResource.swift
@@ -9,11 +9,14 @@
 import Foundation
 
 public typealias ResourceParseClosure<T> = (Data) throws -> T
+public typealias ResourceErrorParseClosure<E: Error> = (Data) -> E?
 
 public protocol NetworkResource {
     associatedtype T
+    associatedtype E: Error
 
     var parser: ResourceParseClosure<T> { get }
+    var apiErrorParser: ResourceErrorParseClosure<E> { get }
 
     func toRequest(withBaseURL baseURL: URL) -> URLRequest
 }

--- a/Sources/Resource/Resource.swift
+++ b/Sources/Resource/Resource.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct Resource<T> {
+public struct Resource<T, E: Error> {
 
     let path: String
     let method: HTTP.Method
@@ -17,13 +17,15 @@ public struct Resource<T> {
     let body: Data?
 
     public let parser: ResourceParseClosure<T>
+    public let apiErrorParser: ResourceErrorParseClosure<E>
 
     public init(path: String,
                 method: HTTP.Method,
                 headers: HTTP.Headers? = nil,
                 query: HTTP.Query? = nil,
                 body: Data? = nil,
-                parser: @escaping ResourceParseClosure<T>) {
+                parser: @escaping ResourceParseClosure<T>,
+                apiErrorParser: @escaping ResourceErrorParseClosure<E>) {
 
         self.path = path
         self.method = method
@@ -31,6 +33,7 @@ public struct Resource<T> {
         self.query = query
         self.body = body
         self.parser = parser
+        self.apiErrorParser = apiErrorParser
     }
 }
 

--- a/Tests/AlicerceTests/Resource/NetworkResourceTestCase.swift
+++ b/Tests/AlicerceTests/Resource/NetworkResourceTestCase.swift
@@ -12,6 +12,10 @@ import XCTest
 
 final class NetworkResourceTestCase: XCTestCase {
 
+    enum APIError: Error {
+        case 💥
+    }
+
     func testToRequest_WhenProvidedARequestWithAllValues_ItShouldReturnAValidURLRequest() {
         let path = "/"
         let method = HTTP.Method.GET
@@ -19,13 +23,15 @@ final class NetworkResourceTestCase: XCTestCase {
         let query: HTTP.Query = ["param1" : "value1"]
         let body = "👀".data(using: .utf8)
         let parser: (Data) throws -> String = { _ in "" }
+        let apiErrorParser: (Data) -> APIError? = { _ in .💥 }
 
-        let resource = Resource<String>(path: path,
-                                        method: method,
-                                        headers: headers,
-                                        query: query,
-                                        body: body,
-                                        parser: parser)
+        let resource = Resource<String, APIError>(path: path,
+                                                  method: method,
+                                                  headers: headers,
+                                                  query: query,
+                                                  body: body,
+                                                  parser: parser,
+                                                  apiErrorParser: apiErrorParser)
 
         let baseURL = URL(string: "http://localhost")!
 

--- a/Tests/AlicerceTests/Resource/ResourceTestCase.swift
+++ b/Tests/AlicerceTests/Resource/ResourceTestCase.swift
@@ -12,6 +12,10 @@ import XCTest
 
 final class ResourceTestCase: XCTestCase {
 
+    enum APIError: Error {
+        case 💣
+    }
+
     func testResource_WithFullInit_ItShouldPopulateAllValues() {
 
         let path = "/"
@@ -20,13 +24,15 @@ final class ResourceTestCase: XCTestCase {
         let query: HTTP.Query = ["👉" : "😜"]
         let body = "👀".data(using: .utf8)
         let parser: (Data) throws -> String = { _ in "" }
+        let apiErrorParser: (Data) -> APIError? = { _ in .💣 }
 
-        let resource = Resource<String>(path: path,
-                                        method: method,
-                                        headers: headers,
-                                        query: query,
-                                        body: body,
-                                        parser: parser)
+        let resource = Resource<String, APIError>(path: path,
+                                                  method: method,
+                                                  headers: headers,
+                                                  query: query,
+                                                  body: body,
+                                                  parser: parser,
+                                                  apiErrorParser: apiErrorParser)
 
         XCTAssertEqual(resource.path, path)
         XCTAssertEqual(resource.method, method)
@@ -40,8 +46,12 @@ final class ResourceTestCase: XCTestCase {
         let path = "/"
         let method = HTTP.Method.GET
         let parser: (Data) throws -> String = { _ in "" }
+        let apiErrorParser: (Data) -> APIError? = { _ in .💣 }
 
-        let resource = Resource<String>(path: path, method: method, parser: parser)
+        let resource = Resource<String, APIError>(path: path,
+                                                  method: method,
+                                                  parser: parser,
+                                                  apiErrorParser: apiErrorParser)
 
         XCTAssertEqual(resource.path, path)
         XCTAssertEqual(resource.method, method)


### PR DESCRIPTION
Whenever a request fails with a non successful status code, the payload
of the request was being ignored, and no attempt to parse error
information was made.

By adding an error parsing closure `(Data) -> E?` to the
`NetworkRequest`, the `NetworkStack` can then try to parse error
information from the returned data, if any.