### PR TITLE
Send original request to `shouldRetry` ♻️

### DIFF
--- a/Sources/Network/NetworkAuthenticator.swift
+++ b/Sources/Network/NetworkAuthenticator.swift
@@ -11,7 +11,7 @@ import Foundation
 public protocol NetworkAuthenticator {
     typealias PerformRequestClosure = (_ inner: () throws -> URLRequest) -> Cancelable
 
-    func authenticate(request: URLRequest, _ performRequest: @escaping PerformRequestClosure) -> Cancelable
+    func authenticate(request: URLRequest, performRequest: @escaping PerformRequestClosure) -> Cancelable
 
-    func shouldRetry(with data: Data?, response: HTTPURLResponse?, error: Swift.Error?) -> Bool
+    func shouldRetry(request: URLRequest, data: Data?, response: HTTPURLResponse?, error: Swift.Error?) -> Bool
 }

--- a/Sources/Network/URLSessionNetworkStack.swift
+++ b/Sources/Network/URLSessionNetworkStack.swift
@@ -177,7 +177,7 @@ public extension Network {
                 }
 
                 if let authenticator = strongSelf.authenticator,
-                    authenticator.shouldRetry(with: data, response: httpResponse, error: error) {
+                    authenticator.shouldRetry(request: request, data: data, response: httpResponse, error: error) {
 
                     let retryCancelable = strongSelf.networkAuthenticator(authenticator,
                                                                           fetch: resource,

--- a/Tests/AlicerceTests/Network/URLSessionNetworkStackTestCase.swift
+++ b/Tests/AlicerceTests/Network/URLSessionNetworkStackTestCase.swift
@@ -190,7 +190,7 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
             return $0
         }
 
-        mockAuthenticator.shouldRetryClosure = { _,_,_ in
+        mockAuthenticator.shouldRetryClosure = { _, _, _, _ in
             expectation3.fulfill()
             return false
         }
@@ -226,7 +226,7 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
             return $0
         }
 
-        mockAuthenticator.shouldRetryClosure = { _, _, _ in
+        mockAuthenticator.shouldRetryClosure = { _, _, _, _ in
             expectation3.fulfill()
             return false
         }
@@ -273,7 +273,7 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
             return $0
         }
 
-        mockAuthenticator.shouldRetryClosure = { _, _, _ in
+        mockAuthenticator.shouldRetryClosure = { _, _, _, _ in
             retryCount -= 1
 
             expectation3.fulfill()
@@ -316,7 +316,7 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
             return $0
         }
 
-        mockAuthenticator.shouldRetryClosure = { _, _, _ in
+        mockAuthenticator.shouldRetryClosure = { _, _, _, _ in
             expectation3.fulfill()
             return false
         }
@@ -659,15 +659,15 @@ final class MockURLSessionDataTask: URLSessionDataTask {
 final class MockNetworkAuthenticator: NetworkAuthenticator {
 
     var authenticateClosure: ((URLRequest) throws -> URLRequest)?
-    var shouldRetryClosure: ((Data?, HTTPURLResponse?, Error?) -> Bool)?
+    var shouldRetryClosure: ((URLRequest, Data?, HTTPURLResponse?, Error?) -> Bool)?
 
     func authenticate(request: URLRequest,
-                      _ performRequest: @escaping NetworkAuthenticator.PerformRequestClosure) -> Cancelable {
+                      performRequest: @escaping NetworkAuthenticator.PerformRequestClosure) -> Cancelable {
         return performRequest { try authenticateClosure?(request) ?? request }
     }
 
-    func shouldRetry(with data: Data?, response: HTTPURLResponse?, error: Error?) -> Bool {
-        return shouldRetryClosure?(data, response, error) ?? false
+    func shouldRetry(request: URLRequest, data: Data?, response: HTTPURLResponse?, error: Error?) -> Bool {
+        return shouldRetryClosure?(request, data, response, error) ?? false
     }
 }
 


### PR DESCRIPTION
When a request fails and `NetworkAuthenticator`'s `shouldRetry` is
invoked, information about the original request can be very useful to
pass on, since it enables better decisions and optimizations.

A simple example is when multiple requests fail due to an expired
token. In this scenario, only the first should trigger a token renewal,
and the remaining ones should use the token fetched by the first
request. Using the original request data, we can accurately compare the
tokens of each request (and/or additional metadata) and check whether
the token renewal is in fact required or not.