### PR TITLE
Move tracker protocol methods to main class 😅 😇

### DIFF
--- a/Sources/PerformanceMetrics/PerformanceMetrics.swift
+++ b/Sources/PerformanceMetrics/PerformanceMetrics.swift
@@ -46,19 +46,12 @@ public final class PerformanceMetrics {
 
         return try measureBlock(end)
     }
-}
-
-extension PerformanceMetrics: PerformanceMetricsTracker {
 
     public func begin(with identifier: PerformanceMetrics.Identifier) {
-        let trackersCopy = trackers
-
-        trackersCopy.forEach { $0.begin(with: identifier) }
+        trackers.forEach { $0.begin(with: identifier) }
     }
-
+    
     public func end(with identifier: PerformanceMetrics.Identifier) {
-        let trackersCopy = trackers
-
-        trackersCopy.forEach { $0.end(with: identifier) }
+        trackers.forEach { $0.end(with: identifier) }
     }
 }


### PR DESCRIPTION
Since those methods are public API, it makes more sense to move them to the main implementation

This also enables compatibility with swift 3.2