### PR TITLE
JSON date parse helper 📅 ⏰

### DIFF
--- a/Sources/Network/JSON.swift
+++ b/Sources/Network/JSON.swift
@@ -321,7 +321,11 @@ public enum JSON {
 
         let jsonValue: T = try parseValue(rawValue: rawValue, key: key, json: json, parseAPIError: parseAPIError)
 
-        return formatter(jsonValue)
+        guard let date = formatter(jsonValue) else {
+            throw Error.unexpectedAttributeValue(key, json: json)
+        }
+
+        return date
     }
 
     // MARK: - Private methods

--- a/Sources/Network/JSON.swift
+++ b/Sources/Network/JSON.swift
@@ -264,6 +264,62 @@ public enum JSON {
         return try parseOptionalRawRepresentableAttribute(T.self, key: key, json: json, parseAPIError: parseAPIError)
     }
 
+
+    /// Parse an attribute of type `T` with the given key on the given JSON dictionary, trying to convert it to a date,
+    /// using the provided formatter which receives a `T` and returns a Date or nil if it fails.
+    /// An exception is thrown if the formatter is unable to convert the provided value into Date.
+    /// Additionally, an optional `parseAPIError` closure can be supplied so that if a parsing step fails
+    /// an attempt is made to extract a domain specific error and throw it.
+    ///
+    /// - Parameters:
+    ///   - key: The JSON attribute key to parse.
+    ///   - json: The JSON dictionary.
+    ///   - formatter: The formatter to convert the parsed type into Date.
+    ///   - parseAPIError: The API error parsing closure.
+    /// - Returns: The Date obtained from the formatter.
+    /// - Throws: An error of type `JSON.Error`, or a domain specific `Swift.Error` produced by `parseAPIError`.
+    public static func parseDateAttribute<T>(key: JSON.AttributeKey,
+                                             json: JSON.Dictionary,
+                                             formatter: (T) -> Date?,
+                                             parseAPIError: ParseAPIErrorClosure? = nil) throws -> Date {
+
+        guard let parsedDate = try parseOptionalDateAttribute(key: key,
+                                                          json: json,
+                                                          formatter: formatter,
+                                                          parseAPIError: parseAPIError) else {
+            throw Error.unexpectedAttributeValue(key, json: json)
+        }
+
+        return parsedDate
+    }
+
+
+    /// Parse an attribute of type `T` with the given key on the given JSON dictionary, trying to convert it to a date,
+    /// using the provided formatter which receives a `T` and returns a Date or nil if it fails.
+    /// Additionally, an optional `parseAPIError` closure can be supplied so that if a parsing step fails
+    /// an attempt is made to extract a domain specific error and throw it.
+    ///
+    /// - Parameters:
+    ///   - key: The JSON attribute key to parse.
+    ///   - json: The JSON dictionary.
+    ///   - formatter: The formatter to convert the parsed type into Date.
+    ///   - parseAPIError: The API error parsing closure.
+    /// - Returns: The Date obtained from the formatter or nil.
+    /// - Throws: An error of type `JSON.Error`, or a domain specific `Swift.Error` produced by `parseAPIError`.
+    public static func parseOptionalDateAttribute<T>(key: JSON.AttributeKey,
+                                                     json: JSON.Dictionary,
+                                                     formatter: (T) -> Date?,
+                                                     parseAPIError: ParseAPIErrorClosure? = nil) throws -> Date? {
+
+        guard let rawValue = json[key] else {
+            throw parseAPIError?(json) ?? Error.missingAttribute(key, json: json)
+        }
+
+        let jsonValue: T = try parseValue(rawValue: rawValue, key: key, json: json, parseAPIError: parseAPIError)
+
+        return formatter(jsonValue)
+    }
+
     // MARK: - Private methods
 
     /// Parse the given raw data into a type `T`.

--- a/Tests/AlicerceTests/Network/JSONTests.swift
+++ b/Tests/AlicerceTests/Network/JSONTests.swift
@@ -1613,6 +1613,73 @@ class JSONTests: XCTestCase {
         }
     }
 
+    func testParseOptionalDateAttribute_WithValidIntegerInferredFromFormatter_ShouldReturnAValidDate() {
+
+        let testDate = Date()
+
+        let json = [
+            "testDate" : testDate.timeIntervalSince1970
+        ]
+
+        do {
+            let date = try JSON.parseOptionalDateAttribute("testDate",
+                                                           json: json,
+                                                           formatter: Date.init(timeIntervalSince1970:))
+
+            XCTAssertNotNil(date)
+            XCTAssertEqual(date?.timeIntervalSince1970, testDate.timeIntervalSince1970)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)")
+        }
+    }
+
+    func testParseOptionalDateAttribute_WithValidStringInferredFromFormatter_ShouldReturnAValidDate() {
+
+        let dateFormatter: DateFormatter = {
+            $0.dateFormat = "yyyy-MM-dd"
+            return $0
+        }(DateFormatter())
+
+        let testDateString = dateFormatter.string(from: Date())
+
+        let json = [
+            "testDate" : testDateString
+        ]
+
+        let testDate = dateFormatter.date(from: testDateString)!
+
+        do {
+            let date = try JSON.parseOptionalDateAttribute("testDate", json: json, formatter: dateFormatter.date)
+
+            XCTAssertNotNil(date)
+            XCTAssertEqual(testDate, date)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)")
+        }
+    }
+
+    func testParseOptionalDateAttribute_WithInvalidStringForFormatter_ShouldFailWithUnexpectedAttributeValue() {
+
+        let dateFormatter: DateFormatter = {
+            $0.dateFormat = "yyyy-MM-dd"
+            return $0
+        }(DateFormatter())
+
+        let json = [
+            "testDate" : "🤷‍♂️"
+        ]
+
+        do {
+            let _ = try JSON.parseOptionalDateAttribute("testDate", json: json, formatter: dateFormatter.date)
+
+            XCTFail("🔥: unexpected success!")
+        } catch let JSON.Error.unexpectedAttributeValue(key, json: _) {
+            XCTAssertEqual(key, "testDate")
+        } catch {
+            XCTFail("🔥: unexpected error \(error)")
+        }
+    }
+
     // MARK: - Auxiliary
 
     private func assertEqualJSONDictionaries(_ lhs: JSON.Dictionary, _ rhs: JSON.Dictionary) {

--- a/Tests/AlicerceTests/Network/JSONTests.swift
+++ b/Tests/AlicerceTests/Network/JSONTests.swift
@@ -1531,6 +1531,121 @@ class JSONTests: XCTestCase {
         }
     }
 
+    func testParseDateAttribute_WithValidIntegerInferredFromFormatter_ShouldReturnAValidDate() {
+
+        let testDate = Date()
+
+        let json = [
+            "testDate" : testDate.timeIntervalSince1970
+        ]
+
+        do {
+            let date = try JSON.parseDateAttribute(key: "testDate",
+                                                   json: json,
+                                                   formatter: Date.init(timeIntervalSince1970:))
+
+            XCTAssertEqual(testDate, date)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)")
+        }
+    }
+
+    func testParseDateAttribute_WithValidStringInferredFromFormatter_ShouldReturnAValidDate() {
+
+        let testDate = Date()
+        let dateFormatter: DateFormatter = {
+            $0.dateFormat = "yyyy-MM-dd"
+            return $0
+        }(DateFormatter())
+
+        let json = [
+            "testDate" : dateFormatter.string(from: testDate)
+        ]
+
+        do {
+            let date = try JSON.parseDateAttribute(key: "testDate", json: json, formatter: dateFormatter.date)
+
+            XCTAssertEqual(testDate, date)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)")
+        }
+    }
+
+    func testParseDateAttribute_WithInvalidInteger_ShouldFailWithUnexpectedAttributeValue() {
+
+        let json = [
+            "testDate" : 1531
+        ]
+
+        do {
+            let _ = try JSON.parseDateAttribute(key: "testDate",
+                                                   json: json,
+                                                   formatter: Date.init(timeIntervalSince1970:))
+
+            XCTFail("🔥: unexpected success!")
+        } catch let JSON.Error.unexpectedAttributeValue(key, json: _) {
+            XCTAssertEqual(key, "testDate")
+        } catch {
+            XCTFail("🔥: unexpected error \(error)")
+        }
+    }
+
+    func testParseDateAttribute_WithInvalidStringForFormatter_ShouldFailWithUnexpectedAttributeValue() {
+
+        let dateFormatter: DateFormatter = {
+            $0.dateFormat = "yyyy-MM-dd"
+            return $0
+        }(DateFormatter())
+
+        let json = [
+            "testDate" : "🤷‍♂️"
+        ]
+
+        do {
+            let _ = try JSON.parseDateAttribute(key: "testDate", json: json, formatter: dateFormatter.date)
+
+            XCTFail("🔥: unexpected success!")
+        } catch let JSON.Error.unexpectedAttributeValue(key, json: _) {
+            XCTAssertEqual(key, "testDate")
+        } catch {
+            XCTFail("🔥: unexpected error \(error)")
+        }
+    }
+
+    func testParseOptionalDateAttribute_WithUnexistingKey_ShouldReturnNil() {
+
+        let json = [
+            "ups" : "🤷‍♂️"
+        ]
+
+        do {
+            let date = try JSON.parseOptionalDateAttribute(key: "testDate",
+                                                           json: json,
+                                                           formatter: Date.init(timeIntervalSince1970:))
+
+            XCTAssertNil(date)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)")
+        }
+    }
+
+    func testParseOptionalDateAttribute_WithInvalidIntegerInferredFromFormatter_ShouldReturnNil() {
+
+        let json = [
+            "testDate" : 1513
+        ]
+
+        do {
+            let date = try JSON.parseOptionalDateAttribute(key: "testDate",
+                                                           json: json,
+                                                           formatter: Date.init(timeIntervalSince1970:))
+
+            XCTAssertNil(date)
+        } catch {
+            XCTFail("🔥: unexpected error \(error)")
+        }
+    }
+
     // MARK: - Auxiliary
 
     private func assertEqualJSONDictionaries(_ lhs: JSON.Dictionary, _ rhs: JSON.Dictionary) {

--- a/Tests/AlicerceTests/Network/JSONTests.swift
+++ b/Tests/AlicerceTests/Network/JSONTests.swift
@@ -1540,11 +1540,11 @@ class JSONTests: XCTestCase {
         ]
 
         do {
-            let date = try JSON.parseDateAttribute(key: "testDate",
+            let date = try JSON.parseDateAttribute("testDate",
                                                    json: json,
                                                    formatter: Date.init(timeIntervalSince1970:))
 
-            XCTAssertEqual(testDate, date)
+            XCTAssertEqual(date.timeIntervalSince1970, testDate.timeIntervalSince1970)
         } catch {
             XCTFail("🔥: unexpected error \(error)")
         }
@@ -1552,39 +1552,23 @@ class JSONTests: XCTestCase {
 
     func testParseDateAttribute_WithValidStringInferredFromFormatter_ShouldReturnAValidDate() {
 
-        let testDate = Date()
         let dateFormatter: DateFormatter = {
             $0.dateFormat = "yyyy-MM-dd"
             return $0
         }(DateFormatter())
 
+        let testDateString = dateFormatter.string(from: Date())
+
         let json = [
-            "testDate" : dateFormatter.string(from: testDate)
+            "testDate" : testDateString
         ]
 
+        let testDate = dateFormatter.date(from: testDateString)!
+
         do {
-            let date = try JSON.parseDateAttribute(key: "testDate", json: json, formatter: dateFormatter.date)
+            let date = try JSON.parseDateAttribute("testDate", json: json, formatter: dateFormatter.date)
 
             XCTAssertEqual(testDate, date)
-        } catch {
-            XCTFail("🔥: unexpected error \(error)")
-        }
-    }
-
-    func testParseDateAttribute_WithInvalidInteger_ShouldFailWithUnexpectedAttributeValue() {
-
-        let json = [
-            "testDate" : 1531
-        ]
-
-        do {
-            let _ = try JSON.parseDateAttribute(key: "testDate",
-                                                   json: json,
-                                                   formatter: Date.init(timeIntervalSince1970:))
-
-            XCTFail("🔥: unexpected success!")
-        } catch let JSON.Error.unexpectedAttributeValue(key, json: _) {
-            XCTAssertEqual(key, "testDate")
         } catch {
             XCTFail("🔥: unexpected error \(error)")
         }
@@ -1602,7 +1586,7 @@ class JSONTests: XCTestCase {
         ]
 
         do {
-            let _ = try JSON.parseDateAttribute(key: "testDate", json: json, formatter: dateFormatter.date)
+            let _ = try JSON.parseDateAttribute("testDate", json: json, formatter: dateFormatter.date)
 
             XCTFail("🔥: unexpected success!")
         } catch let JSON.Error.unexpectedAttributeValue(key, json: _) {
@@ -1619,24 +1603,7 @@ class JSONTests: XCTestCase {
         ]
 
         do {
-            let date = try JSON.parseOptionalDateAttribute(key: "testDate",
-                                                           json: json,
-                                                           formatter: Date.init(timeIntervalSince1970:))
-
-            XCTAssertNil(date)
-        } catch {
-            XCTFail("🔥: unexpected error \(error)")
-        }
-    }
-
-    func testParseOptionalDateAttribute_WithInvalidIntegerInferredFromFormatter_ShouldReturnNil() {
-
-        let json = [
-            "testDate" : 1513
-        ]
-
-        do {
-            let date = try JSON.parseOptionalDateAttribute(key: "testDate",
+            let date = try JSON.parseOptionalDateAttribute("testDate",
                                                            json: json,
                                                            formatter: Date.init(timeIntervalSince1970:))
 

--- a/Tests/AlicerceTests/Network/JSONTests.swift
+++ b/Tests/AlicerceTests/Network/JSONTests.swift
@@ -1627,7 +1627,7 @@ class JSONTests: XCTestCase {
                                                            formatter: Date.init(timeIntervalSince1970:))
 
             XCTAssertNotNil(date)
-            XCTAssertEqual(date?.timeIntervalSince1970, testDate.timeIntervalSince1970)
+            XCTAssertEqual(date!, testDate)
         } catch {
             XCTFail("🔥: unexpected error \(error)")
         }


### PR DESCRIPTION
Created helpers to parse and format a date from a JSON

Type on JSON is inferred from the formatter closure input type.

There is also an Optional version of the API.