### PR TITLE
"Publify" 🤣 Resource request builder

### DIFF
--- a/Sources/Resource/NetworkResource.swift
+++ b/Sources/Resource/NetworkResource.swift
@@ -26,7 +26,7 @@ public protocol RelativeNetworkResource: NetworkResource {
 
 extension RelativeNetworkResource {
 
-    var request: URLRequest {
+    public var request: URLRequest {
         var url = Self.baseURL
 
         if var components = URLComponents(url: url, resolvingAgainstBaseURL: false) {
@@ -55,7 +55,7 @@ public protocol StaticNetworkResource: NetworkResource {
 
 extension StaticNetworkResource {
 
-    var request: URLRequest {
+    public var request: URLRequest {
 
         var newUrl = url
 


### PR DESCRIPTION
I think we leave this internal on purpose, but if we want to create a specific Resource for certain types, like images for example, we will have the request default behaviour if we make this public.