### PR TITLE
Restrict deploys to 'master' branch commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ jobs:
           overwrite: true
           on:
             repo: Mindera/Alicerce
+            branch: master
             tags: true
     - stage: Deploy Cocoapods
       script: skip
@@ -50,4 +51,5 @@ jobs:
           skip_cleanup: true
           on:
             repo: Mindera/Alicerce
+            branch: master
             tags: true


### PR DESCRIPTION
Only tagged commits on the 'master' branch will trigger a new deploy 🙂

(https://docs.travis-ci.com/user/deployment)