### PR TITLE
Fix `StoreTestCase` tests failing under high load

### DIFF
--- a/Tests/AlicerceTests/Network/MockNetworkStack.swift
+++ b/Tests/AlicerceTests/Network/MockNetworkStack.swift
@@ -30,7 +30,7 @@ final class MockNetworkStack: NetworkStack {
     var beforeFetchCompletionClosure: (() -> Void)?
     var afterFetchCompletionClosure: (() -> Void)?
 
-    init(queue: DispatchQueue = DispatchQueue.global()) {
+    init(queue: DispatchQueue = DispatchQueue(label: "com.mindera.alicerce.MockNetworkStack")) {
 
         self.queue = queue
     }

--- a/Tests/AlicerceTests/Stores/StoreTestCase.swift
+++ b/Tests/AlicerceTests/Stores/StoreTestCase.swift
@@ -341,7 +341,7 @@ class StoreTestCase: XCTestCase {
 
         // force fetch to wait for the beforeFetchCompletionClosure to be set
         let semaphore = DispatchSemaphore(value: 0)
-        networkStack.queue.async(flags: .barrier) { semaphore.wait() }
+        networkStack.queue.async { semaphore.wait() }
 
         // When
         let cancelable = store.fetch(resource: resource) { (value, error) in
@@ -402,7 +402,7 @@ class StoreTestCase: XCTestCase {
 
         // force fetch to wait for the cancelClosure to be set
         let semaphore = DispatchSemaphore(value: 0)
-        networkStack.queue.async(flags: .barrier) { semaphore.wait() }
+        networkStack.queue.async { semaphore.wait() }
 
         // When
         let cancelable = store.fetch(resource: resource) { (value, error) in


### PR DESCRIPTION
When the CI environment is under high load (i.e. few available cores), some `StoreTestCase` tests failed sporadically. This could be confirmed by forcing the test suite to run on a single core (e.g. via
Instruments).

This was most likely caused by timing issues, and the fact that we were using a global concurrent queue on `MockNetworkStack`.