### PR TITLE
UIColor to hex string extension method

### DIFF
--- a/Sources/UIKit/UIColor.swift
+++ b/Sources/UIKit/UIColor.swift
@@ -41,20 +41,20 @@ public extension UIColor {
 
         var components = UIColor.components(fromHex6: 0)
         getRed(&components.red, green: &components.green, blue: &components.blue, alpha: &components.alpha)
-        let rgb: Int = (Int)(components.red*255)<<16
-            | (Int)(components.green*255)<<8
-            | (Int)(components.blue*255)<<0
+        let rgb: Int = (Int)(components.red * UIColor.divisor) << 16
+            | (Int)(components.green * UIColor.divisor) << 8
+            | (Int)(components.blue * UIColor.divisor) << 0
         return String(format:"#%06x", rgb)
     }
 
     var hexStringWithAlpha: String {
 
-        var components = UIColor.components(fromHex6: 0)
+        var components = UIColor.components(fromHex8: 0)
         getRed(&components.red, green: &components.green, blue: &components.blue, alpha: &components.alpha)
-        let argb: Int = (Int)(components.alpha * 255)<<24
-            | (Int)(components.red*255)<<16
-            | (Int)(components.green*255)<<8
-            | (Int)(components.blue*255)<<0
+        let argb: Int = (Int)(components.alpha * UIColor.divisor) << 24
+            | (Int)(components.red * UIColor.divisor) << 16
+            | (Int)(components.green * UIColor.divisor) << 8
+            | (Int)(components.blue * UIColor.divisor) << 0
         return String(format:"#%08x", argb)
     }
 
@@ -69,10 +69,11 @@ public extension UIColor {
     }
 
     private static func components(fromHex8 hex: UInt32) -> Components {
-        let red = CGFloat((hex & 0xFF000000) >> 24) / UIColor.divisor
-        let green = CGFloat((hex & 0x00FF0000) >> 16) / UIColor.divisor
-        let blue = CGFloat((hex & 0x0000FF00) >> 8) / UIColor.divisor
-        let alpha = CGFloat(hex & 0x000000FF) / UIColor.divisor
+
+        let alpha = CGFloat((hex & 0xFF000000) >> 24) / UIColor.divisor
+        let red = CGFloat((hex & 0x00FF0000) >> 16) / UIColor.divisor
+        let green = CGFloat((hex & 0x0000FF00) >> 8) / UIColor.divisor
+        let blue = CGFloat(hex & 0x000000FF) / UIColor.divisor
         
         return (red, green, blue, alpha)
     }

--- a/Sources/UIKit/UIColor.swift
+++ b/Sources/UIKit/UIColor.swift
@@ -37,6 +37,27 @@ public extension UIColor {
         self.init(red: components.red, green: components.green, blue: components.blue, alpha: components.alpha)
     }
 
+    var hexString: String {
+
+        var components = UIColor.components(fromHex6: 0)
+        getRed(&components.red, green: &components.green, blue: &components.blue, alpha: &components.alpha)
+        let rgb: Int = (Int)(components.red*255)<<16
+            | (Int)(components.green*255)<<8
+            | (Int)(components.blue*255)<<0
+        return String(format:"#%06x", rgb)
+    }
+
+    var hexStringWithAlpha: String {
+
+        var components = UIColor.components(fromHex6: 0)
+        getRed(&components.red, green: &components.green, blue: &components.blue, alpha: &components.alpha)
+        let argb: Int = (Int)(components.alpha * 255)<<24
+            | (Int)(components.red*255)<<16
+            | (Int)(components.green*255)<<8
+            | (Int)(components.blue*255)<<0
+        return String(format:"#%08x", argb)
+    }
+
     // MARK: - Private Methods
 
     private static func components(fromHex6 hex: UInt32) -> Components {

--- a/Sources/UIKit/UIColor.swift
+++ b/Sources/UIKit/UIColor.swift
@@ -41,7 +41,7 @@ public extension UIColor {
 
         var components = UIColor.components(fromHex6: 0)
         getRed(&components.red, green: &components.green, blue: &components.blue, alpha: &components.alpha)
-        let rgb: Int = (Int)(components.red * UIColor.divisor) << 16
+        let rgb = (Int)(components.red * UIColor.divisor) << 16
             | (Int)(components.green * UIColor.divisor) << 8
             | (Int)(components.blue * UIColor.divisor) << 0
         return String(format:"#%06x", rgb)
@@ -51,7 +51,7 @@ public extension UIColor {
 
         var components = UIColor.components(fromHex8: 0)
         getRed(&components.red, green: &components.green, blue: &components.blue, alpha: &components.alpha)
-        let argb: Int = (Int)(components.alpha * UIColor.divisor) << 24
+        let argb = (Int)(components.alpha * UIColor.divisor) << 24
             | (Int)(components.red * UIColor.divisor) << 16
             | (Int)(components.green * UIColor.divisor) << 8
             | (Int)(components.blue * UIColor.divisor) << 0

--- a/Tests/AlicerceTests/UIKit/UIColorTestCase.swift
+++ b/Tests/AlicerceTests/UIKit/UIColorTestCase.swift
@@ -38,4 +38,26 @@ final class UIColorTestCase: XCTestCase {
         XCTAssertEqual(ciColor.blue, 1.0)
         XCTAssertEqual(ciColor.alpha, 0.0)
     }
+
+    func testHexString_WithBaseColors_ItShouldReturnCorrectHexColor() {
+
+        let hexRed = UIColor.red.hexString
+        let hexGreen = UIColor.green.hexString
+        let hexBlue = UIColor.blue.hexString
+
+        XCTAssertEqual(hexRed, "#ff0000")
+        XCTAssertEqual(hexGreen, "#00ff00")
+        XCTAssertEqual(hexBlue, "#0000ff")
+    }
+
+    func testHexString_WithAlphaColors_ItShouldReturnCorrectHexColor() {
+
+        let hexOpaque = UIColor(white: 1.0, alpha: 1.0).hexStringWithAlpha
+        let hexSemi = UIColor(white: 1.0, alpha: 0.5).hexStringWithAlpha
+        let hexTransparent = UIColor(white: 1.0, alpha: 0.0).hexStringWithAlpha
+
+        XCTAssertEqual(hexOpaque, "#ffffffff")
+        XCTAssertEqual(hexSemi, "#7fffffff")
+        XCTAssertEqual(hexTransparent, "#00ffffff")
+    }
 }

--- a/Tests/AlicerceTests/UIKit/UIColorTestCase.swift
+++ b/Tests/AlicerceTests/UIKit/UIColorTestCase.swift
@@ -27,7 +27,7 @@ final class UIColorTestCase: XCTestCase {
     }
 
     func testHex_When32BitsRGBColorProvided_ItShouldReturnAValidUIColor() {
-        let colorHex = "#ffffff00"
+        let colorHex = "#00ffffff"
 
         let color = UIColor(hex: colorHex)
 
@@ -39,7 +39,7 @@ final class UIColorTestCase: XCTestCase {
         XCTAssertEqual(ciColor.alpha, 0.0)
     }
 
-    func testHexString_WithBaseColors_ItShouldReturnCorrectHexColor() {
+    func testHexToColorToHex_WithBaseColors_ShouldGiveSameResults() {
 
         let hexRed = UIColor.red.hexString
         let hexGreen = UIColor.green.hexString
@@ -48,9 +48,27 @@ final class UIColorTestCase: XCTestCase {
         XCTAssertEqual(hexRed, "#ff0000")
         XCTAssertEqual(hexGreen, "#00ff00")
         XCTAssertEqual(hexBlue, "#0000ff")
+
+        let ciRed = CIColor(color: UIColor(hex: hexRed))
+        XCTAssertEqual(ciRed.red, 1.0)
+        XCTAssertEqual(ciRed.green, 0.0)
+        XCTAssertEqual(ciRed.blue, 0.0)
+        XCTAssertEqual(ciRed.alpha, 1.0)
+
+        let ciGreen = CIColor(color: UIColor(hex: hexGreen))
+        XCTAssertEqual(ciGreen.red, 0.0)
+        XCTAssertEqual(ciGreen.green, 1.0)
+        XCTAssertEqual(ciGreen.blue, 0.0)
+        XCTAssertEqual(ciGreen.alpha, 1.0)
+
+        let ciBlue = CIColor(color: UIColor(hex: hexBlue))
+        XCTAssertEqual(ciBlue.red, 0.0)
+        XCTAssertEqual(ciBlue.green, 0.0)
+        XCTAssertEqual(ciBlue.blue, 1.0)
+        XCTAssertEqual(ciBlue.alpha, 1.0)
     }
 
-    func testHexString_WithAlphaColors_ItShouldReturnCorrectHexColor() {
+    func testHexToColorToHex_WithAlphaColors_ShouldGiveSameResults() {
 
         let hexOpaque = UIColor(white: 1.0, alpha: 1.0).hexStringWithAlpha
         let hexSemi = UIColor(white: 1.0, alpha: 0.5).hexStringWithAlpha
@@ -59,5 +77,27 @@ final class UIColorTestCase: XCTestCase {
         XCTAssertEqual(hexOpaque, "#ffffffff")
         XCTAssertEqual(hexSemi, "#7fffffff")
         XCTAssertEqual(hexTransparent, "#00ffffff")
+
+        let colorOpaque = UIColor(hex: hexOpaque)
+        let colorSemi = UIColor(hex: hexSemi)
+        let colorTransparent = UIColor(hex: hexTransparent)
+
+        let ciOpaqueColor = CIColor(color: colorOpaque)
+        XCTAssertEqual(ciOpaqueColor.red, 1.0)
+        XCTAssertEqual(ciOpaqueColor.green, 1.0)
+        XCTAssertEqual(ciOpaqueColor.blue, 1.0)
+        XCTAssertEqual(ciOpaqueColor.alpha, 1.0)
+
+        let ciSemiColor = CIColor(color: colorSemi)
+        XCTAssertEqual(ciSemiColor.red, 1.0)
+        XCTAssertEqual(ciSemiColor.green, 1.0)
+        XCTAssertEqual(ciSemiColor.blue, 1.0)
+        XCTAssertLessThan(abs(ciSemiColor.alpha - 0.5), 0.01)
+
+        let ciTransparentColor = CIColor(color: colorTransparent)
+        XCTAssertEqual(ciTransparentColor.red, 1.0)
+        XCTAssertEqual(ciTransparentColor.green, 1.0)
+        XCTAssertEqual(ciTransparentColor.blue, 1.0)
+        XCTAssertEqual(ciTransparentColor.alpha, 0.0)
     }
 }


### PR DESCRIPTION
Little UIColor helper method to convert any UIColor to a (HTML)-hex string representation, with or without alpha component.