### PR TITLE
Fixed query build with existing query items

### DIFF
--- a/Alicerce.xcodeproj/project.pbxproj
+++ b/Alicerce.xcodeproj/project.pbxproj
@@ -136,6 +136,7 @@
 		0ABFFAE21EAA6ED400CFC8BD /* HTTP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ABFFAE11EAA6ED400CFC8BD /* HTTP.swift */; };
 		0AE330961EBB71F8003E8506 /* Cancelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE330951EBB71F8003E8506 /* Cancelable.swift */; };
 		1B14CDC11ECCC84D00CFAC15 /* KeyboardObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B14CDC01ECCC84D00CFAC15 /* KeyboardObserver.swift */; };
+		1B327F99207BE6C300ACEEBD /* ResourceTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B327F97207BE39400ACEEBD /* ResourceTestCase.swift */; };
 		1B3C01791F0A93CD00DF8394 /* NetworkAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B3C01781F0A93CD00DF8394 /* NetworkAuthenticator.swift */; };
 		1B40334D1ED6E57200B4B03D /* Serialize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B40334C1ED6E57200B4B03D /* Serialize.swift */; };
 		1B4033581ED8927E00B4B03D /* ViewModelCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B4033571ED8927E00B4B03D /* ViewModelCollectionViewCell.swift */; };
@@ -311,6 +312,7 @@
 		0ABFFAE11EAA6ED400CFC8BD /* HTTP.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTP.swift; sourceTree = "<group>"; };
 		0AE330951EBB71F8003E8506 /* Cancelable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Cancelable.swift; sourceTree = "<group>"; };
 		1B14CDC01ECCC84D00CFAC15 /* KeyboardObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardObserver.swift; sourceTree = "<group>"; };
+		1B327F97207BE39400ACEEBD /* ResourceTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceTestCase.swift; sourceTree = "<group>"; };
 		1B3C01781F0A93CD00DF8394 /* NetworkAuthenticator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkAuthenticator.swift; sourceTree = "<group>"; };
 		1B40334C1ED6E57200B4B03D /* Serialize.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Serialize.swift; sourceTree = "<group>"; };
 		1B4033571ED8927E00B4B03D /* ViewModelCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewModelCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -562,6 +564,7 @@
 				0A83888E1EB209D100C1E835 /* MockNetworkStack.swift */,
 				0A3C2D221EA7E1EE00EFB7D4 /* NetworkTestCase.swift */,
 				0A3C2D231EA7E1EE00EFB7D4 /* ParseTestCase.swift */,
+				1B327F97207BE39400ACEEBD /* ResourceTestCase.swift */,
 				0A3C2D241EA7E1EE00EFB7D4 /* URLSessionNetworkStackTestCase.swift */,
 			);
 			path = Network;
@@ -1009,6 +1012,7 @@
 				0A266FAE1ED59FB6009CD0D7 /* CALayerTestCase.swift in Sources */,
 				0A9AF8B61FC30B660076458E /* NibViewTestCase.swift in Sources */,
 				1BBEB60C1F333E6E00D06526 /* UIImageTestCase.swift in Sources */,
+				1B327F99207BE6C300ACEEBD /* ResourceTestCase.swift in Sources */,
 				0A266FB11ED59FB6009CD0D7 /* StoreTestCase.swift in Sources */,
 				0A266FB21ED59FB6009CD0D7 /* CollectionReusableViewTestCase.swift in Sources */,
 				0A3907F71FC35E760050714A /* ReusableViewTableViewTestCase.swift in Sources */,

--- a/Alicerce.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Alicerce.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Sources/Resource/NetworkResource.swift
+++ b/Sources/Resource/NetworkResource.swift
@@ -62,8 +62,7 @@ extension StaticNetworkResource {
         var newUrl = url
 
         if var components = URLComponents(url: url, resolvingAgainstBaseURL: false) {
-            components.queryItems = build(queryItems: query)
-                .flatMap { (components.queryItems ?? []) + $0 } ?? components.queryItems
+            build(queryItems: query).then { components.queryItems = (components.queryItems ?? []) + $0 }
 
             components.url.then { newUrl = $0 }
         }

--- a/Sources/Resource/NetworkResource.swift
+++ b/Sources/Resource/NetworkResource.swift
@@ -63,6 +63,7 @@ extension StaticNetworkResource {
 
         if var components = URLComponents(url: url, resolvingAgainstBaseURL: false) {
             components.queryItems = build(queryItems: query)
+                .flatMap { (components.queryItems ?? []) + $0 } ?? components.queryItems
 
             components.url.then { newUrl = $0 }
         }

--- a/Tests/AlicerceTests/Network/ResourceTestCase.swift
+++ b/Tests/AlicerceTests/Network/ResourceTestCase.swift
@@ -1,0 +1,90 @@
+//
+//  ResourceTestCase.swift
+//  Alicerce
+//
+//  Created by Luís Portela on 09/04/2018.
+//  Copyright © 2018 Mindera. All rights reserved.
+//
+
+import XCTest
+
+@testable import Alicerce
+
+final class ResourceTestCase: XCTestCase {
+
+    // MARK: - StaticNetworkResource
+
+    func testStaticNetworkResource_WithoutQueryItemsOnPathAndNoQueryItems_ItShouldReturnTheSameURL() {
+        let url = URL(string: "http://test.com/somepath/")!
+        let resource = MockStaticNetworkResource(url: url)
+
+        let builtRequest = resource.request
+
+        XCTAssertNotNil(builtRequest.url)
+        XCTAssertEqual(builtRequest.url, url, "💥 the URLs should be the same")
+    }
+
+    func testStaticNetworkResource_WithQueryItemsOnPathAndNoQueryItems_ItShouldReturnTheSameURL() {
+        let url = URL(string: "http://test.com/somepath/?item1=one&item2=two")!
+        let resource = MockStaticNetworkResource(url: url)
+
+        let builtRequest = resource.request
+
+        XCTAssertNotNil(builtRequest.url)
+        XCTAssertEqual(builtRequest.url, url, "💥 the URLs should be the same")
+    }
+
+    func testStaticNetworkResource_WithoutQueryItemsOnPathAndQueryItems_ItShouldReturnTheURLWithTheQueryItems() {
+        let url = URL(string: "http://test.com/somepath/")!
+        let resource = MockStaticNetworkResource(url: url, query: ["item1" : "one", "item2" : "two"])
+
+        let builtRequest = resource.request
+
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+        components.queryItems = resource.query.flatMap { $0.map { URLQueryItem(name: $0, value: $1) } }
+
+        let builtURL = components.url!
+
+        XCTAssertNotNil(builtRequest.url)
+        XCTAssertEqual(builtRequest.url, builtURL, "💥 the URLs should be the same")
+    }
+
+    func testStaticNetworkResource_WithQueryItemsOnPathAndQueryItems_ItShouldReturnTheURLWithBothQueryItems() {
+        let url = URL(string: "http://test.com/somepath/?item1=one&item2=two")!
+        let resource = MockStaticNetworkResource(url: url, query: ["item3" : "three", "item4" : "four"])
+
+        let builtRequest = resource.request
+
+        var components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+        components.queryItems = components.queryItems! + resource.query.flatMap { $0.map { URLQueryItem(name: $0, value: $1) } }!
+
+        let builtURL = components.url!
+
+        XCTAssertNotNil(builtRequest.url)
+        XCTAssertEqual(builtRequest.url, builtURL, "💥 the URLs should be the same")
+    }
+}
+
+private enum NoError: Swift.Error { case empty }
+
+private struct MockStaticNetworkResource: StaticNetworkResource {
+    static var empty: Void = ()
+
+    let parse: ResourceMapClosure<Void, Void> = { _ in XCTFail("💥 How was this possible? 😳") }
+    let serialize: ResourceMapClosure<Void, Void> = { _ in XCTFail("💥 How was this possible? 😳") }
+    let errorParser: ResourceErrorParseClosure<Void, NoError> = { _ in XCTFail("💥 How was this possible? 😳"); return NoError.empty }
+
+    let url: URL
+    let headers: HTTP.Headers?
+    let method: HTTP.Method
+    let query: HTTP.Query?
+    let body: Data?
+
+    init(url: URL, headers: HTTP.Headers? = nil, method: HTTP.Method = .GET, query: HTTP.Query? = nil, body: Data? = nil) {
+        self.url = url
+        self.headers = headers
+        self.method = method
+        self.query = query
+        self.body = body
+    }
+}


### PR DESCRIPTION
Our helpers to build the query based on the parameters sent in the `Resource` were not using the items in the `URLComponents` parsed from the URL.

This fix appends the new items created from the `Resource` with `queryItems` parsed in the `URLComponents`.

Please look at this as soon as possible, it's a matter of life and death 😇 😂 