### PR TITLE
HTTP Response 204 No Content

### DIFF
--- a/Sources/Network/Parse.swift
+++ b/Sources/Network/Parse.swift
@@ -61,6 +61,7 @@ public enum Parse {
     ///
     /// - Parameter data: Raw data
     /// - Throws: A Parse.Error that can be of type
+    ///   - `unexpectedData` if data is not empty as expected
     public static func void(data: Data) throws {
         guard data.isEmpty else {
             throw Error.unexpectedData

--- a/Sources/Network/Parse.swift
+++ b/Sources/Network/Parse.swift
@@ -13,6 +13,7 @@ public enum Parse {
     public enum Error: Swift.Error {
         case json(Swift.Error)
         case image
+        case noData
     }
 
     /// Converts raw data into a `T` object
@@ -54,5 +55,15 @@ public enum Parse {
         }
 
         return image
+    }
+
+    /// Parses empty data
+    ///
+    /// - Parameter data: Raw data
+    /// - Throws: A Parse.Error that can be of type
+    public static func void(data: Data) throws {
+        guard data.isEmpty else {
+            throw Error.noData
+        }
     }
 }

--- a/Sources/Network/Parse.swift
+++ b/Sources/Network/Parse.swift
@@ -13,7 +13,7 @@ public enum Parse {
     public enum Error: Swift.Error {
         case json(Swift.Error)
         case image
-        case noData
+        case unexpectedData
     }
 
     /// Converts raw data into a `T` object
@@ -63,7 +63,7 @@ public enum Parse {
     /// - Throws: A Parse.Error that can be of type
     public static func void(data: Data) throws {
         guard data.isEmpty else {
-            throw Error.noData
+            throw Error.unexpectedData
         }
     }
 }

--- a/Sources/Network/URLSessionNetworkStack.swift
+++ b/Sources/Network/URLSessionNetworkStack.swift
@@ -196,6 +196,8 @@ public extension Network {
                 switch (httpStatusCode, data as? R.Remote) {
                 case (.success, let remoteData?):
                     completion { remoteData }
+                case (.success(204), nil) where R.Local.self == Void.self:
+                    completion { try resource.empty() }
                 case (.success, _): 
                     completion { throw Network.Error.noData }
                 case let (statusCode, remoteData?):

--- a/Sources/Network/URLSessionNetworkStack.swift
+++ b/Sources/Network/URLSessionNetworkStack.swift
@@ -197,7 +197,7 @@ public extension Network {
                 case (.success, let remoteData?):
                     completion { remoteData }
                 case (.success(204), nil) where R.Local.self == Void.self:
-                    completion { try resource.empty() }
+                    completion { resource.empty }
                 case (.success, _): 
                     completion { throw Network.Error.noData }
                 case let (statusCode, remoteData?):

--- a/Sources/Network/URLSessionNetworkStack.swift
+++ b/Sources/Network/URLSessionNetworkStack.swift
@@ -197,7 +197,7 @@ public extension Network {
                 case (.success, let remoteData?):
                     completion { remoteData }
                 case (.success(204), nil) where R.Local.self == Void.self:
-                    completion { resource.empty }
+                    completion { R.empty }
                 case (.success, _): 
                     completion { throw Network.Error.noData }
                 case let (statusCode, remoteData?):

--- a/Sources/Resource/NetworkResource.swift
+++ b/Sources/Resource/NetworkResource.swift
@@ -11,7 +11,8 @@ import Foundation
 public protocol NetworkResource: Resource {
 
     var request: URLRequest { get }
-    var empty: Remote { get }
+
+    static var empty: Remote { get }
 }
 
 public protocol RelativeNetworkResource: NetworkResource {

--- a/Sources/Resource/NetworkResource.swift
+++ b/Sources/Resource/NetworkResource.swift
@@ -8,12 +8,10 @@
 
 import Foundation
 
-public typealias ResourceErrorParseClosure<R, E: Swift.Error> = (R) -> E?
-
 public protocol NetworkResource: Resource {
 
     var request: URLRequest { get }
-    var empty: ResourceEmptyClosure<Remote> { get }
+    var empty: Remote { get }
 }
 
 public protocol RelativeNetworkResource: NetworkResource {

--- a/Sources/Resource/NetworkResource.swift
+++ b/Sources/Resource/NetworkResource.swift
@@ -8,9 +8,12 @@
 
 import Foundation
 
+public typealias ResourceErrorParseClosure<R, E: Swift.Error> = (R) -> E?
+
 public protocol NetworkResource: Resource {
 
     var request: URLRequest { get }
+    var empty: ResourceEmptyClosure<Remote> { get }
 }
 
 public protocol RelativeNetworkResource: NetworkResource {

--- a/Sources/Resource/Resource.swift
+++ b/Sources/Resource/Resource.swift
@@ -10,7 +10,6 @@ import Foundation
 
 public typealias ResourceEmptyClosure<U> = () throws -> U
 public typealias ResourceMapClosure<U, V> = (U) throws -> V
-public typealias ResourceErrorParseClosure<R, E: Swift.Error> = (R) -> E?
 
 public protocol Resource {
     associatedtype Remote
@@ -20,5 +19,4 @@ public protocol Resource {
     var parse: ResourceMapClosure<Remote, Local> { get }
     var serialize: ResourceMapClosure<Local, Remote> { get }
     var errorParser: ResourceErrorParseClosure<Remote, Error> { get }
-    var empty: ResourceEmptyClosure<Remote> { get }
 }

--- a/Sources/Resource/Resource.swift
+++ b/Sources/Resource/Resource.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 
-public typealias ResourceEmptyClosure<U> = () throws -> U
 public typealias ResourceMapClosure<U, V> = (U) throws -> V
+public typealias ResourceErrorParseClosure<R, E: Swift.Error> = (R) -> E?
 
 public protocol Resource {
     associatedtype Remote

--- a/Sources/Resource/Resource.swift
+++ b/Sources/Resource/Resource.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+public typealias ResourceEmptyClosure<U> = () throws -> U
 public typealias ResourceMapClosure<U, V> = (U) throws -> V
 public typealias ResourceErrorParseClosure<R, E: Swift.Error> = (R) -> E?
 
@@ -19,4 +20,5 @@ public protocol Resource {
     var parse: ResourceMapClosure<Remote, Local> { get }
     var serialize: ResourceMapClosure<Local, Remote> { get }
     var errorParser: ResourceErrorParseClosure<Remote, Error> { get }
+    var empty: ResourceEmptyClosure<Remote> { get }
 }

--- a/Tests/AlicerceTests/Network/ParseTestCase.swift
+++ b/Tests/AlicerceTests/Network/ParseTestCase.swift
@@ -73,4 +73,16 @@ final class ParseTestCase: XCTestCase {
             XCTFail("🔥 received unexpected error 👉 \(error) 😱")
         }
     }
+
+    func testVoid_WhenDataIsInvalid_ItShouldThrowAUnexpectedDataError() {
+        let data = "🤓".data(using: .utf8)!
+
+        do {
+            let _ = try Parse.void(data: data)
+        } catch Parse.Error.unexpectedData {
+            // 🤠 well done sir
+        } catch {
+            XCTFail("🔥 received unexpected error 👉 \(error) 😱")
+        }
+    }
 }

--- a/Tests/AlicerceTests/Network/URLSessionNetworkStackTestCase.swift
+++ b/Tests/AlicerceTests/Network/URLSessionNetworkStackTestCase.swift
@@ -22,7 +22,7 @@ private struct URLSessionMockResource<Local, Remote, Error: Swift.Error>: Static
     let parse: ResourceMapClosure<Remote, Local>
     let serialize: ResourceMapClosure<Local, Remote>
     let errorParser: ResourceErrorParseClosure<Remote, Error>
-    let empty: ResourceEmptyClosure<Remote>
+    let empty: Remote
 }
 
 final class URLSessionNetworkStackTestCase: XCTestCase {
@@ -90,7 +90,7 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
                                parse: @escaping ResourceMapClosure<Data, Void> = { _ in () },
                                serialize: @escaping ResourceMapClosure<Void, Data> = { _ in Data() },
                                errorParser: @escaping ResourceErrorParseClosure<Data, APIError> = { _ in APIError.💥 },
-                               empty: @escaping ResourceEmptyClosure<Data> = { Data() })
+                               empty: Data = Data())
     -> URLSessionMockResource<Void, Data, APIError>  {
         return URLSessionMockResource(url: url,
                                       path: "",

--- a/Tests/AlicerceTests/Network/URLSessionNetworkStackTestCase.swift
+++ b/Tests/AlicerceTests/Network/URLSessionNetworkStackTestCase.swift
@@ -22,6 +22,7 @@ private struct URLSessionMockResource<Local, Remote, Error: Swift.Error>: Static
     let parse: ResourceMapClosure<Remote, Local>
     let serialize: ResourceMapClosure<Local, Remote>
     let errorParser: ResourceErrorParseClosure<Remote, Error>
+    let empty: ResourceEmptyClosure<Remote>
 }
 
 final class URLSessionNetworkStackTestCase: XCTestCase {
@@ -88,7 +89,8 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
     private func buildResource(url: URL = URL(string: "http://0.0.0.0")!,
                                parse: @escaping ResourceMapClosure<Data, Void> = { _ in () },
                                serialize: @escaping ResourceMapClosure<Void, Data> = { _ in Data() },
-                               errorParser: @escaping ResourceErrorParseClosure<Data, APIError> = { _ in APIError.💥 })
+                               errorParser: @escaping ResourceErrorParseClosure<Data, APIError> = { _ in APIError.💥 },
+                               empty: @escaping ResourceEmptyClosure<Data> = { Data() })
     -> URLSessionMockResource<Void, Data, APIError>  {
         return URLSessionMockResource(url: url,
                                       path: "",
@@ -98,7 +100,8 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
                                       body: nil,
                                       parse: parse,
                                       serialize: serialize,
-                                      errorParser: errorParser)
+                                      errorParser: errorParser,
+                                      empty: empty)
     }
 
     // MARK: - Success tests

--- a/Tests/AlicerceTests/Network/URLSessionNetworkStackTestCase.swift
+++ b/Tests/AlicerceTests/Network/URLSessionNetworkStackTestCase.swift
@@ -10,7 +10,9 @@ import XCTest
 
 @testable import Alicerce
 
-private struct URLSessionMockResource<Local, Remote, Error: Swift.Error>: StaticNetworkResource {
+private struct URLSessionMockResource<T, Error: Swift.Error>: StaticNetworkResource {
+
+    static var empty: Data { return Data() }
 
     var url: URL
     var path: String
@@ -19,10 +21,9 @@ private struct URLSessionMockResource<Local, Remote, Error: Swift.Error>: Static
     var query: HTTP.Query?
     var body: Data?
 
-    let parse: ResourceMapClosure<Remote, Local>
-    let serialize: ResourceMapClosure<Local, Remote>
-    let errorParser: ResourceErrorParseClosure<Remote, Error>
-    let empty: Remote
+    let parse: ResourceMapClosure<Data, T>
+    let serialize: ResourceMapClosure<T, Data>
+    let errorParser: ResourceErrorParseClosure<Data, Error>
 }
 
 final class URLSessionNetworkStackTestCase: XCTestCase {
@@ -38,7 +39,7 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
     private var requestHandlerNetworkStack: Network.URLSessionNetworkStack!
     private var mockRequestHandlerSession: MockURLSession!
 
-    enum APIError: Error {
+    private enum APIError: Error {
         case 💩
         case 💥
     }
@@ -89,9 +90,8 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
     private func buildResource(url: URL = URL(string: "http://0.0.0.0")!,
                                parse: @escaping ResourceMapClosure<Data, Void> = { _ in () },
                                serialize: @escaping ResourceMapClosure<Void, Data> = { _ in Data() },
-                               errorParser: @escaping ResourceErrorParseClosure<Data, APIError> = { _ in APIError.💥 },
-                               empty: Data = Data())
-    -> URLSessionMockResource<Void, Data, APIError>  {
+                               errorParser: @escaping ResourceErrorParseClosure<Data, APIError> = { _ in APIError.💥 })
+    -> URLSessionMockResource<Void, APIError>  {
         return URLSessionMockResource(url: url,
                                       path: "",
                                       method: .GET,
@@ -100,8 +100,7 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
                                       body: nil,
                                       parse: parse,
                                       serialize: serialize,
-                                      errorParser: errorParser,
-                                      empty: empty)
+                                      errorParser: errorParser)
     }
 
     // MARK: - Success tests

--- a/Tests/AlicerceTests/Stores/StoreTestCase.swift
+++ b/Tests/AlicerceTests/Stores/StoreTestCase.swift
@@ -29,7 +29,7 @@ struct MockResource: NetworkResource, PersistableResource, StrategyFetchResource
     }
 
     let request = URLRequest(url: URL(string: "http://localhost")!)
-    let empty: Data
+    static var empty = Data()
 }
 
 class StoreTestCase: XCTestCase {
@@ -49,16 +49,14 @@ class StoreTestCase: XCTestCase {
                             strategy: .networkThenPersistence,
                             parse: { String(data: $0, encoding: .utf8)! },
                             serialize: { $0.data(using: .utf8)! },
-                            errorParser: { _ in .🔥 },
-                            empty: Data())
+                            errorParser: { _ in .🔥 })
     }()
     private lazy var testResourcePersistenceThenNetwork: MockResource = {
         return MockResource(value: "persistence",
                             strategy: .persistenceThenNetwork,
                             parse: { String(data: $0, encoding: .utf8)! },
                             serialize: { $0.data(using: .utf8)! },
-                            errorParser: { _ in .🔥 },
-                            empty: Data())
+                            errorParser: { _ in .🔥 })
     }()
 
     private let expectationTimeout: TimeInterval = 5
@@ -172,8 +170,7 @@ class StoreTestCase: XCTestCase {
                                     strategy: .persistenceThenNetwork,
                                     parse: { _ in throw Parse.Error.json(TestParseError.💩) },
                                     serialize: { _ in throw Serialize.Error.json(TestSerializeError.💩) },
-                                    errorParser: { _ in nil },
-                                    empty: Data())
+                                    errorParser: { _ in nil })
 
         store.fetch(resource: resource) { (value, error) in
             defer { expectation.fulfill() }
@@ -207,8 +204,7 @@ class StoreTestCase: XCTestCase {
                                     strategy: .persistenceThenNetwork,
                                     parse: { _ in throw Parse.Error.json(TestParseError.💩) },
                                     serialize: { _ in throw Serialize.Error.json(TestSerializeError.💩) },
-                                    errorParser: { _ in nil },
-                                    empty: Data())
+                                    errorParser: { _ in nil })
 
         // When
         store.fetch(resource: resource) { (value, error) in
@@ -243,8 +239,7 @@ class StoreTestCase: XCTestCase {
                                     strategy: .networkThenPersistence,
                                     parse: { _ in throw Parse.Error.json(TestParseError.💩) },
                                     serialize: { _ in throw Serialize.Error.json(TestSerializeError.💩) },
-                                    errorParser: { _ in nil },
-                                    empty: Data())
+                                    errorParser: { _ in nil })
 
         // When
         store.fetch(resource: resource) { (value, error) in
@@ -401,8 +396,7 @@ class StoreTestCase: XCTestCase {
                                     strategy: .persistenceThenNetwork,
                                     parse: cancellingParse,
                                     serialize: { _ in throw Serialize.Error.json(TestSerializeError.💩) },
-                                    errorParser: { _ in nil },
-                                    empty: Data())
+                                    errorParser: { _ in nil })
 
 
 

--- a/Tests/AlicerceTests/Stores/StoreTestCase.swift
+++ b/Tests/AlicerceTests/Stores/StoreTestCase.swift
@@ -29,6 +29,7 @@ struct MockResource: NetworkResource, PersistableResource, StrategyFetchResource
     }
 
     let request = URLRequest(url: URL(string: "http://localhost")!)
+    let empty: () throws -> (Data)
 }
 
 class StoreTestCase: XCTestCase {
@@ -48,14 +49,16 @@ class StoreTestCase: XCTestCase {
                             strategy: .networkThenPersistence,
                             parse: { String(data: $0, encoding: .utf8)! },
                             serialize: { $0.data(using: .utf8)! },
-                            errorParser: { _ in .🔥 })
+                            errorParser: { _ in .🔥 },
+                            empty: { Data() })
     }()
     private lazy var testResourcePersistenceThenNetwork: MockResource = {
         return MockResource(value: "persistence",
                             strategy: .persistenceThenNetwork,
                             parse: { String(data: $0, encoding: .utf8)! },
                             serialize: { $0.data(using: .utf8)! },
-                            errorParser: { _ in .🔥 })
+                            errorParser: { _ in .🔥 },
+                            empty: { Data() })
     }()
 
     private let expectationTimeout: TimeInterval = 5
@@ -169,7 +172,8 @@ class StoreTestCase: XCTestCase {
                                     strategy: .persistenceThenNetwork,
                                     parse: { _ in throw Parse.Error.json(TestParseError.💩) },
                                     serialize: { _ in throw Serialize.Error.json(TestSerializeError.💩) },
-                                    errorParser: { _ in nil })
+                                    errorParser: { _ in nil },
+                                    empty: { Data() })
 
         store.fetch(resource: resource) { (value, error) in
             defer { expectation.fulfill() }
@@ -203,7 +207,8 @@ class StoreTestCase: XCTestCase {
                                     strategy: .persistenceThenNetwork,
                                     parse: { _ in throw Parse.Error.json(TestParseError.💩) },
                                     serialize: { _ in throw Serialize.Error.json(TestSerializeError.💩) },
-                                    errorParser: { _ in nil })
+                                    errorParser: { _ in nil },
+                                    empty: { Data() })
 
         // When
         store.fetch(resource: resource) { (value, error) in
@@ -238,7 +243,8 @@ class StoreTestCase: XCTestCase {
                                     strategy: .networkThenPersistence,
                                     parse: { _ in throw Parse.Error.json(TestParseError.💩) },
                                     serialize: { _ in throw Serialize.Error.json(TestSerializeError.💩) },
-                                    errorParser: { _ in nil })
+                                    errorParser: { _ in nil },
+                                    empty: { Data() })
 
         // When
         store.fetch(resource: resource) { (value, error) in
@@ -395,7 +401,8 @@ class StoreTestCase: XCTestCase {
                                     strategy: .persistenceThenNetwork,
                                     parse: cancellingParse,
                                     serialize: { _ in throw Serialize.Error.json(TestSerializeError.💩) },
-                                    errorParser: { _ in nil })
+                                    errorParser: { _ in nil },
+                                    empty: { Data() })
 
 
 

--- a/Tests/AlicerceTests/Stores/StoreTestCase.swift
+++ b/Tests/AlicerceTests/Stores/StoreTestCase.swift
@@ -29,7 +29,7 @@ struct MockResource: NetworkResource, PersistableResource, StrategyFetchResource
     }
 
     let request = URLRequest(url: URL(string: "http://localhost")!)
-    let empty: () throws -> (Data)
+    let empty: Data
 }
 
 class StoreTestCase: XCTestCase {
@@ -50,7 +50,7 @@ class StoreTestCase: XCTestCase {
                             parse: { String(data: $0, encoding: .utf8)! },
                             serialize: { $0.data(using: .utf8)! },
                             errorParser: { _ in .🔥 },
-                            empty: { Data() })
+                            empty: Data())
     }()
     private lazy var testResourcePersistenceThenNetwork: MockResource = {
         return MockResource(value: "persistence",
@@ -58,7 +58,7 @@ class StoreTestCase: XCTestCase {
                             parse: { String(data: $0, encoding: .utf8)! },
                             serialize: { $0.data(using: .utf8)! },
                             errorParser: { _ in .🔥 },
-                            empty: { Data() })
+                            empty: Data())
     }()
 
     private let expectationTimeout: TimeInterval = 5
@@ -173,7 +173,7 @@ class StoreTestCase: XCTestCase {
                                     parse: { _ in throw Parse.Error.json(TestParseError.💩) },
                                     serialize: { _ in throw Serialize.Error.json(TestSerializeError.💩) },
                                     errorParser: { _ in nil },
-                                    empty: { Data() })
+                                    empty: Data())
 
         store.fetch(resource: resource) { (value, error) in
             defer { expectation.fulfill() }
@@ -208,7 +208,7 @@ class StoreTestCase: XCTestCase {
                                     parse: { _ in throw Parse.Error.json(TestParseError.💩) },
                                     serialize: { _ in throw Serialize.Error.json(TestSerializeError.💩) },
                                     errorParser: { _ in nil },
-                                    empty: { Data() })
+                                    empty: Data())
 
         // When
         store.fetch(resource: resource) { (value, error) in
@@ -244,7 +244,7 @@ class StoreTestCase: XCTestCase {
                                     parse: { _ in throw Parse.Error.json(TestParseError.💩) },
                                     serialize: { _ in throw Serialize.Error.json(TestSerializeError.💩) },
                                     errorParser: { _ in nil },
-                                    empty: { Data() })
+                                    empty: Data())
 
         // When
         store.fetch(resource: resource) { (value, error) in
@@ -402,7 +402,7 @@ class StoreTestCase: XCTestCase {
                                     parse: cancellingParse,
                                     serialize: { _ in throw Serialize.Error.json(TestSerializeError.💩) },
                                     errorParser: { _ in nil },
-                                    empty: { Data() })
+                                    empty: Data())
 
 
 


### PR DESCRIPTION
## Description
- Added handling for http response 204 with no content by checking success 204 and `Resource.Local` expected void.
- Added empty closure on `Resource` to return in case of 204.