### PR TITLE
Router and TreeRouter improvements

### DIFF
--- a/Alicerce.xcodeproj/project.pbxproj
+++ b/Alicerce.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		0A3C2DC01EA7E5DD00EFB7D4 /* Placeholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3C2CC41EA7E18500EFB7D4 /* Placeholder.swift */; };
 		0A3C2DC11EA7E5DD00EFB7D4 /* ServiceLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3C2CC51EA7E18500EFB7D4 /* ServiceLocator.swift */; };
 		0A7476C81ECB3F88003024D1 /* ReusableViewModelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7476C71ECB3F88003024D1 /* ReusableViewModelView.swift */; };
+		0A76A006209F868C00D46B63 /* Route+Tree_DescriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A76A004209F854C00D46B63 /* Route+Tree_DescriptionTests.swift */; };
 		0A79686120812130005738AF /* LockTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ACEB2992080F0E5000D95AD /* LockTestCase.swift */; };
 		0A7CC0F0208FF76B009F3A6E /* SequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7CC0EE208FF76B009F3A6E /* SequenceTests.swift */; };
 		0A7CC0F1208FF76B009F3A6E /* DictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7CC0EF208FF76B009F3A6E /* DictionaryTests.swift */; };
@@ -280,6 +281,7 @@
 		0A7476CD1ECB4C48003024D1 /* CollectionReusableViewTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionReusableViewTestCase.swift; sourceTree = "<group>"; };
 		0A7476CF1ECB4D15003024D1 /* CollectionViewCellTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionViewCellTestCase.swift; sourceTree = "<group>"; };
 		0A7476D11ECB4D5B003024D1 /* TableViewCellTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewCellTestCase.swift; sourceTree = "<group>"; };
+		0A76A004209F854C00D46B63 /* Route+Tree_DescriptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Route+Tree_DescriptionTests.swift"; sourceTree = "<group>"; };
 		0A7CC0EE208FF76B009F3A6E /* SequenceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SequenceTests.swift; sourceTree = "<group>"; };
 		0A7CC0EF208FF76B009F3A6E /* DictionaryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DictionaryTests.swift; sourceTree = "<group>"; };
 		0A83884A1EB1F55A00C1E835 /* PersistableResource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PersistableResource.swift; sourceTree = "<group>"; };
@@ -550,6 +552,7 @@
 			children = (
 				0A3C2D0A1EA7E1EE00EFB7D4 /* Route+ComponentTests.swift */,
 				0A3C2D0B1EA7E1EE00EFB7D4 /* Route+Tree_AddTests.swift */,
+				0A76A004209F854C00D46B63 /* Route+Tree_DescriptionTests.swift */,
 				0A3C2D0C1EA7E1EE00EFB7D4 /* Route+Tree_InitTests.swift */,
 				0A3C2D0D1EA7E1EE00EFB7D4 /* Route+Tree_MatchTests.swift */,
 				0A3C2D0E1EA7E1EE00EFB7D4 /* Route+Tree_RemoveTests.swift */,
@@ -1056,6 +1059,7 @@
 				0A266FA91ED59FB6009CD0D7 /* CoreDataStackSetupTests.swift in Sources */,
 				0ACEB2962080ED90000D95AD /* AtomicTestCase.swift in Sources */,
 				0A266FAA1ED59FB6009CD0D7 /* MockCoreDataStack.swift in Sources */,
+				0A76A006209F868C00D46B63 /* Route+Tree_DescriptionTests.swift in Sources */,
 				0A266FAB1ED59FB6009CD0D7 /* DiskMemoryPersistenceTestCase.swift in Sources */,
 				0A9AF8C01FC336F60076458E /* ReusableViewTestCase.swift in Sources */,
 				0A266FAC1ED59FB6009CD0D7 /* MockPersistenceStack.swift in Sources */,

--- a/Alicerce.xcodeproj/project.pbxproj
+++ b/Alicerce.xcodeproj/project.pbxproj
@@ -421,9 +421,9 @@
 			isa = PBXGroup;
 			children = (
 				0A3C2C831EA7E18500EFB7D4 /* ApplicationRouter.swift */,
+				0A3C2C861EA7E18500EFB7D4 /* Route.swift */,
 				0A3C2C841EA7E18500EFB7D4 /* Route+Component.swift */,
 				0A3C2C851EA7E18500EFB7D4 /* Route+Tree.swift */,
-				0A3C2C861EA7E18500EFB7D4 /* Route.swift */,
 				0A3C2C871EA7E18500EFB7D4 /* Router.swift */,
 			);
 			path = DeepLinking;

--- a/Sources/DeepLinking/Route+Component.swift
+++ b/Sources/DeepLinking/Route+Component.swift
@@ -73,7 +73,7 @@ extension Route.Component: Hashable {
         }
     }
 
-    public static func ==(lhs: Route.Component, rhs: Route.Component) -> Bool {
+    public static func == (lhs: Route.Component, rhs: Route.Component) -> Bool {
         switch (lhs, rhs) {
         case (.empty, .empty): return true
         case let (.constant(lhsString), .constant(rhsString)): return lhsString == rhsString
@@ -136,7 +136,7 @@ extension Route.Component.Key: Hashable {
         }
     }
 
-    public static func ==(lhs: Route.Component.Key, rhs: Route.Component.Key) -> Bool {
+    public static func == (lhs: Route.Component.Key, rhs: Route.Component.Key) -> Bool {
         switch (lhs, rhs) {
         case (.empty, .empty), (.variable, .variable): return true
         case let (.constant(lhsString), .constant(rhsString)): return lhsString == rhsString

--- a/Sources/DeepLinking/Route+Component.swift
+++ b/Sources/DeepLinking/Route+Component.swift
@@ -10,7 +10,7 @@ import Foundation
 
 public extension Route {
 
-    public enum Component: ExpressibleByStringLiteral, CustomStringConvertible, CustomDebugStringConvertible, Hashable {
+    public enum Component {
         case empty // for default handlers, e.g.: /home
         case constant(String)
         case variable(String?) // variables and wildcard (*)
@@ -51,82 +51,115 @@ public extension Route {
             }
         }
 
-        // MARK: Key (
+        // MARK: Key
 
-        public enum Key: Hashable {
+        public enum Key {
             case empty
             case constant(String)
             case variable
-
-            public var hashValue: Int {
-                switch self {
-                case .empty: return "\(type(of: self).empty)".hashValue
-                case let .constant(value): return value.hashValue
-                case .variable: return "\(type(of: self).variable)".hashValue
-                }
-            }
-
-            public static func ==(lhs: Key, rhs: Key) -> Bool {
-                switch (lhs, rhs) {
-                case (.empty, .empty), (.variable, .variable): return true
-                case let (.constant(lhsString), .constant(rhsString)): return lhsString == rhsString
-                default: return false
-                }
-            }
         }
+    }
+}
 
-        // MARK: ExpressibleByStringLiteral
+extension Route.Component: Hashable {
 
-        public init(stringLiteral value: String) {
-            self.init(component: value)
+    // MARK: Hashable
+
+    public var hashValue: Int {
+        switch self {
+        case .empty: return "\(type(of: self).empty)".hashValue
+        case let .constant(value): return "\(type(of: self).constant)(\(value))".hashValue
+        case let .variable(parameter): return "\(type(of: self).variable)(\(String(describing: parameter)))".hashValue
         }
+    }
 
-        public init(extendedGraphemeClusterLiteral value: String) {
-            self.init(component: value)
+    public static func ==(lhs: Route.Component, rhs: Route.Component) -> Bool {
+        switch (lhs, rhs) {
+        case (.empty, .empty): return true
+        case let (.constant(lhsString), .constant(rhsString)): return lhsString == rhsString
+        case let (.variable(lhsParameter), .variable(rhsParameter)): return lhsParameter == rhsParameter
+        default: return false
         }
+    }
+}
 
-        public init(unicodeScalarLiteral value: String) {
-            self.init(component: value)
+extension Route.Component: ExpressibleByStringLiteral {
+
+    // MARK: ExpressibleByStringLiteral
+
+    public init(stringLiteral value: String) {
+        self.init(component: value)
+    }
+
+    public init(extendedGraphemeClusterLiteral value: String) {
+        self.init(component: value)
+    }
+
+    public init(unicodeScalarLiteral value: String) {
+        self.init(component: value)
+    }
+}
+
+extension Route.Component: CustomStringConvertible, CustomDebugStringConvertible {
+
+    // MARK: CustomStringConvertible
+
+    public var description: String {
+        switch self {
+        case .empty: return ""
+        case let .constant(value): return value
+        case let .variable(value?): return ":" + value
+        case .variable(nil): return "*"
         }
+    }
 
-        // MARK: CustomStringConvertible
+    // MARK: CustomDebugStringConvertible
 
-        public var description: String {
-            switch self {
-            case .empty: return ""
-            case let .constant(value): return value
-            case let .variable(value?): return ":" + value
-            case .variable(nil): return "*"
-            }
+    public var debugDescription: String {
+        switch self {
+        case .empty: return ".empty"
+        case let .constant(value): return ".constant(\(value))"
+        case let .variable(value): return ".variable(\(value ?? "*"))"
         }
+    }
+}
 
-        // MARK: CustomDebugStringConvertible
+extension Route.Component.Key: Hashable {
 
-        public var debugDescription: String {
-            switch self {
-            case .empty: return ".empty"
-            case let .constant(value): return ".constant(\(value))"
-            case let .variable(value): return ".variable(\(value ?? "*"))" 
-            }
+    // MARK: Hashable
+
+    public var hashValue: Int {
+        switch self {
+        case .empty: return "\(type(of: self).empty)".hashValue
+        case let .constant(value): return value.hashValue
+        case .variable: return "\(type(of: self).variable)".hashValue
         }
+    }
 
-        // MARK: Hashable
-
-        public var hashValue: Int {
-            switch self {
-            case .empty: return "\(type(of: self).empty)".hashValue
-            case let .constant(value): return "\(type(of: self).constant)(\(value))".hashValue
-            case let .variable(parameter): return "\(type(of: self).variable)(\(String(describing: parameter)))".hashValue
-            }
+    public static func ==(lhs: Route.Component.Key, rhs: Route.Component.Key) -> Bool {
+        switch (lhs, rhs) {
+        case (.empty, .empty), (.variable, .variable): return true
+        case let (.constant(lhsString), .constant(rhsString)): return lhsString == rhsString
+        default: return false
         }
+    }
+}
 
-        public static func ==(lhs: Component, rhs: Component) -> Bool {
-            switch (lhs, rhs) {
-            case (.empty, .empty): return true
-            case let (.constant(lhsString), .constant(rhsString)): return lhsString == rhsString
-            case let (.variable(lhsParameter), .variable(rhsParameter)): return lhsParameter == rhsParameter
-            default: return false
-            }
+extension Route.Component.Key: CustomStringConvertible, CustomDebugStringConvertible {
+
+    // MARK: CustomStringConvertible
+
+    public var description: String {
+        switch self {
+        case .empty: return ".empty"
+        case .constant(let string): return ".constant(\(string))"
+        case .variable: return ".variable"
         }
+    }
+
+    // MARK: CustomDebugStringConvertible
+
+    public var debugDescription: String {
+        return description
     }
 }

--- a/Sources/DeepLinking/Route+Component.swift
+++ b/Sources/DeepLinking/Route+Component.swift
@@ -53,7 +53,7 @@ public extension Route {
 
         // MARK: Key (
 
-        public enum Key : Hashable{
+        public enum Key: Hashable {
             case empty
             case constant(String)
             case variable

--- a/Sources/DeepLinking/Route+Tree.swift
+++ b/Sources/DeepLinking/Route+Tree.swift
@@ -10,17 +10,17 @@ import Foundation
 
 public extension Route {
 
+    public enum TreeError: Swift.Error {
+        case invalidRoute
+        case duplicateEmptyComponent
+        case conflictingParameterName(existing: String, new: String)
+        case routeNotFound
+        case invalidComponent(Component)
+    }
+
     public indirect enum Tree<Handler> {
 
         // MARK: Nested types
-
-        public enum Error: Swift.Error {
-            case invalidRoute
-            case duplicateEmptyComponent
-            case conflictingParameterName(existing: String, new: String)
-            case routeNotFound
-            case invalidComponent(Component)
-        }
 
         public enum Edge {
             case simple(Tree<Handler>)
@@ -40,7 +40,7 @@ public extension Route {
             case nil:
                 self = .leaf(handler)
             case .empty?:
-                guard route.count == 1 else { throw Error.invalidRoute }
+                guard route.count == 1 else { throw TreeError.invalidRoute }
                 
                 self = .leaf(handler)
             case let currentComponent?:
@@ -97,10 +97,10 @@ public extension Route {
                         fatalError("💥: Can't match .parameter edge with .empty or .constant component! 😱")
                     }
 
-                    guard nodeParameterName == componentParameterName else { throw Error.routeNotFound }
+                    guard nodeParameterName == componentParameterName else { throw TreeError.routeNotFound }
 
                     childTree = nextTree
-                case nil: throw Error.routeNotFound
+                case nil: throw TreeError.routeNotFound
                 }
 
                 return try removeFromChildTree(childTree,
@@ -111,7 +111,7 @@ public extension Route {
 
                 // only match if the route is empty or contains a *single* .empty component
                 guard route.first ?? .empty == .empty, route.count <= 1 else {
-                    throw Error.routeNotFound
+                    throw TreeError.routeNotFound
                 }
 
                 // extract the handler and change to an empty node, effectively removing the handler from the tree
@@ -136,13 +136,13 @@ public extension Route {
                                                   currentComponent: currentComponent,
                                                   remainingRoute: remainingRoute)
                 case nil:
-                    throw Error.routeNotFound
+                    throw TreeError.routeNotFound
                 }
             case let .leaf(handler):
                 
                 // only match if the route is empty or contains a *single* .empty component
                 guard route.first ?? .empty == .empty, route.count <= 1 else {
-                    throw Error.routeNotFound
+                    throw TreeError.routeNotFound
                 }
 
                 return ([:], handler)
@@ -171,7 +171,7 @@ public extension Route {
             switch currentComponent {
             case .empty:
                 // this node already has an empty edge, so reject addition
-                throw Error.duplicateEmptyComponent
+                throw TreeError.duplicateEmptyComponent
             case .constant:
                 guard case let .simple(nextTree) = matchingChildEdge else {
                     fatalError("💥: Can't match .parameter edge with .constant component! 😱")
@@ -184,8 +184,8 @@ public extension Route {
                 }
 
                 guard existingParameterName == newParameterName else {
-                    throw Error.conflictingParameterName(existing: existingParameterName ?? "*",
-                                                         new: newParameterName ?? "*")
+                    throw TreeError.conflictingParameterName(existing: existingParameterName ?? "*",
+                                                             new: newParameterName ?? "*")
                 }
 
                 childTree = nextTree
@@ -205,7 +205,7 @@ public extension Route {
                                        handler: Handler) throws -> ChildEdges {
             if case .empty = currentComponent {
                 // leaves cannot grow with an already empty component
-                throw Error.duplicateEmptyComponent
+                throw TreeError.duplicateEmptyComponent
             }
 
             let newTree = try Tree<Handler>(route: remainingRoute, handler: handler)
@@ -242,7 +242,7 @@ public extension Route {
                 return edges[component.key] ?? edges[.variable]
             case .variable:
                 // routes should be matched against empty or constant values only
-                throw Error.invalidComponent(component)
+                throw TreeError.invalidComponent(component)
             }
         }
 
@@ -258,7 +258,7 @@ public extension Route {
 
             guard case let .constant(parameterValue) = currentComponent else {
                 assertionFailure("🔥: matched non `.constant` component \(currentComponent) to `parameter(\(parameterName))` edge!")
-                throw Error.routeNotFound
+                throw TreeError.routeNotFound
             }
 
             assert(parameters[parameterName] == nil, "🔥: duplicate variable in route!")

--- a/Sources/DeepLinking/Route+Tree.swift
+++ b/Sources/DeepLinking/Route+Tree.swift
@@ -268,3 +268,49 @@ public extension Route {
         }
     }
 }
+
+extension Route.Tree: CustomStringConvertible, CustomDebugStringConvertible {
+
+    // MARK: CustomStringConvertible
+
+    public var description: String {
+        switch self {
+        case .leaf(let handler): return ".leaf(\(handler))"
+        case .node(let childs): return ".node(\(childs))"
+        }
+    }
+
+    // MARK: CustomDebugStringConvertible
+
+    public var debugDescription: String {
+        switch self {
+        case .leaf(let handler): return ".leaf(\(handler))"
+        case .node(let childs): return ".node(\(childs.debugDescription))"
+        }
+    }
+}
+
+extension Route.Tree.Edge: CustomStringConvertible, CustomDebugStringConvertible {
+
+    // MARK: CustomStringConvertible
+
+    public var description: String {
+        switch self {
+        case .simple(let tree): return ".simple(\(tree))"
+        case .parameter(let parameterName, let tree): return ".parameter(\(parameterName ?? "*"), \(tree))"
+        }
+    }
+
+    // MARK: CustomDebugStringConvertible
+
+    public var debugDescription: String {
+        switch self {
+        case .simple(let tree):
+            return ".simple(\(tree.debugDescription))"
+        case .parameter(let parameterName, let tree):
+            return ".parameter(\(parameterName ?? "*"), \(tree.debugDescription))"
+        }
+    }
+}
+
+

--- a/Sources/DeepLinking/Router.swift
+++ b/Sources/DeepLinking/Router.swift
@@ -99,9 +99,7 @@ public final class TreeRouter<T>: Router {
             } catch Route.TreeError.routeNotFound {
                 throw TreeRouterError.routeNotFound
             } catch {
-                assertionFailure("🔥: unexpected Route.Tree.Error type!")
-                // FIXME: add logging
-                print("⚠️: unexpected error when unregistering \(route)! Error: \(error)")
+                assertionFailure("🔥: unexpected error when unregistering \(route)! Error: \(error)")
                 throw TreeRouterError.routeNotFound
             }
 
@@ -124,9 +122,7 @@ public final class TreeRouter<T>: Router {
             } catch let Route.TreeError.invalidComponent(component) {
                 throw TreeRouterError.invalidRoute(.invalidVariableComponent(component.description))
             } catch {
-                assertionFailure("🔥: unexpected Route.Tree.Error type!")
-                // FIXME: add logging
-                print("⚠️: unexpected error when routing \(route)! Error: \(error)")
+                assertionFailure("🔥: unexpected error when routing \(route)! Error: \(error)")
                 throw TreeRouterError.invalidRoute(.unexpected(error))
             }
         }

--- a/Sources/DeepLinking/Router.swift
+++ b/Sources/DeepLinking/Router.swift
@@ -14,20 +14,33 @@ public protocol RouteHandler {
     func handle(route: URL, parameters: [String : String], queryItems: [URLQueryItem], completion: ((T) -> Void)?)
 }
 
-public protocol Router {
-    associatedtype Handler: RouteHandler
+public final class AnyRouteHandler<T>: RouteHandler {
 
-    func register(_ route: URL, handler: Handler) throws
-    func unregister(_ route: URL) throws -> Handler
+    let _handle: (URL, [String : String], [URLQueryItem], ((T) -> Void)?) -> Void
 
-    func route(_ route: URL, completion: ((Handler.T) -> Void)?) throws
+    init<H: RouteHandler>(_ h: H) where H.T == T {
+        _handle = h.handle
+    }
+
+    public func handle(route: URL,
+                       parameters: [String : String],
+                       queryItems: [URLQueryItem],
+                       completion: ((T) -> Void)?) {
+        _handle(route, parameters, queryItems, completion)
+    }
 }
 
-public final class TreeRouter<Handler: RouteHandler, T>: Router where Handler.T == T {
+public protocol Router {
+    associatedtype T
 
-    public typealias Match = Route.Tree<Handler>.Match
+    func route(_ route: URL, handleCompletion: ((T) -> Void)?) throws
+}
 
-    private typealias Tree = Route.Tree<Handler>
+public final class TreeRouter<T>: Router {
+
+    public typealias Match = Route.Tree<AnyRouteHandler<T>>.Match
+
+    private typealias Tree = Route.Tree<AnyRouteHandler<T>>
     private typealias AnnotatedParsedRoute = (scheme: Route.Scheme, components: [Route.Component])
     private typealias ParsedRoute = (scheme: Route.Scheme, components: [Route.Component], queryItems: [URLQueryItem])
 
@@ -35,6 +48,7 @@ public final class TreeRouter<Handler: RouteHandler, T>: Router where Handler.T 
         case invalidRoute(InvalidRouteError)
         case duplicateRoute
         case routeNotFound
+        case handlerTypeMismatch(expected: Any.Type, found: Any.Type)
 
         public enum InvalidRouteError: Swift.Error {
             case misplacedEmptyComponent
@@ -45,29 +59,23 @@ public final class TreeRouter<Handler: RouteHandler, T>: Router where Handler.T 
         }
     }
 
-    private var routes: [Route.Scheme : Tree] = [:]
-    private let queue: DispatchQueue
+    private var routes: Atomic<[Route.Scheme : Tree]> = Atomic([:])
 
-    public init(qos: DispatchQoS = .default) {
-        queue = DispatchQueue(label: "com.mindera.Alicerce.\(type(of: self)).queue", qos: qos)
-    }
-
-    public func register(_ route: URL, handler: Handler) throws {
+    public func register(_ route: URL, handler: AnyRouteHandler<T>) throws {
         let (scheme, routeComponents) = parseAnnotatedRoute(route)
 
-        try queue.sync { [unowned self] in
-
+        try routes.modify { routes in
             do {
-                if var schemeTree = self.routes[scheme] {
+                if var schemeTree = routes[scheme] {
                     try schemeTree.add(route: routeComponents, handler: handler)
-                    self.routes[scheme] = schemeTree
+                    routes[scheme] = schemeTree
                 } else {
-                    self.routes[scheme] = try Tree(route: routeComponents, handler: handler)
+                    routes[scheme] = try Tree(route: routeComponents, handler: handler)
                 }
             } catch Tree.Error.duplicateEmptyComponent {
-                throw Error.duplicateRoute 
+                throw Error.duplicateRoute
             } catch Tree.Error.invalidRoute {
-                 // empty route elements are only allowed at the end of the route
+                // empty route elements are only allowed at the end of the route
                 throw Error.invalidRoute(.misplacedEmptyComponent)
             } catch let Tree.Error.conflictingParameterName(existing, new) {
                 throw Error.invalidRoute(.conflictingVariableComponent(existing: existing, new: new))
@@ -77,13 +85,14 @@ public final class TreeRouter<Handler: RouteHandler, T>: Router where Handler.T 
         }
     }
 
-    public func unregister(_ route: URL) throws -> Handler {
+    @discardableResult
+    public func unregister(_ route: URL) throws -> AnyRouteHandler<T> {
         let (scheme, routeComponents) = parseAnnotatedRoute(route)
 
-        return try queue.sync { [unowned self] in
-            guard var schemeTree = self.routes[scheme] else { throw Error.routeNotFound }
+        return try routes.modify { routes in
+            guard var schemeTree = routes[scheme] else { throw Error.routeNotFound }
 
-            let handler: Handler
+            let handler: AnyRouteHandler<T>
 
             do {
                 handler = try schemeTree.remove(route: routeComponents)
@@ -96,17 +105,17 @@ public final class TreeRouter<Handler: RouteHandler, T>: Router where Handler.T 
                 throw Error.routeNotFound
             }
 
-            self.routes[scheme] = schemeTree
+            routes[scheme] = schemeTree
 
             return handler
         }
     }
 
-    public func route(_ route: URL, completion: ((T) -> Void)? = nil) throws {
+    public func route(_ route: URL, handleCompletion: ((T) -> Void)? = nil) throws {
         let (scheme, routeComponents, queryItems) = try parseRoute(route)
 
-        let match: Match = try queue.sync { [unowned self] in
-            guard let schemeTree = self.routes[scheme] else { throw Error.routeNotFound }
+        let match: Match = try routes.modify { routes in
+            guard let schemeTree = routes[scheme] else { throw Error.routeNotFound }
 
             do {
                 return try schemeTree.match(route: routeComponents)
@@ -122,7 +131,10 @@ public final class TreeRouter<Handler: RouteHandler, T>: Router where Handler.T 
             }
         }
 
-        match.handler.handle(route: route, parameters: match.parameters, queryItems: queryItems, completion: completion)
+        match.handler.handle(route: route,
+                             parameters: match.parameters,
+                             queryItems: queryItems,
+                             completion: handleCompletion)
     }
 
     // MARK: - Private methods
@@ -145,8 +157,8 @@ public final class TreeRouter<Handler: RouteHandler, T>: Router where Handler.T 
 
         // use a dummy value for empty hosts, since we can't use an .empty component unless it's terminating a route
         // and it will match registered wildcard routes (empty routes). "|empty|" should be safe since it crashes URL 
-        //and URLComponents creation, which should avoid collisions
-        let hostComponent = Route.Component(component: route.host ?? "|empty|") // this should be
+        // and URLComponents creation, which should avoid collisions
+        let hostComponent = Route.Component(component: route.host ?? "|empty|")
         var pathComponents = route.pathComponents.filter { $0 != "/" }.map(Route.Component.init(component:))
 
         // add an empty path component if not already on the last position (to match leafs and empty nodes)

--- a/Sources/DeepLinking/Router.swift
+++ b/Sources/DeepLinking/Router.swift
@@ -36,6 +36,21 @@ public protocol Router {
     func route(_ route: URL, handleCompletion: ((T) -> Void)?) throws
 }
 
+public enum TreeRouterError: Swift.Error {
+    case invalidRoute(InvalidRouteError)
+    case duplicateRoute
+    case routeNotFound
+    case handlerTypeMismatch(expected: Any.Type, found: Any.Type)
+
+    public enum InvalidRouteError: Swift.Error {
+        case misplacedEmptyComponent
+        case conflictingVariableComponent(existing: String, new: String)
+        case invalidVariableComponent(String)
+        case invalidURL
+        case unexpected(Swift.Error)
+    }
+}
+
 public final class TreeRouter<T>: Router {
 
     public typealias Match = Route.Tree<AnyRouteHandler<T>>.Match
@@ -43,21 +58,6 @@ public final class TreeRouter<T>: Router {
     private typealias Tree = Route.Tree<AnyRouteHandler<T>>
     private typealias AnnotatedParsedRoute = (scheme: Route.Scheme, components: [Route.Component])
     private typealias ParsedRoute = (scheme: Route.Scheme, components: [Route.Component], queryItems: [URLQueryItem])
-
-    public enum Error: Swift.Error {
-        case invalidRoute(InvalidRouteError)
-        case duplicateRoute
-        case routeNotFound
-        case handlerTypeMismatch(expected: Any.Type, found: Any.Type)
-
-        public enum InvalidRouteError: Swift.Error {
-            case misplacedEmptyComponent
-            case conflictingVariableComponent(existing: String, new: String)
-            case invalidVariableComponent(String)
-            case invalidURL
-            case unexpected(Swift.Error)
-        }
-    }
 
     private var routes: Atomic<[Route.Scheme : Tree]> = Atomic([:])
 
@@ -72,15 +72,15 @@ public final class TreeRouter<T>: Router {
                 } else {
                     routes[scheme] = try Tree(route: routeComponents, handler: handler)
                 }
-            } catch Tree.Error.duplicateEmptyComponent {
-                throw Error.duplicateRoute
-            } catch Tree.Error.invalidRoute {
+            } catch Route.TreeError.duplicateEmptyComponent {
+                throw TreeRouterError.duplicateRoute
+            } catch Route.TreeError.invalidRoute {
                 // empty route elements are only allowed at the end of the route
-                throw Error.invalidRoute(.misplacedEmptyComponent)
-            } catch let Tree.Error.conflictingParameterName(existing, new) {
-                throw Error.invalidRoute(.conflictingVariableComponent(existing: existing, new: new))
+                throw TreeRouterError.invalidRoute(.misplacedEmptyComponent)
+            } catch let Route.TreeError.conflictingParameterName(existing, new) {
+                throw TreeRouterError.invalidRoute(.conflictingVariableComponent(existing: existing, new: new))
             } catch {
-                throw Error.invalidRoute(.unexpected(error))
+                throw TreeRouterError.invalidRoute(.unexpected(error))
             }
         }
     }
@@ -90,19 +90,19 @@ public final class TreeRouter<T>: Router {
         let (scheme, routeComponents) = parseAnnotatedRoute(route)
 
         return try routes.modify { routes in
-            guard var schemeTree = routes[scheme] else { throw Error.routeNotFound }
+            guard var schemeTree = routes[scheme] else { throw TreeRouterError.routeNotFound }
 
             let handler: AnyRouteHandler<T>
 
             do {
                 handler = try schemeTree.remove(route: routeComponents)
-            } catch Tree.Error.routeNotFound {
-                throw Error.routeNotFound
+            } catch Route.TreeError.routeNotFound {
+                throw TreeRouterError.routeNotFound
             } catch {
                 assertionFailure("🔥: unexpected Route.Tree.Error type!")
                 // FIXME: add logging
                 print("⚠️: unexpected error when unregistering \(route)! Error: \(error)")
-                throw Error.routeNotFound
+                throw TreeRouterError.routeNotFound
             }
 
             routes[scheme] = schemeTree
@@ -115,19 +115,19 @@ public final class TreeRouter<T>: Router {
         let (scheme, routeComponents, queryItems) = try parseRoute(route)
 
         let match: Match = try routes.modify { routes in
-            guard let schemeTree = routes[scheme] else { throw Error.routeNotFound }
+            guard let schemeTree = routes[scheme] else { throw TreeRouterError.routeNotFound }
 
             do {
                 return try schemeTree.match(route: routeComponents)
-            } catch Tree.Error.routeNotFound {
-                throw Error.routeNotFound
-            } catch let Tree.Error.invalidComponent(component) {
-                throw Error.invalidRoute(.invalidVariableComponent(component.description))
+            } catch Route.TreeError.routeNotFound {
+                throw TreeRouterError.routeNotFound
+            } catch let Route.TreeError.invalidComponent(component) {
+                throw TreeRouterError.invalidRoute(.invalidVariableComponent(component.description))
             } catch {
                 assertionFailure("🔥: unexpected Route.Tree.Error type!")
                 // FIXME: add logging
                 print("⚠️: unexpected error when routing \(route)! Error: \(error)")
-                throw Error.invalidRoute(.unexpected(error))
+                throw TreeRouterError.invalidRoute(.unexpected(error))
             }
         }
 
@@ -169,7 +169,7 @@ public final class TreeRouter<T>: Router {
         let routeComponents = [hostComponent] + pathComponents
 
         guard let urlComponents = URLComponents(url: route, resolvingAgainstBaseURL: false) else {
-            throw Error.invalidRoute(.invalidURL)
+            throw TreeRouterError.invalidRoute(.invalidURL)
         }
 
         return (scheme: scheme, components: routeComponents, queryItems: urlComponents.queryItems ?? [])

--- a/Tests/AlicerceTests/DeepLinking/Route+ComponentTests.swift
+++ b/Tests/AlicerceTests/DeepLinking/Route+ComponentTests.swift
@@ -365,4 +365,33 @@ class Route_ComponentTests: XCTestCase {
         XCTAssertNotEqual(constant, variable)
     }
 
+    // MARK: description
+
+    func testKeyDescription_ShouldMatchValue() {
+
+        let empty: Route.Component.Key = .empty
+        XCTAssertEqual(empty.description, ".empty")
+
+        let constantName = "constant"
+        let constant: Route.Component.Key = .constant(constantName)
+        XCTAssertEqual(constant.description, ".constant(\(constantName))")
+
+        let valueVariable: Route.Component.Key = .variable
+        XCTAssertEqual(valueVariable.description, ".variable")
+    }
+
+    // MARK: debugDescription
+
+    func testKeyDebugDescription_ShouldMatchValue() {
+
+        let empty: Route.Component.Key = .empty
+        XCTAssertEqual(empty.debugDescription, ".empty")
+
+        let constantName = "constant"
+        let constant: Route.Component.Key = .constant(constantName)
+        XCTAssertEqual(constant.debugDescription, ".constant(\(constantName))")
+
+        let valueVariable: Route.Component.Key = .variable
+        XCTAssertEqual(valueVariable.debugDescription, ".variable")
+    }
 }

--- a/Tests/AlicerceTests/DeepLinking/Route+Tree_AddTests.swift
+++ b/Tests/AlicerceTests/DeepLinking/Route+Tree_AddTests.swift
@@ -24,7 +24,7 @@ class Route_Tree_AddTests: XCTestCase {
         do {
             try testTree.add(route: [], handler: "💥")
             XCTFail("🔥: unexpected success!")
-        } catch TestTree.Error.duplicateEmptyComponent {
+        } catch Route.TreeError.duplicateEmptyComponent {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -38,7 +38,7 @@ class Route_Tree_AddTests: XCTestCase {
         do {
             try testTree.add(route: [], handler: "💥")
             XCTFail("🔥: unexpected success!")
-        } catch TestTree.Error.duplicateEmptyComponent {
+        } catch Route.TreeError.duplicateEmptyComponent {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -52,7 +52,7 @@ class Route_Tree_AddTests: XCTestCase {
         do {
             try testTree.add(route: [.empty], handler: "💥")
             XCTFail("🔥: unexpected success!")
-        } catch TestTree.Error.duplicateEmptyComponent {
+        } catch Route.TreeError.duplicateEmptyComponent {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -66,7 +66,7 @@ class Route_Tree_AddTests: XCTestCase {
         do {
             try testTree.add(route: [.empty], handler: "💥")
             XCTFail("🔥: unexpected success!")
-        } catch TestTree.Error.duplicateEmptyComponent {
+        } catch Route.TreeError.duplicateEmptyComponent {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -84,7 +84,7 @@ class Route_Tree_AddTests: XCTestCase {
         do {
             try testTree.add(route: [newComponent], handler: "💥")
             XCTFail("🔥: unexpected success!")
-        } catch let TestTree.Error.conflictingParameterName(existing, new) {
+        } catch let Route.TreeError.conflictingParameterName(existing, new) {
             XCTAssertEqual(existing, testParameterName)
             XCTAssertEqual(new, newParameterName)
         } catch {
@@ -102,7 +102,7 @@ class Route_Tree_AddTests: XCTestCase {
         do {
             try testTree.add(route: [newComponent], handler: "💥")
             XCTFail("🔥: unexpected success!")
-        } catch let TestTree.Error.conflictingParameterName(existing, new) {
+        } catch let Route.TreeError.conflictingParameterName(existing, new) {
             XCTAssertEqual(existing, testParameterName)
             XCTAssertEqual(new, "*")
         } catch {
@@ -120,7 +120,7 @@ class Route_Tree_AddTests: XCTestCase {
         do {
             try testTree.add(route: [newComponent], handler: "💥")
             XCTFail("🔥: unexpected success!")
-        } catch let TestTree.Error.conflictingParameterName(existing, new) {
+        } catch let Route.TreeError.conflictingParameterName(existing, new) {
             XCTAssertEqual(existing, "*")
             XCTAssertEqual(new, newParameterName)
         } catch {

--- a/Tests/AlicerceTests/DeepLinking/Route+Tree_DescriptionTests.swift
+++ b/Tests/AlicerceTests/DeepLinking/Route+Tree_DescriptionTests.swift
@@ -1,0 +1,117 @@
+//
+//  Route+Tree_DescriptionTests.swift
+//  Alicerce
+//
+//  Created by André Pacheco Neves on 06/05/2018.
+//  Copyright © 2018 Mindera. All rights reserved.
+//
+
+import XCTest
+@testable import Alicerce
+
+class Route_Tree_DescriptionTests: XCTestCase {
+
+    typealias TestTree = Route.Tree<String>
+
+    private let testHandler = "test"
+
+    // MARK: - Tree
+
+    // MARK: description
+
+    func testDescription_ShouldMatchValue() {
+
+        do {
+            let leafTree = try TestTree(route: [], handler: testHandler)
+            guard case .leaf = leafTree else { return XCTFail("🔥: unexpected node type!") }
+
+            XCTAssertEqual(leafTree.description, ".leaf(\(testHandler))")
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        let testComponent = Route.Component(component: "a")
+        let testRoute = [testComponent]
+
+        do {
+            let nodeTree =  try TestTree(route: testRoute, handler: testHandler)
+            guard case let .node(childEdges) = nodeTree else { return XCTFail("🔥: unexpected node type!") }
+
+            XCTAssertEqual(nodeTree.description, ".node(\(childEdges))")
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    // MARK: debugDescription
+
+    func testDebugDescription_ShouldMatchValue() {
+
+        do {
+            let leafTree = try TestTree(route: [], handler: testHandler)
+            guard case .leaf = leafTree else { return XCTFail("🔥: unexpected node type!") }
+
+            XCTAssertEqual(leafTree.debugDescription, ".leaf(\(testHandler))")
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        let testComponent = Route.Component(component: "a")
+        let testRoute = [testComponent]
+
+        do {
+            let nodeTree =  try TestTree(route: testRoute, handler: testHandler)
+            guard case let .node(childEdges) = nodeTree else { return XCTFail("🔥: unexpected node type!") }
+
+            XCTAssertEqual(nodeTree.debugDescription, ".node(\(childEdges.debugDescription))")
+        } catch {
+            XCTFail("🔥: unexpected error \(error)!")
+        }
+    }
+
+    // MARK: - Edge
+
+    // MARK: description
+
+    func testEdgeDescription_ShouldMatchValue() {
+
+        let tree: TestTree
+        do {
+            tree = try TestTree(route: [], handler: testHandler)
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        let simple: TestTree.Edge = .simple(tree)
+        XCTAssertEqual(simple.description, ".simple(\(tree.description))")
+
+        let parameterName = "parameter"
+        let namedParameter: TestTree.Edge = .parameter(parameterName, tree)
+        XCTAssertEqual(namedParameter.description, ".parameter(\(parameterName), \(tree.description))")
+
+        let wildcardParameter: TestTree.Edge = .parameter(nil, tree)
+        XCTAssertEqual(wildcardParameter.description, ".parameter(*, \(tree.description))")
+    }
+
+    // MARK: debugDescription
+
+    func testEdgeDebugDescription_ShouldMatchValue() {
+
+        let tree: TestTree
+        do {
+            tree = try TestTree(route: [], handler: testHandler)
+        } catch {
+            return XCTFail("🔥: unexpected error \(error)!")
+        }
+
+        let simple: TestTree.Edge = .simple(tree)
+        XCTAssertEqual(simple.debugDescription, ".simple(\(tree.debugDescription))")
+
+        let parameterName = "parameter"
+        let namedParameter: TestTree.Edge = .parameter(parameterName, tree)
+        XCTAssertEqual(namedParameter.debugDescription, ".parameter(\(parameterName), \(tree.debugDescription))")
+
+        let wildcardParameter: TestTree.Edge = .parameter(nil, tree)
+        XCTAssertEqual(wildcardParameter.debugDescription, ".parameter(*, \(tree.debugDescription))")
+    }
+}

--- a/Tests/AlicerceTests/DeepLinking/Route+Tree_InitTests.swift
+++ b/Tests/AlicerceTests/DeepLinking/Route+Tree_InitTests.swift
@@ -22,7 +22,7 @@ class Route_Tree_InitTests: XCTestCase {
         do {
             let _ = try TestTree(route: [.empty, .empty], handler: testHandler)
             XCTFail("🔥: unexpected success!")
-        } catch Route.Tree<String>.Error.invalidRoute {
+        } catch Route.TreeError.invalidRoute {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -31,7 +31,7 @@ class Route_Tree_InitTests: XCTestCase {
         do {
             let _ = try TestTree(route: [.empty, .constant("a")], handler: testHandler)
             XCTFail("🔥: unexpected success!")
-        } catch Route.Tree<String>.Error.invalidRoute {
+        } catch Route.TreeError.invalidRoute {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -40,7 +40,7 @@ class Route_Tree_InitTests: XCTestCase {
         do {
             let _ = try TestTree(route: [.empty, .variable("a")], handler: testHandler)
             XCTFail("🔥: unexpected success!")
-        } catch Route.Tree<String>.Error.invalidRoute {
+        } catch Route.TreeError.invalidRoute {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -49,7 +49,7 @@ class Route_Tree_InitTests: XCTestCase {
         do {
             let _ = try TestTree(route: [.empty, .variable(nil)], handler: testHandler)
             XCTFail("🔥: unexpected success!")
-        } catch Route.Tree<String>.Error.invalidRoute {
+        } catch Route.TreeError.invalidRoute {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")

--- a/Tests/AlicerceTests/DeepLinking/Route+Tree_MatchTests.swift
+++ b/Tests/AlicerceTests/DeepLinking/Route+Tree_MatchTests.swift
@@ -25,7 +25,7 @@ class Route_Tree_MatchTests: XCTestCase {
 
         do {
             let _ = try testTree.match(route: [.constant("a")])
-        } catch TestTree.Error.routeNotFound {
+        } catch Route.TreeError.routeNotFound {
             // expected error 💪
         } catch {
             return XCTFail("🔥: unexpected error \(error)!")
@@ -33,7 +33,7 @@ class Route_Tree_MatchTests: XCTestCase {
 
         do {
             let _ = try testTree.match(route: [.variable("a")])
-        } catch TestTree.Error.routeNotFound {
+        } catch Route.TreeError.routeNotFound {
             // expected error 💪
         } catch {
             return XCTFail("🔥: unexpected error \(error)!")
@@ -41,7 +41,7 @@ class Route_Tree_MatchTests: XCTestCase {
 
         do {
             let _ = try testTree.match(route: [.variable(nil)])
-        } catch TestTree.Error.routeNotFound {
+        } catch Route.TreeError.routeNotFound {
             // expected error 💪
         } catch {
             return XCTFail("🔥: unexpected error \(error)!")
@@ -54,7 +54,7 @@ class Route_Tree_MatchTests: XCTestCase {
 
         do {
             let _ = try testTree.match(route: [.empty, .constant("a")])
-        } catch TestTree.Error.routeNotFound {
+        } catch Route.TreeError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -62,7 +62,7 @@ class Route_Tree_MatchTests: XCTestCase {
 
         do {
             let _ = try testTree.match(route: [.variable(nil), .constant("a")])
-        } catch TestTree.Error.routeNotFound {
+        } catch Route.TreeError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -70,7 +70,7 @@ class Route_Tree_MatchTests: XCTestCase {
 
         do {
             let _ = try testTree.match(route: [.variable("a"), .constant("b")])
-        } catch TestTree.Error.routeNotFound {
+        } catch Route.TreeError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -78,7 +78,7 @@ class Route_Tree_MatchTests: XCTestCase {
 
         do {
             let _ = try testTree.match(route: [.constant("a"), .variable("b")])
-        } catch TestTree.Error.routeNotFound {
+        } catch Route.TreeError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -97,7 +97,7 @@ class Route_Tree_MatchTests: XCTestCase {
         do {
             let _ = try testTree.match(route: matchRoute)
             XCTFail("🔥: unexpected success!")
-        } catch let TestTree.Error.invalidComponent(component) {
+        } catch let Route.TreeError.invalidComponent(component) {
             XCTAssertEqual(component, variableComponent)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -114,7 +114,7 @@ class Route_Tree_MatchTests: XCTestCase {
         do {
             let _ = try testTree.match(route: matchRoute)
             XCTFail("🔥: unexpected success!")
-        } catch let TestTree.Error.invalidComponent(component) {
+        } catch let Route.TreeError.invalidComponent(component) {
             XCTAssertEqual(component, variableComponent)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -131,7 +131,7 @@ class Route_Tree_MatchTests: XCTestCase {
 
         do {
             let _ = try testTree.match(route: matchRoute)
-        } catch TestTree.Error.routeNotFound {
+        } catch Route.TreeError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -148,7 +148,7 @@ class Route_Tree_MatchTests: XCTestCase {
 
         do {
             let _ = try testTree.match(route: matchRoute)
-        } catch TestTree.Error.routeNotFound {
+        } catch Route.TreeError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -165,7 +165,7 @@ class Route_Tree_MatchTests: XCTestCase {
 
         do {
             let _ = try testTree.match(route: matchRoute)
-        } catch TestTree.Error.routeNotFound {
+        } catch Route.TreeError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -184,7 +184,7 @@ class Route_Tree_MatchTests: XCTestCase {
             // TODO: evaluate if it makes sense to consider .empty as a valid value parameter
             // e.g.: should "/a/" match "/a/:p"?
             let _ = try testTree.match(route: matchRoute)
-        } catch TestTree.Error.routeNotFound {
+        } catch Route.TreeError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -203,7 +203,7 @@ class Route_Tree_MatchTests: XCTestCase {
             // TODO: evaluate if it makes sense to consider .empty as a valid wildcard parameter
             // e.g.: should "/a/" match "/a/*"?
             let _ = try testTree.match(route: matchRoute)
-        } catch TestTree.Error.routeNotFound {
+        } catch Route.TreeError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -225,7 +225,7 @@ class Route_Tree_MatchTests: XCTestCase {
 
         do {
             let _ = try testTree.match(route: matchRoute)
-        } catch TestTree.Error.routeNotFound {
+        } catch Route.TreeError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -245,7 +245,7 @@ class Route_Tree_MatchTests: XCTestCase {
 
         do {
             let _ = try testTree.match(route: matchRoute)
-        } catch TestTree.Error.routeNotFound {
+        } catch Route.TreeError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -268,7 +268,7 @@ class Route_Tree_MatchTests: XCTestCase {
         var matchRoute = [nonExistentComponent]
         do {
             let _ = try testTree.match(route: matchRoute)
-        } catch TestTree.Error.routeNotFound {
+        } catch Route.TreeError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -278,7 +278,7 @@ class Route_Tree_MatchTests: XCTestCase {
         matchRoute = [testComponentA, nonExistentComponent]
         do {
             let _ = try testTree.match(route: matchRoute)
-        } catch TestTree.Error.routeNotFound {
+        } catch Route.TreeError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -299,7 +299,7 @@ class Route_Tree_MatchTests: XCTestCase {
 
         do {
             let _ = try testTree.match(route: matchRoute)
-        } catch TestTree.Error.routeNotFound {
+        } catch Route.TreeError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -320,7 +320,7 @@ class Route_Tree_MatchTests: XCTestCase {
 
         do {
             let _ = try testTree.match(route: matchRoute)
-        } catch TestTree.Error.routeNotFound {
+        } catch Route.TreeError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -340,7 +340,7 @@ class Route_Tree_MatchTests: XCTestCase {
 
         do {
             let _ = try testTree.match(route: matchRoute)
-        } catch TestTree.Error.routeNotFound {
+        } catch Route.TreeError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -360,7 +360,7 @@ class Route_Tree_MatchTests: XCTestCase {
 
         do {
             let _ = try testTree.match(route: matchRoute)
-        } catch TestTree.Error.routeNotFound {
+        } catch Route.TreeError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -380,7 +380,7 @@ class Route_Tree_MatchTests: XCTestCase {
 
         do {
             let _ = try testTree.match(route: matchRoute)
-        } catch TestTree.Error.routeNotFound {
+        } catch Route.TreeError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")

--- a/Tests/AlicerceTests/DeepLinking/Route+Tree_RemoveTests.swift
+++ b/Tests/AlicerceTests/DeepLinking/Route+Tree_RemoveTests.swift
@@ -26,7 +26,7 @@ class Route_Tree_RemoveTests: XCTestCase {
         do {
             // TODO: perhaps removing an `.empty` from a leaf should behave as an empty route 🤔
             let _ = try testTree.remove(route: [.empty, .constant("a")])
-        } catch TestTree.Error.routeNotFound {
+        } catch Route.TreeError.routeNotFound {
             // expected error 💪
         } catch {
             return XCTFail("🔥: unexpected error \(error)!")
@@ -49,7 +49,7 @@ class Route_Tree_RemoveTests: XCTestCase {
 
         do {
             let _ = try testTree.remove(route: removeRoute)
-        } catch TestTree.Error.routeNotFound {
+        } catch Route.TreeError.routeNotFound {
             // expected error 💪
         } catch {
             return XCTFail("🔥: unexpected error \(error)!")
@@ -75,7 +75,7 @@ class Route_Tree_RemoveTests: XCTestCase {
 
         do {
             let _ = try testTree.remove(route: removeRoute)
-        } catch TestTree.Error.routeNotFound {
+        } catch Route.TreeError.routeNotFound {
             // expected error 💪
         } catch {
             return XCTFail("🔥: unexpected error \(error)!")
@@ -100,7 +100,7 @@ class Route_Tree_RemoveTests: XCTestCase {
         do {
             // test empty vs constant match
             let _ = try testTree.remove(route: [.constant("a")])
-        } catch TestTree.Error.routeNotFound {
+        } catch Route.TreeError.routeNotFound {
             // expected error 💪
         } catch {
             return XCTFail("🔥: unexpected error \(error)!")
@@ -109,7 +109,7 @@ class Route_Tree_RemoveTests: XCTestCase {
         do {
             // empty vs variable
             let _ = try testTree.remove(route: [.variable("a")])
-        } catch TestTree.Error.routeNotFound {
+        } catch Route.TreeError.routeNotFound {
             // expected error 💪
         } catch {
             return XCTFail("🔥: unexpected error \(error)!")
@@ -143,7 +143,7 @@ class Route_Tree_RemoveTests: XCTestCase {
 
         do {
             let _ = try testTree.remove(route: removeRoute)
-        } catch TestTree.Error.routeNotFound {
+        } catch Route.TreeError.routeNotFound {
             // expected error 💪
         } catch {
             return XCTFail("🔥: unexpected error \(error)!")
@@ -176,7 +176,7 @@ class Route_Tree_RemoveTests: XCTestCase {
 
         do {
             let _ = try testTree.remove(route: removeRoute)
-        } catch TestTree.Error.routeNotFound {
+        } catch Route.TreeError.routeNotFound {
             // expected error 💪
         } catch {
             return XCTFail("🔥: unexpected error \(error)!")
@@ -212,7 +212,7 @@ class Route_Tree_RemoveTests: XCTestCase {
 
         do {
             let _ = try testTree.remove(route: removeRoute)
-        } catch TestTree.Error.routeNotFound {
+        } catch Route.TreeError.routeNotFound {
             // expected error 💪
         } catch {
             return XCTFail("🔥: unexpected error \(error)!")
@@ -248,7 +248,7 @@ class Route_Tree_RemoveTests: XCTestCase {
 
         do {
             let _ = try testTree.remove(route: removeRoute)
-        } catch TestTree.Error.routeNotFound {
+        } catch Route.TreeError.routeNotFound {
             // expected error 💪
         } catch {
             return XCTFail("🔥: unexpected error \(error)!")
@@ -282,7 +282,7 @@ class Route_Tree_RemoveTests: XCTestCase {
 
         do {
             let _ = try testTree.remove(route: removeRoute)
-        } catch TestTree.Error.routeNotFound {
+        } catch Route.TreeError.routeNotFound {
             // expected error 💪
         } catch {
             return XCTFail("🔥: unexpected error \(error)!")
@@ -317,7 +317,7 @@ class Route_Tree_RemoveTests: XCTestCase {
 
         do {
             let _ = try testTree.remove(route: removeRoute)
-        } catch TestTree.Error.routeNotFound {
+        } catch Route.TreeError.routeNotFound {
             // expected error 💪
         } catch {
             return XCTFail("🔥: unexpected error \(error)!")

--- a/Tests/AlicerceTests/DeepLinking/TreeRouterTests.swift
+++ b/Tests/AlicerceTests/DeepLinking/TreeRouterTests.swift
@@ -68,7 +68,7 @@ class TreeRouterTests: XCTestCase {
         do {
             try router.register(duplicateRoute, handler: testHandler)
             XCTFail("🔥: unexpected success!")
-        } catch TestRouter.Error.duplicateRoute {
+        } catch TreeRouterError.duplicateRoute {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -89,7 +89,7 @@ class TreeRouterTests: XCTestCase {
         do {
             try router.register(duplicateRoute, handler: testHandler)
             XCTFail("🔥: unexpected success!")
-        } catch TestRouter.Error.duplicateRoute {
+        } catch TreeRouterError.duplicateRoute {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -110,7 +110,7 @@ class TreeRouterTests: XCTestCase {
         do {
             try router.register(duplicateRoute, handler: testHandler)
             XCTFail("🔥: unexpected success!")
-        } catch TestRouter.Error.duplicateRoute {
+        } catch TreeRouterError.duplicateRoute {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -131,7 +131,7 @@ class TreeRouterTests: XCTestCase {
         do {
             try router.register(duplicateRoute, handler: testHandler)
             XCTFail("🔥: unexpected success!")
-        } catch TestRouter.Error.duplicateRoute {
+        } catch TreeRouterError.duplicateRoute {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -158,7 +158,7 @@ class TreeRouterTests: XCTestCase {
         do {
             try router.register(invalidRouteA, handler: testHandler)
             XCTFail("🔥: unexpected success!")
-        } catch let TestRouter.Error.invalidRoute(.conflictingVariableComponent(existing, new)) {
+        } catch let TreeRouterError.invalidRoute(.conflictingVariableComponent(existing, new)) {
             // expected error 💪
             XCTAssertEqual(existing, existingParameterName)
             XCTAssertEqual(new, conflictingParameterNameA)
@@ -170,7 +170,7 @@ class TreeRouterTests: XCTestCase {
         do {
             try router.register(invalidRouteB, handler: testHandler)
             XCTFail("🔥: unexpected success!")
-        } catch let TestRouter.Error.invalidRoute(.conflictingVariableComponent(existing, new)) {
+        } catch let TreeRouterError.invalidRoute(.conflictingVariableComponent(existing, new)) {
             // expected error 💪
             XCTAssertEqual(existing, existingParameterName)
             XCTAssertEqual(new, conflictingParameterNameB)
@@ -276,7 +276,7 @@ class TreeRouterTests: XCTestCase {
         do {
             let _ = try router.unregister(route)
             XCTFail("🔥: unexpected success!")
-        } catch TestRouter.Error.routeNotFound {
+        } catch TreeRouterError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -289,7 +289,7 @@ class TreeRouterTests: XCTestCase {
         do {
             let _ = try router.unregister(route)
             XCTFail("🔥: unexpected success!")
-        } catch TestRouter.Error.routeNotFound {
+        } catch TreeRouterError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -310,7 +310,7 @@ class TreeRouterTests: XCTestCase {
         do {
             let _ = try router.unregister(nonExistentRoute)
             XCTFail("🔥: unexpected success!")
-        } catch TestRouter.Error.routeNotFound {
+        } catch TreeRouterError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -331,7 +331,7 @@ class TreeRouterTests: XCTestCase {
         do {
             let _ = try router.unregister(nonExistentRoute)
             XCTFail("🔥: unexpected success!")
-        } catch TestRouter.Error.routeNotFound {
+        } catch TreeRouterError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -352,7 +352,7 @@ class TreeRouterTests: XCTestCase {
         do {
             let _ = try router.unregister(nonExistentRoute)
             XCTFail("🔥: unexpected success!")
-        } catch TestRouter.Error.routeNotFound {
+        } catch TreeRouterError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -376,7 +376,7 @@ class TreeRouterTests: XCTestCase {
         do {
             let _ = try router.unregister(partialMatchRouteA)
             XCTFail("🔥: unexpected success!")
-        } catch TestRouter.Error.routeNotFound {
+        } catch TreeRouterError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -385,7 +385,7 @@ class TreeRouterTests: XCTestCase {
         do {
             let _ = try router.unregister(partialMatchRouteB)
             XCTFail("🔥: unexpected success!")
-        } catch TestRouter.Error.routeNotFound {
+        } catch TreeRouterError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -407,7 +407,7 @@ class TreeRouterTests: XCTestCase {
         do {
             let _ = try router.unregister(partialMatchRouteA)
             XCTFail("🔥: unexpected success!")
-        } catch TestRouter.Error.routeNotFound {
+        } catch TreeRouterError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -416,7 +416,7 @@ class TreeRouterTests: XCTestCase {
         do {
             let _ = try router.unregister(partialMatchRouteB)
             XCTFail("🔥: unexpected success!")
-        } catch TestRouter.Error.routeNotFound {
+        } catch TreeRouterError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -438,7 +438,7 @@ class TreeRouterTests: XCTestCase {
         do {
             let _ = try router.unregister(partialMatchRouteA)
             XCTFail("🔥: unexpected success!")
-        } catch TestRouter.Error.routeNotFound {
+        } catch TreeRouterError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -447,7 +447,7 @@ class TreeRouterTests: XCTestCase {
         do {
             let _ = try router.unregister(partialMatchRouteB)
             XCTFail("🔥: unexpected success!")
-        } catch TestRouter.Error.routeNotFound {
+        } catch TreeRouterError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -469,7 +469,7 @@ class TreeRouterTests: XCTestCase {
         do {
             let _ = try router.unregister(partialMatchRouteA)
             XCTFail("🔥: unexpected success!")
-        } catch TestRouter.Error.routeNotFound {
+        } catch TreeRouterError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -478,7 +478,7 @@ class TreeRouterTests: XCTestCase {
         do {
             let _ = try router.unregister(partialMatchRouteB)
             XCTFail("🔥: unexpected success!")
-        } catch TestRouter.Error.routeNotFound {
+        } catch TreeRouterError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -831,7 +831,7 @@ class TreeRouterTests: XCTestCase {
         do {
             try router.route(invalidRoute)
             XCTFail("🔥: unexpected success!")
-        } catch TestRouter.Error.routeNotFound {
+        } catch TreeRouterError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -844,7 +844,7 @@ class TreeRouterTests: XCTestCase {
         do {
             try router.route(route)
             XCTFail("🔥: unexpected success!")
-        } catch TestRouter.Error.routeNotFound {
+        } catch TreeRouterError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -857,7 +857,7 @@ class TreeRouterTests: XCTestCase {
         do {
             try router.route(route)
             XCTFail("🔥: unexpected success!")
-        } catch TestRouter.Error.routeNotFound {
+        } catch TreeRouterError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -878,7 +878,7 @@ class TreeRouterTests: XCTestCase {
         do {
             try router.route(nonExistentRoute)
             XCTFail("🔥: unexpected success!")
-        } catch TestRouter.Error.routeNotFound {
+        } catch TreeRouterError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -899,7 +899,7 @@ class TreeRouterTests: XCTestCase {
         do {
             try router.route(nonExistentRoute)
             XCTFail("🔥: unexpected success!")
-        } catch TestRouter.Error.routeNotFound {
+        } catch TreeRouterError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -923,7 +923,7 @@ class TreeRouterTests: XCTestCase {
         do {
             try router.route(partialMatchRouteA)
             XCTFail("🔥: unexpected success!")
-        } catch TestRouter.Error.routeNotFound {
+        } catch TreeRouterError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -932,7 +932,7 @@ class TreeRouterTests: XCTestCase {
         do {
             try router.route(partialMatchRouteB)
             XCTFail("🔥: unexpected success!")
-        } catch TestRouter.Error.routeNotFound {
+        } catch TreeRouterError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -954,7 +954,7 @@ class TreeRouterTests: XCTestCase {
         do {
             try router.route(partialMatchRouteA)
             XCTFail("🔥: unexpected success!")
-        } catch TestRouter.Error.routeNotFound {
+        } catch TreeRouterError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -963,7 +963,7 @@ class TreeRouterTests: XCTestCase {
         do {
             try router.route(partialMatchRouteB)
             XCTFail("🔥: unexpected success!")
-        } catch TestRouter.Error.routeNotFound {
+        } catch TreeRouterError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -985,7 +985,7 @@ class TreeRouterTests: XCTestCase {
         do {
             try router.route(partialMatchRouteA)
             XCTFail("🔥: unexpected success!")
-        } catch TestRouter.Error.routeNotFound {
+        } catch TreeRouterError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -994,7 +994,7 @@ class TreeRouterTests: XCTestCase {
         do {
             try router.route(partialMatchRouteB)
             XCTFail("🔥: unexpected success!")
-        } catch TestRouter.Error.routeNotFound {
+        } catch TreeRouterError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -1016,7 +1016,7 @@ class TreeRouterTests: XCTestCase {
         do {
             try router.route(partialMatchRouteA)
             XCTFail("🔥: unexpected success!")
-        } catch TestRouter.Error.routeNotFound {
+        } catch TreeRouterError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -1025,7 +1025,7 @@ class TreeRouterTests: XCTestCase {
         do {
             try router.route(partialMatchRouteB)
             XCTFail("🔥: unexpected success!")
-        } catch TestRouter.Error.routeNotFound {
+        } catch TreeRouterError.routeNotFound {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -1053,7 +1053,7 @@ class TreeRouterTests: XCTestCase {
         do {
             try router.route(invalidRouteA)
             XCTFail("🔥: unexpected success!")
-        } catch TestRouter.Error.invalidRoute(.invalidURL) {
+        } catch TreeRouterError.invalidRoute(.invalidURL) {
             // expected error 💪
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
@@ -1062,7 +1062,7 @@ class TreeRouterTests: XCTestCase {
         do {
             try router.route(invalidRouteB)
             XCTFail("🔥: unexpected success!")
-        } catch let TestRouter.Error.invalidRoute(.invalidVariableComponent(component)) {
+        } catch let TreeRouterError.invalidRoute(.invalidVariableComponent(component)) {
             // expected error 💪
             XCTAssertEqual(component, variableComponentB.description)
         } catch {
@@ -1089,7 +1089,7 @@ class TreeRouterTests: XCTestCase {
         do {
             try router.route(invalidRouteA)
             XCTFail("🔥: unexpected success!")
-        } catch let TestRouter.Error.invalidRoute(.invalidVariableComponent(component)) {
+        } catch let TreeRouterError.invalidRoute(.invalidVariableComponent(component)) {
             // expected error 💪
             XCTAssertEqual(component, variableComponentA.description)
         } catch {
@@ -1099,7 +1099,7 @@ class TreeRouterTests: XCTestCase {
         do {
             try router.route(invalidRouteB)
             XCTFail("🔥: unexpected success!")
-        } catch let TestRouter.Error.invalidRoute(.invalidVariableComponent(component)) {
+        } catch let TreeRouterError.invalidRoute(.invalidVariableComponent(component)) {
             // expected error 💪
             XCTAssertEqual(component, variableComponentB.description)
         } catch {

--- a/Tests/AlicerceTests/DeepLinking/TreeRouterTests.swift
+++ b/Tests/AlicerceTests/DeepLinking/TreeRouterTests.swift
@@ -23,7 +23,7 @@ final class TestHandler: RouteHandler {
 
 class TreeRouterTests: XCTestCase {
 
-    typealias TestRouter = TreeRouter<TestHandler, HandledRoute>
+    typealias TestRouter = TreeRouter<HandledRoute>
     typealias TestRouteTree = Route.Tree<TestHandler>
 
     fileprivate let expectationTimeout: TimeInterval = 5
@@ -34,13 +34,13 @@ class TreeRouterTests: XCTestCase {
     }
 
     var router: TestRouter!
-    var testHandler: TestHandler!
+    var testHandler: AnyRouteHandler<HandledRoute>!
     
     override func setUp() {
         super.setUp()
 
         router = TestRouter()
-        testHandler = TestHandler()
+        testHandler = AnyRouteHandler(TestHandler())
     }
     
     override func tearDown() {
@@ -1132,7 +1132,7 @@ class TreeRouterTests: XCTestCase {
         }
 
         do {
-            try router.route(route, completion: completion)
+            try router.route(route, handleCompletion: completion)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
             expectation.fulfill()
@@ -1162,7 +1162,7 @@ class TreeRouterTests: XCTestCase {
         }
 
         do {
-            try router.route(route, completion: completion)
+            try router.route(route, handleCompletion: completion)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
             expectation.fulfill()
@@ -1192,7 +1192,7 @@ class TreeRouterTests: XCTestCase {
         }
 
         do {
-            try router.route(route, completion: completion)
+            try router.route(route, handleCompletion: completion)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
             expectation.fulfill()
@@ -1222,7 +1222,7 @@ class TreeRouterTests: XCTestCase {
         }
 
         do {
-            try router.route(route, completion: completion)
+            try router.route(route, handleCompletion: completion)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
             expectation.fulfill()
@@ -1254,7 +1254,7 @@ class TreeRouterTests: XCTestCase {
         }
 
         do {
-            try router.route(routeA, completion: completionA)
+            try router.route(routeA, handleCompletion: completionA)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
             expectationA.fulfill()
@@ -1270,7 +1270,7 @@ class TreeRouterTests: XCTestCase {
         }
 
         do {
-            try router.route(routeB, completion: completionB)
+            try router.route(routeB, handleCompletion: completionB)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
             expectationB.fulfill()
@@ -1302,7 +1302,7 @@ class TreeRouterTests: XCTestCase {
         }
 
         do {
-            try router.route(routeA, completion: completionA)
+            try router.route(routeA, handleCompletion: completionA)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
             expectationA.fulfill()
@@ -1318,7 +1318,7 @@ class TreeRouterTests: XCTestCase {
         }
 
         do {
-            try router.route(routeB, completion: completionB)
+            try router.route(routeB, handleCompletion: completionB)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
             expectationB.fulfill()
@@ -1350,7 +1350,7 @@ class TreeRouterTests: XCTestCase {
         }
 
         do {
-            try router.route(routeA, completion: completionA)
+            try router.route(routeA, handleCompletion: completionA)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
             expectationA.fulfill()
@@ -1366,7 +1366,7 @@ class TreeRouterTests: XCTestCase {
         }
 
         do {
-            try router.route(routeB, completion: completionB)
+            try router.route(routeB, handleCompletion: completionB)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
             expectationB.fulfill()
@@ -1407,7 +1407,7 @@ class TreeRouterTests: XCTestCase {
         }
 
         do {
-            try router.route(routeA, completion: completionA)
+            try router.route(routeA, handleCompletion: completionA)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
             expectationA.fulfill()
@@ -1424,7 +1424,7 @@ class TreeRouterTests: XCTestCase {
         }
 
         do {
-            try router.route(routeB, completion: completionB)
+            try router.route(routeB, handleCompletion: completionB)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
             expectationB.fulfill()
@@ -1458,7 +1458,7 @@ class TreeRouterTests: XCTestCase {
         }
 
         do {
-            try router.route(routeA, completion: completionA)
+            try router.route(routeA, handleCompletion: completionA)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
             expectationA.fulfill()
@@ -1474,7 +1474,7 @@ class TreeRouterTests: XCTestCase {
         }
 
         do {
-            try router.route(routeB, completion: completionB)
+            try router.route(routeB, handleCompletion: completionB)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
             expectationB.fulfill()
@@ -1516,7 +1516,7 @@ class TreeRouterTests: XCTestCase {
         }
 
         do {
-            try router.route(routeA, completion: completionA)
+            try router.route(routeA, handleCompletion: completionA)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
             expectationA.fulfill()
@@ -1532,7 +1532,7 @@ class TreeRouterTests: XCTestCase {
         }
 
         do {
-            try router.route(routeB, completion: completionB)
+            try router.route(routeB, handleCompletion: completionB)
         } catch {
             XCTFail("🔥: unexpected error \(error)!")
             expectationB.fulfill()


### PR DESCRIPTION
## Changes

#### Improve `Router` and `TreeRouter` API’s

- Allow multiple `RouteHandler`'s per `TreeRouter`

Since `TreeRouter` was generic on `RouteHandler` and `T` (because of the
completion closure having a `T`), only a single `RouteHandler`
implementation could be used.

To enable multiple handlers on a single `TreeRouter` (simplifying it to
`TreeRouter<T>`, a new type erasing `AnyRouteHandler<T>` was created
to wrap any handler implementation using a `T`.

- Improved `TreeRouter` API

  + Added `@discardableResult` to `unregister`
  + Changed `completion` on `route` API to `handleCompletion`, to be
clearer as to what it means (i.e. it's only run when a match is
found and the handler executes)

- Removed private queue from `TreeRouter` and replaced with an `Atomic`

- Removed `register` and `unregister` from `Router` API

#### Unnest Errors in Route types

Because the `Route.Tree` and `TreeRouter` are generic, their nested
`Error`'s also were, which made it less flexible to handle, because
each generic specialization had in practice its own `Error` type.

#### Add and reorganize `Route.X` conformances

- Added some missing `CustomStringConvertible` and
`CustomDebugStringConvertible` conformances on `Route` subtypes.

- Reorganized protocol conformances to be on extensions.