### PR TITLE
Migrate to Swift 4.1 and Xcode 9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,30 +3,26 @@ osx_image: xcode9.3
 
 xcode_project: Alicerce.xcodeproj
 
-env:
-  global:
-    - XCODE_PROJECT_NAME=Alicerce
-    - XCODE_SDK=iphonesimulator
-    - XCODE_ACTION='build test'
-    - XCODE_DESTINATION='platform=iOS Simulator,name=iPhone 6s,OS=latest'
-    - XCODE_DERIVED_DATA_PATH=build
-  matrix:
-    - XCODE_SCHEME=Alicerce
-
 before_install:
   - gem install cocoapods
 
 install: true
 
-script:
-  - set -o pipefail
-  - xcodebuild $XCODE_ACTION -project "$TRAVIS_XCODE_PROJECT" -scheme "$XCODE_SCHEME" -sdk "$XCODE_SDK" -destination "$XCODE_DESTINATION" -derivedDataPath "$XCODE_DERIVED_DATA_PATH" | xcpretty
-
-after_success:
-  - bash <(curl -s https://codecov.io/bash) -D $XCODE_DERIVED_DATA_PATH -J "^$XCODE_SCHEME$"
-
 jobs:
   include:
+    - stage: Build + Test
+      env:
+        - XCODE_PROJECT_NAME=Alicerce
+        - XCODE_SDK=iphonesimulator
+        - XCODE_ACTION='build test'
+        - XCODE_DESTINATION='platform=iOS Simulator,name=iPhone 6s,OS=latest'
+        - XCODE_DERIVED_DATA_PATH=build
+        - XCODE_SCHEME=Alicerce
+      script:
+        - set -o pipefail
+        - xcodebuild $XCODE_ACTION -project "$TRAVIS_XCODE_PROJECT" -scheme "$XCODE_SCHEME" -sdk "$XCODE_SDK" -destination "$XCODE_DESTINATION" -derivedDataPath "$XCODE_DERIVED_DATA_PATH" | xcpretty
+      after_success:
+        - bash <(curl -s https://codecov.io/bash) -D $XCODE_DERIVED_DATA_PATH -J "^$XCODE_SCHEME$"
     - stage: Pod lib lint
       script: pod lib lint --verbose
     - stage: Deploy Github

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: swift
-osx_image: xcode9
+osx_image: xcode9.3
 
 xcode_project: Alicerce.xcodeproj
 

--- a/Alicerce.podspec
+++ b/Alicerce.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
     s.source        = { :git => 'https://github.com/Mindera/Alicerce.git', :tag => '0.1.0' }
 
     s.module_name   = 'Alicerce'
-    s.swift_version = '4.0'
+    s.swift_version = '4.1'
 
     s.ios.deployment_target  = '9.0'
 

--- a/Alicerce.xcodeproj/project.pbxproj
+++ b/Alicerce.xcodeproj/project.pbxproj
@@ -930,7 +930,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0830;
-				LastUpgradeCheck = 0900;
+				LastUpgradeCheck = 0930;
 				ORGANIZATIONNAME = Mindera;
 				TargetAttributes = {
 					0A266F801ED59DC7009CD0D7 = {
@@ -1214,7 +1214,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/Tests/AlicerceTests/AlicerceTests-Bridging-Header.h";
-				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -1259,7 +1258,6 @@
 				PRODUCT_MODULE_NAME = AlicerceTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "$(SRCROOT)/Tests/AlicerceTests/AlicerceTests-Bridging-Header.h";
-				SWIFT_VERSION = 4.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -1315,14 +1313,9 @@
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
-				WARNING_CFLAGS = (
-					"-Wall",
-					"-Wextra",
-				);
 			};
 			name = Debug;
 		};
@@ -1372,15 +1365,10 @@
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = YES;
-				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
-				WARNING_CFLAGS = (
-					"-Wall",
-					"-Wextra",
-				);
 			};
 			name = Release;
 		};
@@ -1392,11 +1380,13 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
@@ -1423,7 +1413,11 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = "";
+				SWIFT_VERSION = 4.0;
+				WARNING_CFLAGS = (
+					"-Wall",
+					"-Wextra",
+				);
 			};
 			name = Debug;
 		};
@@ -1435,11 +1429,13 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
@@ -1463,7 +1459,11 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = "";
+				SWIFT_VERSION = 4.0;
+				WARNING_CFLAGS = (
+					"-Wall",
+					"-Wextra",
+				);
 			};
 			name = Release;
 		};

--- a/Alicerce.xcodeproj/xcshareddata/xcschemes/Alicerce.xcscheme
+++ b/Alicerce.xcodeproj/xcshareddata/xcschemes/Alicerce.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0900"
+   LastUpgradeVersion = "0930"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,9 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -61,7 +60,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Sources/Utils/Lock.swift
+++ b/Sources/Utils/Lock.swift
@@ -55,8 +55,8 @@ public class Lock {
         }
 
         deinit {
-            _lock.deinitialize()
-            _lock.deallocate(capacity: 1)
+            _lock.deinitialize(count: 1)
+            _lock.deallocate()
         }
     }
 
@@ -73,8 +73,8 @@ public class Lock {
 
             defer {
                 pthread_mutexattr_destroy(attr)
-                attr.deinitialize()
-                attr.deallocate(capacity: 1)
+                attr.deinitialize(count: 1)
+                attr.deallocate()
             }
 
             // Darwin pthread for 32-bit ARM somehow returns `EAGAIN` when
@@ -118,8 +118,8 @@ public class Lock {
             let status = pthread_mutex_destroy(_lock)
             assert(status == 0, "Unexpected pthread mutex error code: \(status)")
 
-            _lock.deinitialize()
-            _lock.deallocate(capacity: 1)
+            _lock.deinitialize(count: 1)
+            _lock.deallocate()
         }
     }
 

--- a/Tests/AlicerceTests/Utils.swift
+++ b/Tests/AlicerceTests/Utils.swift
@@ -46,6 +46,6 @@ extension UIView {
     static func instantiateFromNib<T: UIView>(withOwner owner: Any?, nibName: String = "Views") -> T? {
         let nib = UINib(nibName: nibName, bundle: Bundle(for: T.self))
 
-        return nib.instantiate(withOwner: owner, options: nil).flatMap { $0 as? T }.first
+        return nib.instantiate(withOwner: owner, options: nil).compactMap { $0 as? T }.first
     }
 }


### PR DESCRIPTION
- Migrated to Swift 4.1 and Xcode 9.3
- Applied recommented project settings
- Fixed all Swift 4.1 warnings
- Updated .podspec `swift_version` to 4.1
- Updated .travis.yml `osx_image` to xcode9.3