### PR TITLE
Revise `Dictionary` and `Sequence` utils API's

### DIFF
--- a/Alicerce.xcodeproj/project.pbxproj
+++ b/Alicerce.xcodeproj/project.pbxproj
@@ -111,6 +111,8 @@
 		0A3C2DC11EA7E5DD00EFB7D4 /* ServiceLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3C2CC51EA7E18500EFB7D4 /* ServiceLocator.swift */; };
 		0A7476C81ECB3F88003024D1 /* ReusableViewModelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7476C71ECB3F88003024D1 /* ReusableViewModelView.swift */; };
 		0A79686120812130005738AF /* LockTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ACEB2992080F0E5000D95AD /* LockTestCase.swift */; };
+		0A7CC0F0208FF76B009F3A6E /* SequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7CC0EE208FF76B009F3A6E /* SequenceTests.swift */; };
+		0A7CC0F1208FF76B009F3A6E /* DictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7CC0EF208FF76B009F3A6E /* DictionaryTests.swift */; };
 		0A83884B1EB1F55A00C1E835 /* PersistableResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A83884A1EB1F55A00C1E835 /* PersistableResource.swift */; };
 		0A83884D1EB1F60000C1E835 /* Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A83884C1EB1F60000C1E835 /* Persistence.swift */; };
 		0A8388581EB1F6B000C1E835 /* CoreDataEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A83884F1EB1F6B000C1E835 /* CoreDataEntity.swift */; };
@@ -276,6 +278,8 @@
 		0A7476CD1ECB4C48003024D1 /* CollectionReusableViewTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionReusableViewTestCase.swift; sourceTree = "<group>"; };
 		0A7476CF1ECB4D15003024D1 /* CollectionViewCellTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionViewCellTestCase.swift; sourceTree = "<group>"; };
 		0A7476D11ECB4D5B003024D1 /* TableViewCellTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewCellTestCase.swift; sourceTree = "<group>"; };
+		0A7CC0EE208FF76B009F3A6E /* SequenceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SequenceTests.swift; sourceTree = "<group>"; };
+		0A7CC0EF208FF76B009F3A6E /* DictionaryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DictionaryTests.swift; sourceTree = "<group>"; };
 		0A83884A1EB1F55A00C1E835 /* PersistableResource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PersistableResource.swift; sourceTree = "<group>"; };
 		0A83884C1EB1F60000C1E835 /* Persistence.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Persistence.swift; sourceTree = "<group>"; };
 		0A83884F1EB1F6B000C1E835 /* CoreDataEntity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreDataEntity.swift; sourceTree = "<group>"; };
@@ -659,6 +663,15 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		0A7CC0ED208FF76B009F3A6E /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				0A7CC0EE208FF76B009F3A6E /* SequenceTests.swift */,
+				0A7CC0EF208FF76B009F3A6E /* DictionaryTests.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		0A83884E1EB1F6B000C1E835 /* CoreData */ = {
 			isa = PBXGroup;
 			children = (
@@ -806,6 +819,7 @@
 				0A3C2D071EA7E1EE00EFB7D4 /* AlicerceTests-Bridging-Header.h */,
 				1B57E9861EB15F3C0027AB30 /* Analytics */,
 				0A3C2D091EA7E1EE00EFB7D4 /* DeepLinking */,
+				0A7CC0ED208FF76B009F3A6E /* Extensions */,
 				0A3C2D101EA7E1EE00EFB7D4 /* Foundation */,
 				0A3C2D141EA7E1EE00EFB7D4 /* Logging */,
 				0A3C2D1E1EA7E1EE00EFB7D4 /* Network */,
@@ -1004,6 +1018,7 @@
 				0A266F8F1ED59FB6009CD0D7 /* PageTestCase.swift in Sources */,
 				0A266F901ED59FB6009CD0D7 /* Route+ComponentTests.swift in Sources */,
 				0A266F911ED59FB6009CD0D7 /* Route+Tree_AddTests.swift in Sources */,
+				0A7CC0F1208FF76B009F3A6E /* DictionaryTests.swift in Sources */,
 				0A266F921ED59FB6009CD0D7 /* Route+Tree_InitTests.swift in Sources */,
 				0A266F931ED59FB6009CD0D7 /* Route+Tree_MatchTests.swift in Sources */,
 				0A266F941ED59FB6009CD0D7 /* Route+Tree_RemoveTests.swift in Sources */,
@@ -1052,6 +1067,7 @@
 				0A266FB61ED59FB6009CD0D7 /* UIColorTestCase.swift in Sources */,
 				1B4033681ED8CB3C00B4B03D /* ViewModelTableViewHeaderFooterViewTestCase.swift in Sources */,
 				0A266FB71ED59FB6009CD0D7 /* UIViewControllerTestCase.swift in Sources */,
+				0A7CC0F0208FF76B009F3A6E /* SequenceTests.swift in Sources */,
 				1B40335F1ED8C6F500B4B03D /* ViewModelTableViewCellTestCase.swift in Sources */,
 				0A266FB81ED59FB6009CD0D7 /* ServiceLocatorTests.swift in Sources */,
 				1B4033651ED8CA5F00B4B03D /* ViewModelCollectionViewCellTestCase.swift in Sources */,

--- a/Sources/Analytics/Analytics.swift
+++ b/Sources/Analytics/Analytics.swift
@@ -85,7 +85,7 @@ private func merge(parameters: Analytics.Parameters?,
     
     switch (parameters, extra) {
     case (var parameters?, let extra?):
-        parameters.unionInPlace(dictionary: extra)
+        parameters.merge(extra, uniquingKeysWith: { _, new in new })
         return parameters
     default:
         return parameters ?? extra

--- a/Sources/Extensions/Sequence.swift
+++ b/Sources/Extensions/Sequence.swift
@@ -22,14 +22,14 @@ public extension Sequence {
     ///   - combine: a closure that combines the accumulating value of a group and produces a new accumulating value.
     ///   - groupBy: a closure that produces a key for each element in the sequence.
     /// - Returns: a dictionary containing the final accumulated values for each produced key.
-    func groupedReduce<K, U>(initial: U,
-                                       combine: (U, Iterator.Element) -> U,
-                                       groupBy: (Iterator.Element) -> K) -> [K : U] {
+    func groupedReduce<K: Hashable, U>(initial: U,
+                                       combine: (U, Iterator.Element) throws -> U,
+                                       groupBy: (Iterator.Element) throws -> K) rethrows -> [K : U] {
         var result: [K : U] = [:]
 
         for element in self {
-            let key = groupBy(element)
-            result[key] = combine(result[key] ?? initial, element)
+            let key = try groupBy(element)
+            result[key] = try combine(result[key] ?? initial, element)
         }
         
         return result

--- a/Tests/AlicerceTests/Extensions/DictionaryTests.swift
+++ b/Tests/AlicerceTests/Extensions/DictionaryTests.swift
@@ -1,0 +1,235 @@
+//
+//  DictionaryTests.swift
+//  Alicerce
+//
+//  Created by André Pacheco Neves on 24/04/2018.
+//  Copyright © 2017 Mindera. All rights reserved.
+//
+
+import XCTest
+@testable import Alicerce
+
+class DictionaryTests: XCTestCase {
+
+    // MARK: - Transform
+
+    // MARK: mapKeysAndValues
+
+    func testMapKeysAndValues_WithValueTypeTransformingClosure_ShouldTransformDictionary() {
+
+        let dict = ["a" : 1, "b" : 2, "c" : 3]
+        let valueTransform: (String, Int) -> (String, Double) = { ($0, Double($1)) }
+        let valueUniquing: (Double, Double) -> (Double) = {
+            XCTFail("unexpected duplicate value!")
+            return $1
+        }
+
+        let mappedDict = dict.mapKeysAndValues(valueTransform, uniquingKeysWith: valueUniquing)
+
+        XCTAssertEqual(mappedDict, ["a" : 1.0, "b" : 2.0, "c" : 3.0])
+    }
+
+    func testMapKeysAndValues_WithKeyTransformingClosure_ShouldTransformDictionary() {
+
+        let dict = ["a" : 1, "b" : 2, "c" : 3]
+        let keyTransform: (String, Int) -> (UTF8Char, Int) = { ($0.utf8.first!, $1) }
+        let valueUniquing: (Int, Int) -> (Int) = {
+            XCTFail("unexpected duplicate value!")
+            return $1
+        }
+
+        let mappedDict = dict.mapKeysAndValues(keyTransform, uniquingKeysWith: valueUniquing)
+
+        XCTAssertEqual(mappedDict, [ "a".utf8.first! : 1, "b".utf8.first! : 2, "c".utf8.first! : 3])
+    }
+
+    func testMapKeysAndValues_WithDuplicateKeyTransformingClosure_ShouldTransformDictionaryAndApplyUniquingClosure() {
+
+        let dict = ["a" : 1, "b" : 2, "c" : 3]
+        let duplicateKeyTransform: (String, Int) -> (String, Int) = {
+            // both "a" and "c" will map to "A", so "c"'s transformed value should prevail (33)
+            (["a", "c"].contains($0) ? "A" : $0.uppercased(), $1 * 11)
+        }
+        let valueUniquing: (Int, Int) -> (Int) = { current, new in new }
+
+        let mappedDict = dict.mapKeysAndValues(duplicateKeyTransform, uniquingKeysWith: valueUniquing)
+
+        XCTAssertEqual(mappedDict, [ "A" : 33, "B" : 22])
+    }
+
+    // MARK: flattened
+
+    func testFlattened_withNoNestedDictionaries_ShouldReturnSameDictionary() {
+
+        let dict = ["a" : 1, "b" : 2, "c" : 3]
+
+        let flattenedDict = dict.flattened()
+
+        XCTAssertEqual(flattenedDict, dict)
+    }
+
+    func testFlattened_withNestedDictionaries_ShouldReturnFlattenedDictionary() {
+
+        let AADict = ["aaa" : 11, "aaaa" : 111]
+        let aDict: [String : Any] = ["A" : 1, "AA" : AADict]
+        let dict: [String : Any] = ["a" : aDict, "b" : 2, "c" : 3]
+
+        let flattenedDict = dict.flattened()
+
+        guard let stringIntFlattenedDict = flattenedDict as? [String : Int] else {
+            return XCTFail("🔥: returned flattened dictionary has invalid type!")
+        }
+
+        XCTAssertEqual(stringIntFlattenedDict, ["a.A" : 1, "a.AA.aaa" : 11, "a.AA.aaaa" : 111,  "b" : 2, "c" : 3])
+    }
+
+    func testFlattened_withNestedDictionariesWithInvalidType_ShouldReturnFlattenedDictionaryNotNestingInvalidTypeDictionaries() {
+
+        let cDict = [3.0 : 33, 30.0 : 333]
+        let aDict: [String : Any] = ["A" : 1, "AA" : 11]
+        let dict: [String : Any] = ["a" : aDict, "b" : 2, "c" : cDict]
+
+        let flattenedDict = dict.flattened()
+
+        XCTAssertEqual(flattenedDict["a.A"] as? Int, 1)
+        XCTAssertEqual(flattenedDict["a.AA"] as? Int, 11)
+        XCTAssertEqual(flattenedDict["b"] as? Int ?? 0, 2)
+        XCTAssertEqual(flattenedDict["c"] as? [Double : Int], cDict)
+    }
+
+    func testFlattened_withEmptyDictionary_ShouldReturnEmptyDictionary() {
+
+        let dict: [String : Int] = [:]
+
+        let flattenedDict = dict.flattened()
+
+        XCTAssertEqual(flattenedDict, [:])
+    }
+
+    // MARK: - Remove values
+
+    // MARK: removingValuesForKeys
+
+    func testRemovingValuesForKeys_WithKeySequenceMatchingKeys_ShouldRemoveMatchingKeysFromDictionary() {
+
+        let dict = ["a" : 1, "b" : 2, "c" : 3]
+        let keysToRemove = ["a", "c", "x"]
+
+        let newDict = dict.removingValues(forKeys: keysToRemove)
+
+        XCTAssertEqual(newDict, ["b" : 2])
+    }
+
+    func testRemovingValuesForKeys_WithKeySequenceNotMatchingKeys_ShouldNotRemoveKeysFromDictionary() {
+
+        let dict = ["a" : 1, "b" : 2, "c" : 3]
+        let keysToRemove = ["x", "y"]
+
+        let newDict = dict.removingValues(forKeys: keysToRemove)
+
+        XCTAssertEqual(newDict, dict)
+    }
+
+    func testRemovingValuesForKeys_WithEmptyKeySequence_ShouldNotRemoveKeysFromDictionary() {
+
+        let dict = ["a" : 1, "b" : 2, "c" : 3]
+        let keysToRemove: [String] = []
+
+        let newDict = dict.removingValues(forKeys: keysToRemove)
+
+        XCTAssertEqual(newDict, dict)
+    }
+
+    // MARK: removeValuesForKeys
+
+    func testRemoveValuesForKeys_WithKeySequenceMatchingKeys_ShouldRemoveMatchingKeysFromDictionaryAndReturnKeyValueDict() {
+
+        var dict = ["a" : 1, "b" : 2, "c" : 3]
+        let keysToRemove = ["a", "c", "x"]
+
+        let removedKeyValues = dict.removeValues(forKeys: keysToRemove)
+
+        XCTAssertEqual(dict, ["b" : 2])
+        XCTAssertEqual(removedKeyValues.count, keysToRemove.count)
+        XCTAssertEqual(removedKeyValues["a"], 1)
+        XCTAssertEqual(removedKeyValues["c"], 3)
+        XCTAssertEqual(removedKeyValues["x"], .some(nil))
+    }
+
+    func testRemoveValuesForKeys_WithKeySequenceNotMatchingKeys_ShouldNotRemoveKeysFromDictionaryAndReturnEmptyKeyValueDict() {
+
+        var dict = ["a" : 1, "b" : 2, "c" : 3]
+        let keysToRemove = ["x", "y"]
+
+        let removedKeyValues = dict.removeValues(forKeys: keysToRemove)
+
+        XCTAssertEqual(dict, ["a" : 1, "b" : 2, "c" : 3])
+        XCTAssertEqual(removedKeyValues.count, keysToRemove.count)
+        XCTAssertEqual(removedKeyValues["x"], .some(nil))
+        XCTAssertEqual(removedKeyValues["y"], .some(nil))
+    }
+
+    func testRemoveValuesForKeys_WithEmptyKeySequence_ShouldNotRemoveKeysFromDictionaryAndReturnEmptyKeyValueDict() {
+
+        var dict = ["a" : 1, "b" : 2, "c" : 3]
+        let keysToRemove: [String] = []
+
+        let removedKeyValues = dict.removeValues(forKeys: keysToRemove)
+        
+        XCTAssertEqual(dict, ["a" : 1, "b" : 2, "c" : 3])
+        XCTAssert(removedKeyValues.isEmpty)
+    }
+
+    // MARK: - Get values
+
+    // MARK: multi subscript varargs
+
+    func testMultiSubscriptVarArgs_WithSequenceMatchingKeys_ShouldReturnOptionalValueArrayWithMathingAndNotMatchingValuesInOrder() {
+
+        let dict = ["a" : 1, "b" : 2, "c" : 3]
+
+        let values = dict["a", "b", "x"]
+
+        XCTAssertEqual(values.count, 3)
+        XCTAssertEqual(values[0], 1)
+        XCTAssertEqual(values[1], 2)
+        XCTAssertEqual(values[2], nil)
+    }
+
+    func testMultiSubscriptVarArgs_WithSequenceNotMatchingKeys_ShouldReturnOptionalValueArrayWithOnlyNotMatchingValues() {
+
+        let dict = ["a" : 1, "b" : 2, "c" : 3]
+
+        let values = dict["x", "y"]
+
+        XCTAssertEqual(values.count, 2)
+        XCTAssertEqual(values[0], nil)
+        XCTAssertEqual(values[1], nil)
+    }
+
+    // MARK: multi subscript Sequence
+
+    func testMultiSubscriptSequence_WithSequenceMatchingKeys_ShouldReturnOptionalValueArrayWithMathingAndNotMatchingValuesInOrder() {
+
+        let dict = ["a" : 1, "b" : 2, "c" : 3]
+        let keysToGet = ["a", "b", "x"]
+        let values = dict[keysToGet]
+
+        XCTAssertEqual(values.count, keysToGet.count)
+        XCTAssertEqual(values[0], 1)
+        XCTAssertEqual(values[1], 2)
+        XCTAssertEqual(values[2], nil)
+    }
+
+    func testMultiSubscriptSequence_WithSequenceNotMatchingKeys_ShouldReturnOptionalValueArrayWithOnlyNotMatchingValues() {
+
+        let dict = ["a" : 1, "b" : 2, "c" : 3]
+        let keysToGet = ["x", "y"]
+        let values = dict["x", "y"]
+
+        XCTAssertEqual(values.count, keysToGet.count)
+        XCTAssertEqual(values[0], nil)
+        XCTAssertEqual(values[1], nil)
+    }
+
+}

--- a/Tests/AlicerceTests/Extensions/SequenceTests.swift
+++ b/Tests/AlicerceTests/Extensions/SequenceTests.swift
@@ -1,0 +1,51 @@
+//
+//  SequenceTests.swift
+//  Alicerce
+//
+//  Created by André Pacheco Neves on 24/04/2018.
+//  Copyright © 2017 Mindera. All rights reserved.
+//
+
+import XCTest
+@testable import Alicerce
+
+class SequenceTests: XCTestCase {
+
+    // MARK: groupedReduce
+
+    func testGroupedReduce_WithNonEmptySequenceAndSameKeyType_ShouldReturnGroupedDictionary() {
+
+        let seq = ["a", "a", "a", "b", "b", "c", "d"]
+
+        let sumCombine: (Int, String) -> Int = { acc, element in return acc + 1 }
+        let stringKey: (String) -> String = { $0 }
+
+        let groupedSeq: [String : Int] = seq.groupedReduce(initial: 0, combine: sumCombine, groupBy: stringKey)
+
+        XCTAssertEqual(groupedSeq, ["a" : 3, "b" : 2, "c" : 1, "d" : 1])
+    }
+
+    func testGroupedReduce_WithEmptySequence_ShouldReturnEmptyDictionary() {
+
+        let seq: [String] = []
+
+        let sumCombine: (Int, String) -> Int = { acc, element in return acc + 1 }
+        let stringKey: (String) -> String = { $0 }
+
+        let groupedSeq: [String : Int] = seq.groupedReduce(initial: 0, combine: sumCombine, groupBy: stringKey)
+
+        XCTAssertEqual(groupedSeq, [:])
+    }
+
+    func testGroupedReduce_WithNonEmptySequenceAndDifferentKeyType_ShouldReturnGroupedDictionary() {
+
+        let seq = ["a", "a", "a", "b", "b", "c", "d"]
+
+        let sumCombine: (Int, String) -> Int = { acc, element in return acc + 1 }
+        let utf8Key: (String) -> UTF8Char = { $0.utf8.first! }
+
+        let groupedSeq: [UTF8Char : Int] = seq.groupedReduce(initial: 0, combine: sumCombine, groupBy: utf8Key)
+
+        XCTAssertEqual(groupedSeq, ["a".utf8.first! : 3, "b".utf8.first! : 2, "c".utf8.first! : 1, "d".utf8.first! : 1])
+    }
+}


### PR DESCRIPTION
- Removed `Dictionary` API's that have been sherlocked by Swift's
stdlib 🕵️‍♂️
  + `init(keyValueTuples:)`, replaced by `init(uniqueKeysWithValues:)`
and `init(_ keysAndValues:uniquingKeysWith:)`
  + `unionInPlace` variants, replaced by `merge` API's
  + `multiSubscript(keys:)`, replaced by custom subscripts

- Renamed and updated some `Dictionary` API's to make them more
coherent with stdlib's naming and behaviour:
  + `removeValuesForKeys` to `removeValues`
  + `map` to `mapKeysAndValues`, and adding a `uniquingKeysWith` closure
  + `dictionaryByRemovingValuesForKeys` to `removingValues`

- Updated `Sequence.groupedReduce` to use `throws` and `rethrows`

- Added unit tests to `Dictionary` and `Sequence` API's