### PR TITLE
Add helper methods and fix some NIB related code

### DIFF
--- a/Sources/View/NibView.swift
+++ b/Sources/View/NibView.swift
@@ -16,8 +16,8 @@ public extension NibView where Self: UIView {
 
     static var nib: UINib {
 
-        let bundle = Bundle(for: Self.self)
-        let nibName = String(describing: Self.self)
+        let bundle = Bundle(for: self)
+        let nibName = "\(self)"
         let nib = UINib(nibName: nibName, bundle: bundle)
 
         return nib

--- a/Sources/View/ReusableView.swift
+++ b/Sources/View/ReusableView.swift
@@ -25,9 +25,19 @@ public extension UICollectionView {
         register(cellType, forCellWithReuseIdentifier: cellType.reuseIdentifier)
     }
 
+    func register<T: UICollectionViewCell>(_ cellType: T.Type)
+    where T: ReusableView, T: NibView {
+        register(cellType.nib, forCellWithReuseIdentifier: cellType.reuseIdentifier)
+    }
+
     func register<T: UICollectionReusableView>(_ viewType: T.Type, forSupplementaryViewOfKind kind: String)
     where T: ReusableView {
         register(viewType, forSupplementaryViewOfKind: kind, withReuseIdentifier: viewType.reuseIdentifier)
+    }
+
+    func register<T: UICollectionReusableView>(_ viewType: T.Type, forSupplementaryViewOfKind kind: String)
+    where T: ReusableView, T: NibView {
+        register(viewType.nib, forSupplementaryViewOfKind: kind, withReuseIdentifier: viewType.reuseIdentifier)
     }
 
     func dequeueCell<T: UICollectionViewCell>(`for` indexPath: IndexPath) -> T
@@ -97,9 +107,19 @@ public extension UITableView {
         register(cellType, forCellReuseIdentifier: cellType.reuseIdentifier)
     }
 
+    func register<T: UITableViewCell>(_ cellType: T.Type)
+    where T: ReusableView, T: NibView {
+        register(cellType.nib, forCellReuseIdentifier: cellType.reuseIdentifier)
+    }
+
     func registerHeaderFooterView<T: UITableViewCell>(_ viewType: T.Type)
     where T: ReusableView {
         register(viewType, forHeaderFooterViewReuseIdentifier: T.reuseIdentifier)
+    }
+
+    func registerHeaderFooterView<T: UITableViewCell>(_ viewType: T.Type)
+    where T: ReusableView, T: NibView {
+        register(viewType.nib, forHeaderFooterViewReuseIdentifier: T.reuseIdentifier)
     }
 
     func dequeueCell<T: UITableViewCell>(`for` indexPath: IndexPath) -> T

--- a/Sources/View/ReusableView.swift
+++ b/Sources/View/ReusableView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public protocol ReusableView: View {
+public protocol ReusableView {
     static var reuseIdentifier: String { get }
 }
 


### PR DESCRIPTION
Fix `NibView` extension so that the `nib` property correctly return the `UINib` instance of the view with the same name

The protocol `ReusableView` don't need to implement the protocol `View`.
For example, if the view is implemented using Interface Builder all subviews and constraints are setted in IB. No need to implement `setUpSubviews()` and `setUpConstraints()`. However this view should be allowed to implement the `ReusableView` protocol.

Add helper register method in `UICollectionView` and `UITableView` to register cells that are implemented in Interface Builder