### PR TITLE
Changes the analytics related initialisers to be public

### DIFF
--- a/Sources/Analytics/Analytics.swift
+++ b/Sources/Analytics/Analytics.swift
@@ -27,7 +27,7 @@ public final class Analytics {
     /// Creates an analytics instance with provided configuration
     ///
     /// - Parameter configuration: A Configuration object with QoS and extraParameters (if any)
-    init(configuration: Configuration = Configuration()) {
+    public init(configuration: Configuration = Configuration()) {
         self.trackingQueue = DispatchQueue(label: "com.mindera.alicerce.queue.analytics.tracking",
                                            qos: configuration.queueQoS)
         self.extraParameters = configuration.extraParameters

--- a/Sources/Analytics/Configuration.swift
+++ b/Sources/Analytics/Configuration.swift
@@ -19,7 +19,7 @@ public extension Analytics {
         let queueQoS: DispatchQoS
         let extraParameters: Parameters?
 
-        init(queueQoS: DispatchQoS = .default,
+        public init(queueQoS: DispatchQoS = .default,
              extraParameters: Parameters? = nil) {
             self.queueQoS = queueQoS
             self.extraParameters = extraParameters

--- a/Sources/Analytics/Configuration.swift
+++ b/Sources/Analytics/Configuration.swift
@@ -20,7 +20,7 @@ public extension Analytics {
         let extraParameters: Parameters?
 
         public init(queueQoS: DispatchQoS = .default,
-             extraParameters: Parameters? = nil) {
+                    extraParameters: Parameters? = nil) {
             self.queueQoS = queueQoS
             self.extraParameters = extraParameters
         }

--- a/Sources/Analytics/Event.swift
+++ b/Sources/Analytics/Event.swift
@@ -16,7 +16,7 @@ public extension Analytics {
         let name: String
         let parameters: Parameters?
         
-        init(name: String, parameters: Parameters? = nil) {
+        public init(name: String, parameters: Parameters? = nil) {
             self.name = name
             self.parameters = parameters
         }

--- a/Sources/Analytics/Page.swift
+++ b/Sources/Analytics/Page.swift
@@ -16,7 +16,7 @@ public extension Analytics {
         let name: String
         let parameters: Parameters?
         
-        init(name: String, parameters: Parameters? = nil) {
+        public init(name: String, parameters: Parameters? = nil) {
             self.name = name
             self.parameters = parameters
         }


### PR DESCRIPTION
Just like the title says, the Analytics related classes couldn't be used as the initialisers were `internal`. This PR changes the access level to `public`