### PR TITLE
Logging improvements 🗒

### DIFF
--- a/Sources/Extensions/Thread.swift
+++ b/Sources/Extensions/Thread.swift
@@ -17,8 +17,7 @@ public extension Thread {
 
         if let threadName = current.name, !threadName.isEmpty {
             return threadName
-        }
-        else {
+        } else {
             return String(format: "%p", current)
         }
     }

--- a/Sources/Logging/Log+ConsoleLogDestination.swift
+++ b/Sources/Logging/Log+ConsoleLogDestination.swift
@@ -14,13 +14,12 @@ public extension Log {
 
         public typealias OutputClosure = ((Level, String) -> Void)
 
-        public let queue: Queue
         public let minLevel: Level
         public let formatter: LogItemFormatter
+        private let queue: Queue
+        private let outputClosure: OutputClosure
 
-        private(set) var outputClosure: OutputClosure
-
-        //MARK:- lifecycle
+        // MARK: - Lifecycle
 
         public init(minLevel: Level = .error,
                     formatter: LogItemFormatter = StringLogItemFormatter(),
@@ -33,15 +32,14 @@ public extension Log {
             self.outputClosure = outputClosure
         }
 
-        //MARK:- public methods
+        // MARK: - Public methods
 
-        public func write(item: Item) {
-            queue.dispatchQueue.async { [weak self] in
-                guard let strongSelf = self else { return }
-                let formattedLogItem = strongSelf.formatter.format(logItem: item)
+        public func write(item: Log.Item, failure: @escaping (Swift.Error) -> ()) {
+            queue.dispatchQueue.async { [unowned self] in
+                let formattedLogItem = self.formatter.format(logItem: item)
                 guard !formattedLogItem.isEmpty else { return }
 
-                strongSelf.outputClosure(item.level, formattedLogItem)
+                self.outputClosure(item.level, formattedLogItem)
             }
         }
     }

--- a/Sources/Logging/Log+JSONLogItemFormatter.swift
+++ b/Sources/Logging/Log+JSONLogItemFormatter.swift
@@ -12,16 +12,35 @@ public extension Log {
 
     public struct JSONLogItemFormatter: LogItemFormatter {
 
+        public enum LogKey {
+            static let timestamp = "timestamp"
+            static let level = "level"
+            static let message = "message"
+            static let thread = "thread"
+            static let file = "file"
+            static let function = "function"
+            static let line = "line"
+        }
+
+        private let dateEncoder: (Date) -> Any
+        private let levelEncoder: (Level) -> Any
+
+        init(dateEncoder: @escaping (Date) -> Any = { $0.timeIntervalSince1970 },
+             levelEncoder: @escaping (Level) -> Any = { $0.rawValue }) {
+            self.dateEncoder = dateEncoder
+            self.levelEncoder = levelEncoder
+        }
+
         public func format(logItem: Item) -> String {
 
-            let dict: [String: Any] = [
-                "timestamp": Date().timeIntervalSince1970,
-                "level": logItem.level.rawValue,
-                "message": logItem.message,
-                "thread": logItem.thread,
-                "file": logItem.file,
-                "function": logItem.function,
-                "line": logItem.line
+            let dict: JSON.Dictionary = [
+                LogKey.timestamp: dateEncoder(Date()),
+                LogKey.level: levelEncoder(logItem.level),
+                LogKey.message: logItem.message,
+                LogKey.thread: logItem.thread,
+                LogKey.file: logItem.file,
+                LogKey.function: logItem.function,
+                LogKey.line: logItem.line
             ]
 
             guard let jsonData = try? JSONSerialization.data(withJSONObject: dict, options: []) else {

--- a/Sources/Logging/Log+StringLogItemFormatter.swift
+++ b/Sources/Logging/Log+StringLogItemFormatter.swift
@@ -16,7 +16,7 @@ public extension Log {
         public let dateFormatter: DateFormatter
         public let levelFormatter: LogItemLevelFormatter
 
-        // MARK:- Lifecycle
+        // MARK: - Lifecycle
 
         public init(formatString: String = "$DHH:mm:ss.SSS$d $C$L$c $N.$F:$l - $M",
                     levelFormatter: LogItemLevelFormatter = DefaultLogItemLevelFormatter(),
@@ -75,7 +75,7 @@ public extension Log {
             return text
         }
 
-        //MARK:- private methods
+        // MARK: - Private methods
 
         private func formatDate(_ dateFormat: String) -> String {
 

--- a/Sources/Logging/Protocols/LogDestination.swift
+++ b/Sources/Logging/Protocols/LogDestination.swift
@@ -10,22 +10,18 @@ import Foundation
 
 public protocol LogDestination: class {
 
+    typealias ID = String
+
     var minLevel: Log.Level { get }
     var formatter: LogItemFormatter { get }
-    var instanceId: String { get }
-    var queue: Log.Queue { get }
+    var id: ID { get }
 
-    func write(item: Log.Item)
-}
-
-public protocol LogDestinationFallible: LogDestination {
-
-    var errorClosure: ((LogDestination, Log.Item, Error) -> ())? { get set }
+    func write(item: Log.Item, failure: @escaping (Error) -> ())
 }
 
 extension LogDestination {
 
-    public var instanceId: String {
+    public var id: ID {
         return "\(type(of: self))"
     }
 }

--- a/Sources/Logging/Protocols/Logger.swift
+++ b/Sources/Logging/Protocols/Logger.swift
@@ -8,8 +8,6 @@
 
 public protocol Logger {
 
-    // MARK:- Logging
-
     func verbose(_ message: @autoclosure () -> String,
                  file: StaticString,
                  function: StaticString,

--- a/Tests/AlicerceTests/Logging/ConsoleLogDestinationTests.swift
+++ b/Tests/AlicerceTests/Logging/ConsoleLogDestinationTests.swift
@@ -23,7 +23,7 @@ class ConsoleLogDestinationsTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        log = Log(qos: .default)
+        log = Log()
         queue = Log.Queue(label: "ConsoleLogDestinationsTests")
     }
 
@@ -71,7 +71,12 @@ class ConsoleLogDestinationsTests: XCTestCase {
 
         // execute test
 
-        log.register(destination)
+        do {
+            try log.register(destination)
+        } catch {
+            return XCTFail("unexpected error \(error)!")
+        }
+
         log.verbose("verbose message")
         log.debug("debug message")
         log.info("info message")

--- a/Tests/AlicerceTests/Logging/Destinations/Log+StringLogDestination.swift
+++ b/Tests/AlicerceTests/Logging/Destinations/Log+StringLogDestination.swift
@@ -12,36 +12,31 @@ public extension Log {
 
     public class StringLogDestination: LogDestination {
 
-        public let queue: Queue
         public let minLevel: Level
         public let formatter: LogItemFormatter
-        public var output = ""
-        public var linefeed = "\n"
+        public let logSeparator: String
 
-        //MARK:- lifecycle
+        public private(set) var output = ""
+
+        // MARK: - Lifecycle
 
         public init(minLevel: Level = Level.error,
                     formatter: LogItemFormatter = StringLogItemFormatter(),
-                    queue: Queue = Queue(label: "com.mindera.alicerce.log.destination.string")) {
+                    logSeparator: String = "\n") {
 
             self.minLevel = minLevel
             self.formatter = formatter
-            self.queue = queue
+            self.logSeparator = logSeparator
         }
 
-        //MARK:- public methods
+        // MARK: - Public methods
 
-        public func write(item: Item) {
-            queue.dispatchQueue.async { [weak self] in
-                guard let strongSelf = self else { return }
-
-                let formattedItem = strongSelf.formatter.format(logItem: item)
-                if !strongSelf.output.isEmpty {
-                    strongSelf.output += strongSelf.linefeed
-                }
-
-                strongSelf.output += "\(formattedItem)"
+        public func write(item: Item, failure: @escaping (Swift.Error) -> ()) {
+            if !output.isEmpty {
+                output += logSeparator
             }
+
+            output += formatter.format(logItem: item)
         }
     }
 }

--- a/Tests/AlicerceTests/Logging/FileLogDestinationTests.swift
+++ b/Tests/AlicerceTests/Logging/FileLogDestinationTests.swift
@@ -26,7 +26,7 @@ class FileLogDestinationTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        log = Log(qos: .default)
+        log = Log()
         queue = Log.Queue(label: "FileLogDestinationTests")
         documentsPath = "file:///tmp/Log.log"
         logfileURL = URL(string: self.documentsPath)!
@@ -45,15 +45,20 @@ class FileLogDestinationTests: XCTestCase {
 
         // preparation of the test subject
 
-        let destination = Log.FileLogDestination(fileURL: self.logfileURL,
+        let destination = Log.FileLogDestination(fileURL: logfileURL,
                                                  minLevel: .error,
                                                  formatter: Log.StringLogItemFormatter(formatString: "$M"),
                                                  queue: queue)
 
         // execute test
 
-        destination.clear()
-        log.register(destination)
+        do {
+            try destination.clear()
+            try log.register(destination)
+        } catch {
+            return XCTFail("unexpected error \(error)!")
+        }
+
         log.verbose("verbose message")
         log.debug("debug message")
         log.info("info message")
@@ -72,15 +77,20 @@ class FileLogDestinationTests: XCTestCase {
 
         // preparation of the test subject
 
-        let destination = Log.FileLogDestination(fileURL: self.logfileURL,
+        let destination = Log.FileLogDestination(fileURL: logfileURL,
                                                  minLevel: .warning,
                                                  formatter: Log.StringLogItemFormatter(formatString: "$M"),
                                                  queue: queue)
 
         // execute test
 
-        destination.clear()
-        log.register(destination)
+        do {
+            try destination.clear()
+            try log.register(destination)
+        } catch {
+            return XCTFail("unexpected error \(error)!")
+        }
+
         log.verbose("verbose message")
         log.debug("debug message")
         log.info("info message")
@@ -116,13 +126,18 @@ class FileLogDestinationTests: XCTestCase {
             expectation.fulfill()
         }
 
-        destination.clear()
-        log.register(destination)
+        do {
+            try destination.clear()
+            try log.register(destination)
+        } catch {
+            return XCTFail("unexpected error \(error)!")
+        }
+
         log.error("verbose message")
     }
 
 
-    //MARK:- private methods
+    // MARK: - Private methods
 
     private func logfileContent(logfileURL: URL) -> String {
         

--- a/Tests/AlicerceTests/Logging/LogTests.swift
+++ b/Tests/AlicerceTests/Logging/LogTests.swift
@@ -12,49 +12,83 @@ import XCTest
 class LogTests: XCTestCase {
 
     fileprivate var log: Log!
-    fileprivate var queue: Log.Queue!
-    fileprivate let expectationTimeout: TimeInterval = 5
-    fileprivate let expectationHandler: XCWaitCompletionHandler = { error in
-        if let error = error {
-            XCTFail("🔥: Test expectation wait timed out: \(error)")
-        }
-    }
 
     override func setUp() {
         super.setUp()
 
-        log = Log(qos: .default)
-        queue = Log.Queue(label: "LogTests")
+        log = Log()
     }
 
     override func tearDown() {
         log = nil
-        queue = nil
 
         super.tearDown()
     }
 
-    func testDestinationManagement() {
+    func testRegister_WithUniqueIDs_ShouldSucceed() {
 
         let destination1 = Log.ConsoleLogDestination()
         let destination2 = Log.FileLogDestination(fileURL: URL(string: "https://www.google.com")!)
         let destination3 = Log.FileLogDestination(fileURL: URL(string: "https://www.amazon.com")!)
 
-        log.register(destination1)
-        XCTAssertEqual(log.destinations.count, 1)
-        log.register(destination1)
-        XCTAssertEqual(log.destinations.count, 1)
-        log.register(destination2)
-        XCTAssertEqual(log.destinations.count, 2)
-        log.register(destination3)
-        XCTAssertEqual(log.destinations.count, 3)
-        log.register(destination3)
-        XCTAssertEqual(log.destinations.count, 3)
+        do {
+            try log.register(destination1)
+            XCTAssertEqual(log.destinations.value.count, 1)
+            try log.register(destination2)
+            XCTAssertEqual(log.destinations.value.count, 2)
+            try log.register(destination3)
+            XCTAssertEqual(log.destinations.value.count, 3)
+        } catch {
+            return XCTFail("unexpected error \(error)!")
+        }
+    }
 
-        log.unregister(destination1)
-        XCTAssertEqual(log.destinations.count, 2)
-        log.unregister(destination1)
-        XCTAssertEqual(log.destinations.count, 2)
+    func testRegister_WithDuplicateIDs_ShouldFail() {
+
+        let destination1 = Log.ConsoleLogDestination()
+
+        do {
+            try log.register(destination1)
+            XCTAssertEqual(log.destinations.value.count, 1)
+        } catch {
+            return XCTFail("unexpected error \(error)!")
+        }
+
+        do {
+            try log.register(destination1)
+        } catch Log.Error.duplicateDestination(let id) {
+            XCTAssertEqual(id, destination1.id)
+        } catch {
+            return XCTFail("unexpected error \(error)!")
+        }
+    }
+
+    func testUnregister_WithExistingID_ShouldSucceed() {
+
+        let destination1 = Log.ConsoleLogDestination()
+
+        do {
+            try log.register(destination1)
+            XCTAssertEqual(log.destinations.value.count, 1)
+            try log.unregister(destination1)
+            XCTAssertEqual(log.destinations.value.count, 0)
+        } catch {
+            return XCTFail("unexpected error \(error)!")
+        }
+    }
+
+    func testUnregister_WithNonExistingIDs_ShouldFail() {
+
+        let destination1 = Log.ConsoleLogDestination()
+
+        do {
+            XCTAssertEqual(log.destinations.value.count, 0)
+            try log.unregister(destination1)
+        } catch Log.Error.inexistentDestination(let id) {
+            XCTAssertEqual(id, destination1.id)
+        } catch {
+            return XCTFail("unexpected error \(error)!")
+        }
     }
 
     func testErrorLoggingLevels() {
@@ -62,24 +96,25 @@ class LogTests: XCTestCase {
         // preparation of the test subject
 
         let formatter = Log.StringLogItemFormatter(formatString: "$M")
-        let destination = Log.StringLogDestination(minLevel: .error,
-                                                   formatter: formatter,
-                                                   queue: queue)
+        let destination = Log.StringLogDestination(minLevel: .error, formatter: formatter)
 
         // execute test
 
-        log.register(destination)
+        do {
+            try log.register(destination)
+        } catch {
+            return XCTFail("unexpected error \(error)!")
+        }
+
         log.verbose("verbose message")
         log.debug("debug message")
         log.info("info message")
         log.warning("warning message")
         log.error("error message")
 
-        queue.dispatchQueue.sync {
-            let expected = "error message"
-            XCTAssertEqual(destination.output, expected)
-            XCTAssertEqual(destination.output.split(separator: "\n").count, 1)
-        }
+        let expected = "error message"
+        XCTAssertEqual(destination.output, expected)
+        XCTAssertEqual(destination.output.split(separator: "\n").count, 1)
     }
 
     func testWarningLoggingLevels() {
@@ -87,92 +122,96 @@ class LogTests: XCTestCase {
         // preparation of the test subject
 
         let formatter = Log.StringLogItemFormatter(formatString: "$M")
-        let destination = Log.StringLogDestination(minLevel: .warning,
-                                                   formatter: formatter,
-                                                   queue: queue)
+        let destination = Log.StringLogDestination(minLevel: .warning, formatter: formatter)
 
         // execute test
 
-        log.register(destination)
+        do {
+            try log.register(destination)
+        } catch {
+            return XCTFail("unexpected error \(error)!")
+        }
+
         log.verbose("verbose message")
         log.debug("debug message")
         log.info("info message")
         log.warning("warning message")
         log.error("error message")
 
-        queue.dispatchQueue.sync {
-            let expected = "warning message\nerror message"
-            XCTAssertEqual(destination.output, expected)
-            XCTAssertEqual(destination.output.split(separator: "\n").count, 2)
-        }
+        let expected = "warning message\nerror message"
+        XCTAssertEqual(destination.output, expected)
+        XCTAssertEqual(destination.output.split(separator: "\n").count, 2)
     }
 
     func testInfoLoggingLevels() {
 
         let formatter = Log.StringLogItemFormatter(formatString: "$M")
-        let destination = Log.StringLogDestination(minLevel: .info,
-                                                   formatter: formatter,
-                                                   queue: queue)
+        let destination = Log.StringLogDestination(minLevel: .info, formatter: formatter)
 
         // execute test
 
-        log.register(destination)
+        do {
+            try log.register(destination)
+        } catch {
+            return XCTFail("unexpected error \(error)!")
+        }
+
         log.verbose("verbose message")
         log.debug("debug message")
         log.info("info message")
         log.warning("warning message")
         log.error("error message")
 
-        queue.dispatchQueue.sync {
-            let expected = "info message\nwarning message\nerror message"
-            XCTAssertEqual(destination.output, expected)
-            XCTAssertEqual(destination.output.split(separator: "\n").count, 3)
-        }
+        let expected = "info message\nwarning message\nerror message"
+        XCTAssertEqual(destination.output, expected)
+        XCTAssertEqual(destination.output.split(separator: "\n").count, 3)
     }
 
     func testDebugLoggingLevels() {
 
         let formatter = Log.StringLogItemFormatter(formatString: "$M")
-        let destination = Log.StringLogDestination(minLevel: .debug,
-                                                   formatter: formatter,
-                                                   queue: queue)
+        let destination = Log.StringLogDestination(minLevel: .debug, formatter: formatter)
 
         // execute test
 
-        log.register(destination)
+        do {
+            try log.register(destination)
+        } catch {
+            return XCTFail("unexpected error \(error)!")
+        }
+
         log.verbose("verbose message")
         log.debug("debug message")
         log.info("info message")
         log.warning("warning message")
         log.error("error message")
 
-        queue.dispatchQueue.sync {
-            let expected = "debug message\ninfo message\nwarning message\nerror message"
-            XCTAssertEqual(destination.output, expected)
-            XCTAssertEqual(destination.output.split(separator: "\n").count, 4)
-        }
+        let expected = "debug message\ninfo message\nwarning message\nerror message"
+        XCTAssertEqual(destination.output, expected)
+        XCTAssertEqual(destination.output.split(separator: "\n").count, 4)
     }
 
     func testVerboseLoggingLevels() {
 
         let formatter = Log.StringLogItemFormatter(formatString: "$M")
-        let destination = Log.StringLogDestination(minLevel: .verbose,
-                                                   formatter: formatter,
-                                                   queue: queue)
+        let destination = Log.StringLogDestination(minLevel: .verbose, formatter: formatter)
 
         // execute test
 
-        log.register(destination)
+        do {
+            try log.register(destination)
+        } catch {
+            return XCTFail("unexpected error \(error)!")
+        }
+
         log.verbose("verbose message")
         log.debug("debug message")
         log.info("info message")
         log.warning("warning message")
         log.error("error message")
 
-        queue.dispatchQueue.sync {
-            let expected = "verbose message\ndebug message\ninfo message\nwarning message\nerror message"
-            XCTAssertEqual(destination.output, expected)
-            XCTAssertEqual(destination.output.split(separator: "\n").count, 5)
-        }
+        let expected = "verbose message\ndebug message\ninfo message\nwarning message\nerror message"
+        XCTAssertEqual(destination.output, expected)
+        XCTAssertEqual(destination.output.split(separator: "\n").count, 5)
     }
 }

--- a/Tests/AlicerceTests/Logging/StringLogItemFormatterTests.swift
+++ b/Tests/AlicerceTests/Logging/StringLogItemFormatterTests.swift
@@ -23,7 +23,7 @@ class StringLogItemFormatterTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        log = Log(qos: .default)
+        log = Log()
         queue = Log.Queue(label: "StringLogItemFormatterTests")
     }
 
@@ -39,12 +39,16 @@ class StringLogItemFormatterTests: XCTestCase {
         let dateFormat = "HH:mm:ss"
         let formatter = Log.StringLogItemFormatter(formatString: "$D\(dateFormat)")
         let destination = Log.StringLogDestination(minLevel: .verbose,
-                                                   formatter: formatter,
-                                                   queue: queue)
+                                                   formatter: formatter)
 
         // execute test
 
-        log.register(destination)
+        do {
+            try log.register(destination)
+        } catch {
+            return XCTFail("unexpected error \(error)!")
+        }
+        
         log.verbose("verbose message")
 
         queue.dispatchQueue.sync {


### PR DESCRIPTION
- Improved `Log` API

  + Made `register` and `unregister` throw, and created new `Log.Error`

  + Removed private queue and replaced with an `Atomic`

  + Added logic to only create the `Log.Item` if actually needed (i.e.
the item's level is above at least one destination's min level)

- Removed `LogDestinationFallible` protocol

- Updated `LogDestination`:

  + Added a new failure closure to `write`

  + Renamed `instanceId` to `id`

  + Removed `queue` property, because some destinations don't need a
queue (e.g. they are proxies to a log provider which already handles
async scheduling)

- Updated `FileLogDestination`:

  + Added better error handling, using custom `Error`

  + Optimized file writes (batched text and `/n` in single blob)

- Improved `JSONLogItemFormatter` configurability

- Simplified `StringLogDestination`

- Allowed specifying target queue on `Log.Queue`

- Uniformized `// MARK :` comments