### PR TITLE
Keyboard Observer - Enable/Disable tap multi touch

### DIFF
--- a/Sources/Observers/KeyboardObserver.swift
+++ b/Sources/Observers/KeyboardObserver.swift
@@ -13,13 +13,20 @@ public final class KeyboardObserver: NSObject {
     fileprivate var isKeyboardVisible = false
 
     private weak var window: UIWindow?
+    private let tapGestureRecognizer = UITapGestureRecognizer()
+
+    var shouldTapCancelTouches: Bool = true {
+        didSet {
+            tapGestureRecognizer.cancelsTouchesInView = shouldTapCancelTouches
+        }
+    }
 
     public init(window: UIWindow) {
         self.window = window
 
         super.init()
 
-        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(didTapView))
+        tapGestureRecognizer.addTarget(self, action: #selector(didTapView))
         tapGestureRecognizer.delegate = self
         self.window?.addGestureRecognizer(tapGestureRecognizer)
 

--- a/Sources/Observers/KeyboardObserver.swift
+++ b/Sources/Observers/KeyboardObserver.swift
@@ -15,18 +15,20 @@ public final class KeyboardObserver: NSObject {
     private weak var window: UIWindow?
     private weak var tapGestureRecognizer: UITapGestureRecognizer?
 
-    public var shouldTapCancelTouches: Bool = false {
+    public var shouldTapCancelTouches: Bool {
         didSet {
             tapGestureRecognizer?.cancelsTouchesInView = shouldTapCancelTouches
         }
     }
 
-    public init(window: UIWindow) {
+    public init(window: UIWindow, shouldTapCancelTouches: Bool = false) {
         self.window = window
+        self.shouldTapCancelTouches = shouldTapCancelTouches
 
         super.init()
 
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(didTapView))
+        tapGestureRecognizer.cancelsTouchesInView = shouldTapCancelTouches
         tapGestureRecognizer.delegate = self
         self.window?.addGestureRecognizer(tapGestureRecognizer)
 

--- a/Sources/Observers/KeyboardObserver.swift
+++ b/Sources/Observers/KeyboardObserver.swift
@@ -15,7 +15,7 @@ public final class KeyboardObserver: NSObject {
     private weak var window: UIWindow?
     private weak var tapGestureRecognizer: UITapGestureRecognizer?
 
-    var shouldTapCancelTouches: Bool = true {
+    public var shouldTapCancelTouches: Bool = true {
         didSet {
             tapGestureRecognizer?.cancelsTouchesInView = shouldTapCancelTouches
         }

--- a/Sources/Observers/KeyboardObserver.swift
+++ b/Sources/Observers/KeyboardObserver.swift
@@ -15,7 +15,7 @@ public final class KeyboardObserver: NSObject {
     private weak var window: UIWindow?
     private weak var tapGestureRecognizer: UITapGestureRecognizer?
 
-    public var shouldTapCancelTouches: Bool = true {
+    public var shouldTapCancelTouches: Bool = false {
         didSet {
             tapGestureRecognizer?.cancelsTouchesInView = shouldTapCancelTouches
         }

--- a/Sources/Observers/KeyboardObserver.swift
+++ b/Sources/Observers/KeyboardObserver.swift
@@ -13,11 +13,11 @@ public final class KeyboardObserver: NSObject {
     fileprivate var isKeyboardVisible = false
 
     private weak var window: UIWindow?
-    private let tapGestureRecognizer = UITapGestureRecognizer()
+    private weak var tapGestureRecognizer: UITapGestureRecognizer?
 
     var shouldTapCancelTouches: Bool = true {
         didSet {
-            tapGestureRecognizer.cancelsTouchesInView = shouldTapCancelTouches
+            tapGestureRecognizer?.cancelsTouchesInView = shouldTapCancelTouches
         }
     }
 
@@ -26,9 +26,11 @@ public final class KeyboardObserver: NSObject {
 
         super.init()
 
-        tapGestureRecognizer.addTarget(self, action: #selector(didTapView))
+        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(didTapView))
         tapGestureRecognizer.delegate = self
         self.window?.addGestureRecognizer(tapGestureRecognizer)
+
+        self.tapGestureRecognizer = tapGestureRecognizer
 
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(keyboardDidShow),
@@ -39,6 +41,12 @@ public final class KeyboardObserver: NSObject {
                                                selector: #selector(keyboardDidHide),
                                                name: .UIKeyboardDidHide,
                                                object: nil)
+    }
+
+    deinit {
+        if let tapGestureRecognizer = self.tapGestureRecognizer {
+            window?.removeGestureRecognizer(tapGestureRecognizer)
+        }
     }
 
     // MARK: - Private Methods


### PR DESCRIPTION
## Description
- Allows tap gesture on keyboard observer to be configurable in terms of allowing multi touch.