### PR TITLE
Enabling multi touch in KeyboardObserver

### DIFF
--- a/Sources/Observers/KeyboardObserver.swift
+++ b/Sources/Observers/KeyboardObserver.swift
@@ -20,6 +20,7 @@ public final class KeyboardObserver: NSObject {
         super.init()
 
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(didTapView))
+        tapGestureRecognizer.cancelsTouchesInView = false
         tapGestureRecognizer.delegate = self
         self.window?.addGestureRecognizer(tapGestureRecognizer)
 


### PR DESCRIPTION
## Description
- Disabled cancel touches in view for tap gesture recogniser in KeyboardObserver.