### PR TITLE
Add completion closure to `RouteHandler` 📥

### DIFF
--- a/Tests/AlicerceTests/DeepLinking/TreeRouterTests.swift
+++ b/Tests/AlicerceTests/DeepLinking/TreeRouterTests.swift
@@ -9,20 +9,21 @@
 import XCTest
 @testable import Alicerce
 
+typealias HandledRoute = (URL, [String : String], [URLQueryItem])
+
 final class TestHandler: RouteHandler {
 
-    typealias HandleClosure = (URL, [String : String], [URLQueryItem]) -> Void
-
-    var didCallHandle: (HandleClosure)?
-
-    public func handle(route: URL, parameters: [String : String], queryItems: [URLQueryItem]) {
-        didCallHandle?(route, parameters, queryItems)
+    public func handle(route: URL,
+                       parameters: [String : String],
+                       queryItems: [URLQueryItem],
+                       completion: ((HandledRoute) -> Void)?) {
+        completion?(route, parameters, queryItems)
     }
 }
 
 class TreeRouterTests: XCTestCase {
 
-    typealias TestRouter = TreeRouter<TestHandler>
+    typealias TestRouter = TreeRouter<TestHandler, HandledRoute>
     typealias TestRouteTree = Route.Tree<TestHandler>
 
     fileprivate let expectationTimeout: TimeInterval = 5
@@ -1115,7 +1116,7 @@ class TreeRouterTests: XCTestCase {
         let expectation = self.expectation(description: "TreeRouter.route")
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
-        testHandler.didCallHandle = { (url, parameters, queryItems) in
+        let completion: (HandledRoute) -> Void = { url, parameters, queryItems in
             XCTAssertEqual(url, route)
             XCTAssertEqual(parameters, [:])
             XCTAssertEqual(queryItems, [])
@@ -1129,7 +1130,7 @@ class TreeRouterTests: XCTestCase {
         }
 
         do {
-            try router.route(route)
+            try router.route(route, completion: completion)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
             expectation.fulfill()
@@ -1143,7 +1144,7 @@ class TreeRouterTests: XCTestCase {
         let expectation = self.expectation(description: "TreeRouter.route")
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
-        testHandler.didCallHandle = { (url, parameters, queryItems) in
+        let completion: (HandledRoute) -> Void = { url, parameters, queryItems in
             XCTAssertEqual(url, route)
             XCTAssertEqual(parameters, [:])
             XCTAssertEqual(queryItems, [])
@@ -1157,7 +1158,7 @@ class TreeRouterTests: XCTestCase {
         }
 
         do {
-            try router.route(route)
+            try router.route(route, completion: completion)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
             expectation.fulfill()
@@ -1171,7 +1172,7 @@ class TreeRouterTests: XCTestCase {
         let expectation = self.expectation(description: "TreeRouter.route")
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
-        testHandler.didCallHandle = { (url, parameters, queryItems) in
+        let completion: (HandledRoute) -> Void = { url, parameters, queryItems in
             XCTAssertEqual(url, route)
             XCTAssertEqual(parameters, [:])
             XCTAssertEqual(queryItems, [])
@@ -1185,7 +1186,7 @@ class TreeRouterTests: XCTestCase {
         }
 
         do {
-            try router.route(route)
+            try router.route(route, completion: completion)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
             expectation.fulfill()
@@ -1199,7 +1200,7 @@ class TreeRouterTests: XCTestCase {
         let expectation = self.expectation(description: "TreeRouter.route")
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
-        testHandler.didCallHandle = { (url, parameters, queryItems) in
+        let completion: (HandledRoute) -> Void = { url, parameters, queryItems in
             XCTAssertEqual(url, route)
             XCTAssertEqual(parameters, [:])
             XCTAssertEqual(queryItems, [])
@@ -1213,7 +1214,7 @@ class TreeRouterTests: XCTestCase {
         }
 
         do {
-            try router.route(route)
+            try router.route(route, completion: completion)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
             expectation.fulfill()
@@ -1229,7 +1230,7 @@ class TreeRouterTests: XCTestCase {
         let expectationB = self.expectation(description: "TreeRouter.route")
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
-        testHandler.didCallHandle = { (url, parameters, queryItems) in
+        let completionA: (HandledRoute) -> Void = { url, parameters, queryItems in
             XCTAssertEqual(url, routeA)
             XCTAssertEqual(parameters, [:])
             XCTAssertEqual(queryItems, [])
@@ -1243,13 +1244,13 @@ class TreeRouterTests: XCTestCase {
         }
 
         do {
-            try router.route(routeA)
+            try router.route(routeA, completion: completionA)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
             expectationA.fulfill()
         }
 
-        testHandler.didCallHandle = { (url, parameters, queryItems) in
+        let completionB: (HandledRoute) -> Void = { url, parameters, queryItems in
             XCTAssertEqual(url, routeB)
             XCTAssertEqual(parameters, [:])
             XCTAssertEqual(queryItems, [])
@@ -1257,7 +1258,7 @@ class TreeRouterTests: XCTestCase {
         }
 
         do {
-            try router.route(routeB)
+            try router.route(routeB, completion: completionB)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
             expectationB.fulfill()
@@ -1273,7 +1274,7 @@ class TreeRouterTests: XCTestCase {
         let expectationB = self.expectation(description: "TreeRouter.route")
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
-        testHandler.didCallHandle = { (url, parameters, queryItems) in
+        let completionA: (HandledRoute) -> Void = { url, parameters, queryItems in
             XCTAssertEqual(url, routeA)
             XCTAssertEqual(parameters, [:])
             XCTAssertEqual(queryItems, [])
@@ -1287,13 +1288,13 @@ class TreeRouterTests: XCTestCase {
         }
 
         do {
-            try router.route(routeA)
+            try router.route(routeA, completion: completionA)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
             expectationA.fulfill()
         }
 
-        testHandler.didCallHandle = { (url, parameters, queryItems) in
+        let completionB: (HandledRoute) -> Void = { url, parameters, queryItems in
             XCTAssertEqual(url, routeB)
             XCTAssertEqual(parameters, [:])
             XCTAssertEqual(queryItems, [])
@@ -1301,7 +1302,7 @@ class TreeRouterTests: XCTestCase {
         }
 
         do {
-            try router.route(routeB)
+            try router.route(routeB, completion: completionB)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
             expectationB.fulfill()
@@ -1317,7 +1318,7 @@ class TreeRouterTests: XCTestCase {
         let expectationB = self.expectation(description: "TreeRouter.route")
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
-        testHandler.didCallHandle = { (url, parameters, queryItems) in
+        let completionA: (HandledRoute) -> Void = { url, parameters, queryItems in
             XCTAssertEqual(url, routeA)
             XCTAssertEqual(parameters, [:])
             XCTAssertEqual(queryItems, [])
@@ -1331,13 +1332,13 @@ class TreeRouterTests: XCTestCase {
         }
 
         do {
-            try router.route(routeA)
+            try router.route(routeA, completion: completionA)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
             expectationA.fulfill()
         }
 
-        testHandler.didCallHandle = { (url, parameters, queryItems) in
+        let completionB: (HandledRoute) -> Void = { url, parameters, queryItems in
             XCTAssertEqual(url, routeB)
             XCTAssertEqual(parameters, [:])
             XCTAssertEqual(queryItems, [])
@@ -1345,7 +1346,7 @@ class TreeRouterTests: XCTestCase {
         }
 
         do {
-            try router.route(routeB)
+            try router.route(routeB, completion: completionB)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
             expectationB.fulfill()
@@ -1369,7 +1370,7 @@ class TreeRouterTests: XCTestCase {
         let expectationB = self.expectation(description: "TreeRouter.route")
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
-        testHandler.didCallHandle = { (url, parameters, queryItems) in
+        let completionA: (HandledRoute) -> Void = { url, parameters, queryItems in
             XCTAssertEqual(url, routeA)
             XCTAssertEqual(parameters, [parameterA.description : parameterValueA,
                                         parameterB.description : parameterValueB])
@@ -1384,13 +1385,13 @@ class TreeRouterTests: XCTestCase {
         }
 
         do {
-            try router.route(routeA)
+            try router.route(routeA, completion: completionA)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
             expectationA.fulfill()
         }
 
-        testHandler.didCallHandle = { (url, parameters, queryItems) in
+        let completionB: (HandledRoute) -> Void = { url, parameters, queryItems in
             XCTAssertEqual(url, routeB)
             XCTAssertEqual(parameters, [parameterA.description : parameterValueA,
                                         parameterB.description : parameterValueB])
@@ -1399,7 +1400,7 @@ class TreeRouterTests: XCTestCase {
         }
 
         do {
-            try router.route(routeB)
+            try router.route(routeB, completion: completionB)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
             expectationB.fulfill()
@@ -1417,7 +1418,7 @@ class TreeRouterTests: XCTestCase {
         let expectationB = self.expectation(description: "TreeRouter.route")
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
-        testHandler.didCallHandle = { (url, parameters, queryItems) in
+        let completionA: (HandledRoute) -> Void = { url, parameters, queryItems in
             XCTAssertEqual(url, routeA)
             XCTAssertEqual(parameters, [:])
             XCTAssertEqual(queryItems, [])
@@ -1431,13 +1432,13 @@ class TreeRouterTests: XCTestCase {
         }
 
         do {
-            try router.route(routeA)
+            try router.route(routeA, completion: completionA)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
             expectationA.fulfill()
         }
 
-        testHandler.didCallHandle = { (url, parameters, queryItems) in
+        let completionB: (HandledRoute) -> Void = { url, parameters, queryItems in
             XCTAssertEqual(url, routeB)
             XCTAssertEqual(parameters, [:])
             XCTAssertEqual(queryItems, [])
@@ -1445,7 +1446,7 @@ class TreeRouterTests: XCTestCase {
         }
 
         do {
-            try router.route(routeB)
+            try router.route(routeB, completion: completionB)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
             expectationB.fulfill()
@@ -1471,7 +1472,7 @@ class TreeRouterTests: XCTestCase {
         let expectationB = self.expectation(description: "TreeRouter.route")
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
-        testHandler.didCallHandle = { (url, parameters, queryItems) in
+        let completionA: (HandledRoute) -> Void = { url, parameters, queryItems in
             XCTAssertEqual(url, routeA)
             XCTAssertEqual(parameters, [:])
             XCTAssertEqual(queryItems, testQueryItems)
@@ -1485,13 +1486,13 @@ class TreeRouterTests: XCTestCase {
         }
 
         do {
-            try router.route(routeA)
+            try router.route(routeA, completion: completionA)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
             expectationA.fulfill()
         }
 
-        testHandler.didCallHandle = { (url, parameters, queryItems) in
+        let completionB: (HandledRoute) -> Void = { url, parameters, queryItems in
             XCTAssertEqual(url, routeB)
             XCTAssertEqual(parameters, [:])
             XCTAssertEqual(queryItems, testQueryItems)
@@ -1499,7 +1500,7 @@ class TreeRouterTests: XCTestCase {
         }
 
         do {
-            try router.route(routeB)
+            try router.route(routeB, completion: completionB)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
             expectationB.fulfill()

--- a/Tests/AlicerceTests/Logging/ConsoleLogDestinationTests.swift
+++ b/Tests/AlicerceTests/Logging/ConsoleLogDestinationTests.swift
@@ -11,8 +11,8 @@ import XCTest
 
 class ConsoleLogDestinationsTests: XCTestCase {
 
-    fileprivate let log = Log()
-    fileprivate let queue = Log.Queue(label: "ConsoleLogDestinationsTests")
+    fileprivate var log: Log!
+    fileprivate var queue: Log.Queue!
     fileprivate let expectationTimeout: TimeInterval = 5
     fileprivate let expectationHandler: XCWaitCompletionHandler = { error in
         if let error = error {
@@ -20,22 +20,25 @@ class ConsoleLogDestinationsTests: XCTestCase {
         }
     }
 
+    override func setUp() {
+        super.setUp()
+
+        log = Log(qos: .default)
+        queue = Log.Queue(label: "ConsoleLogDestinationsTests")
+    }
+
     override func tearDown() {
+        log = nil
+        queue = nil
+
         super.tearDown()
-        log.removeAllDestinations()
     }
 
     func testConsoleLogDestination() {
 
         // preparation of the test subject
 
-        let destination = Log.ConsoleLogDestination(minLevel: .verbose,
-                                                    queue: queue)
-
-        // preparation of the test expectations
-
-        let expectation = self.expectation(description: "testConsoleLogDestination")
-        defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
+        let destination = Log.ConsoleLogDestination(minLevel: .verbose, queue: queue)
 
         // execute test
 
@@ -46,9 +49,8 @@ class ConsoleLogDestinationsTests: XCTestCase {
         log.warning("warning message")
         log.error("error message")
 
-        queue.dispatchQueue.async {
+        queue.dispatchQueue.sync {
             XCTAssertEqual(destination.writtenItems, 5)
-            expectation.fulfill()
         }
     }
 }

--- a/Tests/AlicerceTests/Logging/JSONLogItemFormatterTests.swift
+++ b/Tests/AlicerceTests/Logging/JSONLogItemFormatterTests.swift
@@ -11,8 +11,8 @@ import XCTest
 
 class JSONLogItemFormatterTests: XCTestCase {
 
-    fileprivate let log = Log()
-    fileprivate let queue = Log.Queue(label: "JSONLogItemFormatterTests")
+    fileprivate var log: Log!
+    fileprivate var queue: Log.Queue!
     fileprivate let expectationTimeout: TimeInterval = 5
     fileprivate let expectationHandler: XCWaitCompletionHandler = { error in
         if let error = error {
@@ -20,9 +20,18 @@ class JSONLogItemFormatterTests: XCTestCase {
         }
     }
 
+    override func setUp() {
+        super.setUp()
+
+        log = Log(qos: .default)
+        queue = Log.Queue(label: "JSONLogItemFormatterTests")
+    }
+
     override func tearDown() {
+        log = nil
+        queue = nil
+
         super.tearDown()
-        log.removeAllDestinations()
     }
 
     func testLogItemJSONFormatter() {
@@ -34,11 +43,6 @@ class JSONLogItemFormatterTests: XCTestCase {
                                                    queue: queue)
         destination.linefeed = ","
 
-        // preparation of the test expectations
-
-        let expectation = self.expectation(description: "testErrorLoggingLevels")
-        defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
-
         // execute test
 
         log.register(destination)
@@ -48,7 +52,7 @@ class JSONLogItemFormatterTests: XCTestCase {
         log.warning("warning message")
         log.error("error message")
 
-        queue.dispatchQueue.async {
+        queue.dispatchQueue.sync {
 
             let jsonString = "[\(destination.output)]"
             let jsonData = jsonString.data(using: .utf8)
@@ -71,8 +75,6 @@ class JSONLogItemFormatterTests: XCTestCase {
             catch {
                 XCTFail()
             }
-
-            expectation.fulfill()
         }
     }
 }

--- a/Tests/AlicerceTests/Logging/LogTests.swift
+++ b/Tests/AlicerceTests/Logging/LogTests.swift
@@ -11,8 +11,8 @@ import XCTest
 
 class LogTests: XCTestCase {
 
-    fileprivate let log = Log()
-    fileprivate let queue = Log.Queue(label: "LogTests")
+    fileprivate var log: Log!
+    fileprivate var queue: Log.Queue!
     fileprivate let expectationTimeout: TimeInterval = 5
     fileprivate let expectationHandler: XCWaitCompletionHandler = { error in
         if let error = error {
@@ -20,9 +20,18 @@ class LogTests: XCTestCase {
         }
     }
 
+    override func setUp() {
+        super.setUp()
+
+        log = Log(qos: .default)
+        queue = Log.Queue(label: "LogTests")
+    }
+
     override func tearDown() {
+        log = nil
+        queue = nil
+
         super.tearDown()
-        log.removeAllDestinations()
     }
 
     func testDestinationManagement() {
@@ -57,11 +66,6 @@ class LogTests: XCTestCase {
                                                    formatter: formatter,
                                                    queue: queue)
 
-        // preparation of the test expectations
-
-        let expectation = self.expectation(description: "testErrorLoggingLevels")
-        defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
-
         // execute test
 
         log.register(destination)
@@ -71,11 +75,10 @@ class LogTests: XCTestCase {
         log.warning("warning message")
         log.error("error message")
 
-        queue.dispatchQueue.async {
+        queue.dispatchQueue.sync {
             let expected = "error message"
             XCTAssertEqual(destination.output, expected)
             XCTAssertEqual(destination.writtenItems, 1)
-            expectation.fulfill()
         }
     }
 
@@ -88,11 +91,6 @@ class LogTests: XCTestCase {
                                                    formatter: formatter,
                                                    queue: queue)
 
-        // preparation of the test expectations
-
-        let expectation = self.expectation(description: "testWarningLoggingLevels")
-        defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
-
         // execute test
 
         log.register(destination)
@@ -102,11 +100,10 @@ class LogTests: XCTestCase {
         log.warning("warning message")
         log.error("error message")
 
-        queue.dispatchQueue.async {
+        queue.dispatchQueue.sync {
             let expected = "warning message\nerror message"
             XCTAssertEqual(destination.output, expected)
             XCTAssertEqual(destination.writtenItems, 2)
-            expectation.fulfill()
         }
     }
 
@@ -117,11 +114,6 @@ class LogTests: XCTestCase {
                                                    formatter: formatter,
                                                    queue: queue)
 
-        // preparation of the test expectations
-
-        let expectation = self.expectation(description: "testInfoLoggingLevels")
-        defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
-
         // execute test
 
         log.register(destination)
@@ -131,11 +123,10 @@ class LogTests: XCTestCase {
         log.warning("warning message")
         log.error("error message")
 
-        queue.dispatchQueue.async {
+        queue.dispatchQueue.sync {
             let expected = "info message\nwarning message\nerror message"
             XCTAssertEqual(destination.output, expected)
             XCTAssertEqual(destination.writtenItems, 3)
-            expectation.fulfill()
         }
     }
 
@@ -146,11 +137,6 @@ class LogTests: XCTestCase {
                                                    formatter: formatter,
                                                    queue: queue)
 
-        // preparation of the test expectations
-
-        let expectation = self.expectation(description: "testDebugLoggingLevels")
-        defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
-
         // execute test
 
         log.register(destination)
@@ -160,11 +146,10 @@ class LogTests: XCTestCase {
         log.warning("warning message")
         log.error("error message")
 
-        queue.dispatchQueue.async {
+        queue.dispatchQueue.sync {
             let expected = "debug message\ninfo message\nwarning message\nerror message"
             XCTAssertEqual(destination.output, expected)
             XCTAssertEqual(destination.writtenItems, 4)
-            expectation.fulfill()
         }
     }
 
@@ -175,11 +160,6 @@ class LogTests: XCTestCase {
                                                    formatter: formatter,
                                                    queue: queue)
 
-        // preparation of the test expectations
-
-        let expectation = self.expectation(description: "testVerboseLoggingLevels")
-        defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
-
         // execute test
 
         log.register(destination)
@@ -189,11 +169,10 @@ class LogTests: XCTestCase {
         log.warning("warning message")
         log.error("error message")
 
-        queue.dispatchQueue.async {
+        queue.dispatchQueue.sync {
             let expected = "verbose message\ndebug message\ninfo message\nwarning message\nerror message"
             XCTAssertEqual(destination.output, expected)
             XCTAssertEqual(destination.writtenItems, 5)
-            expectation.fulfill()
         }
     }
 }

--- a/Tests/AlicerceTests/Logging/NodeLogDestinationTests.swift
+++ b/Tests/AlicerceTests/Logging/NodeLogDestinationTests.swift
@@ -45,8 +45,8 @@ class NodeLogDestinationTests: XCTestCase {
         }
     }
 
-    fileprivate let log = Log()
-    fileprivate let queue = Log.Queue(label: "NodeLogDestinationTests")
+    fileprivate var log: Log!
+    fileprivate var queue: Log.Queue!
     fileprivate let expectationTimeout: TimeInterval = 5
     fileprivate let expectationHandler: XCWaitCompletionHandler = { error in
         if let error = error {
@@ -54,10 +54,18 @@ class NodeLogDestinationTests: XCTestCase {
         }
     }
 
+    override func setUp() {
+        super.setUp()
+
+        log = Log(qos: .default)
+        queue = Log.Queue(label: "NodeLogDestinationTests")
+    }
+
     override func tearDown() {
+        log = nil
+        queue = nil
+
         super.tearDown()
-        log.errorClosure = nil
-        log.removeAllDestinations()
     }
 
     func testNodeLogHappyPath() {

--- a/Tests/AlicerceTests/Logging/StringLogItemFormatterTests.swift
+++ b/Tests/AlicerceTests/Logging/StringLogItemFormatterTests.swift
@@ -11,8 +11,8 @@ import XCTest
 
 class StringLogItemFormatterTests: XCTestCase {
 
-    fileprivate let log = Log()
-    fileprivate let queue = Log.Queue(label: "StringLogItemFormatterTests")
+    fileprivate var log: Log!
+    fileprivate var queue: Log.Queue!
     fileprivate let expectationTimeout: TimeInterval = 5
     fileprivate let expectationHandler: XCWaitCompletionHandler = { error in
         if let error = error {
@@ -20,9 +20,18 @@ class StringLogItemFormatterTests: XCTestCase {
         }
     }
 
+    override func setUp() {
+        super.setUp()
+
+        log = Log(qos: .default)
+        queue = Log.Queue(label: "StringLogItemFormatterTests")
+    }
+
     override func tearDown() {
+        log = nil
+        queue = nil
+
         super.tearDown()
-        log.removeAllDestinations()
     }
 
     func testDateFormatterCurrentTimeZone() {
@@ -33,17 +42,12 @@ class StringLogItemFormatterTests: XCTestCase {
                                                    formatter: formatter,
                                                    queue: queue)
 
-        // preparation of the test expectations
-
-        let expectation = self.expectation(description: "testDateFormatterCurrentTimeZone")
-        defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
-
         // execute test
 
         log.register(destination)
         log.verbose("verbose message")
 
-        queue.dispatchQueue.async {
+        queue.dispatchQueue.sync {
 
             let dateFormatter = DateFormatter()
             dateFormatter.dateFormat = dateFormat
@@ -51,7 +55,6 @@ class StringLogItemFormatterTests: XCTestCase {
 
             XCTAssertEqual(destination.writtenItems, 1)
             XCTAssertEqual(destination.output, expected)
-            expectation.fulfill()
         }
     }
 }

--- a/Tests/AlicerceTests/Network/MockNetworkStack.swift
+++ b/Tests/AlicerceTests/Network/MockNetworkStack.swift
@@ -24,19 +24,21 @@ final class MockNetworkStack: NetworkStack {
     var mockError: Network.Error?
     var mockCancelable: MockNetworkCancelable = MockNetworkCancelable()
 
+    let queue: DispatchQueue
+
     var beforeFetchCompletionClosure: (() -> Void)?
     var afterFetchCompletionClosure: (() -> Void)?
 
-    init(mockData: Data?, mockError: Network.Error?) {
+    init(mockData: Data?, mockError: Network.Error?, queue: DispatchQueue = DispatchQueue.global()) {
         precondition(mockData != nil || mockError != nil)
 
         self.mockData = mockData
         self.mockError = mockError
+        self.queue = queue
     }
 
     func fetch<R: NetworkResource>(resource: R, _ completion: @escaping Network.CompletionClosure) -> Cancelable {
-        DispatchQueue.global(qos: .default).async {
-
+        queue.async {
             self.beforeFetchCompletionClosure?()
 
             if let error = self.mockError {

--- a/Tests/AlicerceTests/Stores/StoreTestCase.swift
+++ b/Tests/AlicerceTests/Stores/StoreTestCase.swift
@@ -206,6 +206,10 @@ class StoreTestCase: XCTestCase {
             expectation2.fulfill()
         }
 
+        // force fetch to wait for the beforeFetchCompletionClosure to be set
+        let semaphore = DispatchSemaphore(value: 0)
+        networkStack.queue.async(flags: .barrier) { semaphore.wait() }
+
         let cancelable = store.fetch(resource: testResource) { (value, error, isCached) in
             XCTAssertNil(value)
             XCTAssertFalse(isCached)
@@ -225,6 +229,8 @@ class StoreTestCase: XCTestCase {
         networkStack.beforeFetchCompletionClosure = {
             cancelable.cancel()
         }
+
+        semaphore.signal()
     }
 
     func testFetchCancel_BeforePersist_ShouldFailWithCancelledError() {
@@ -248,6 +254,10 @@ class StoreTestCase: XCTestCase {
             expectation2.fulfill()
         }
 
+        // force fetch to wait for the cancelClosure to be set
+        let semaphore = DispatchSemaphore(value: 0)
+        networkStack.queue.async(flags: .barrier) { semaphore.wait() }
+
         let cancelable = store.fetch(resource: cancellingParseResource) { (value, error, isCached) in
             XCTAssertNil(value)
             XCTAssertFalse(isCached)
@@ -267,6 +277,8 @@ class StoreTestCase: XCTestCase {
         cancelClosure = {
             cancelable.cancel()
         }
+
+        semaphore.signal()
     }
 
     // MARK: Success


### PR DESCRIPTION
For some use cases, it is handy to know when a route has effectively
been handled by its `RouteHandler`, instead of losing track of the
execution flow and simply delegating the handling logic.

To address this, a new optional completion closure parameter of type
`((T) -> Void)?` was added to `RouteHandler`'s and `TreeRouter`'s
`handle` methods. Consequently, `RouteHandler` gained a new associated
type `T`, and `TreeRouter` a new generic constraint.

Using a generic type seemed like a nice balance because not only is
completion signaled to the `route` method caller, but the flexibility
to return a custom payload is also provided. This allows the Routing
infrastructure to be used in even more scenarios.

Fixed some synchronization issues on Logging tests and 
`StoreTestCase` which were breaking Travis builds.