### PR TITLE
Add some missing `public init`s

### DIFF
--- a/Sources/DeepLinking/Router.swift
+++ b/Sources/DeepLinking/Router.swift
@@ -18,7 +18,7 @@ public final class AnyRouteHandler<T>: RouteHandler {
 
     let _handle: (URL, [String : String], [URLQueryItem], ((T) -> Void)?) -> Void
 
-    init<H: RouteHandler>(_ h: H) where H.T == T {
+    public init<H: RouteHandler>(_ h: H) where H.T == T {
         _handle = h.handle
     }
 
@@ -60,6 +60,8 @@ public final class TreeRouter<T>: Router {
     private typealias ParsedRoute = (scheme: Route.Scheme, components: [Route.Component], queryItems: [URLQueryItem])
 
     private var routes: Atomic<[Route.Scheme : Tree]> = Atomic([:])
+
+    public init() {}
 
     public func register(_ route: URL, handler: AnyRouteHandler<T>) throws {
         let (scheme, routeComponents) = parseAnnotatedRoute(route)

--- a/Sources/Logging/Log.swift
+++ b/Sources/Logging/Log.swift
@@ -30,6 +30,8 @@ public final class Log: Logger {
         print("💥[Alicerce.Log]: Failed to log item \(item) to destination '\(destination.id)' with error: \(error)")
     }
 
+    public init() {}
+
     // MARK: - Destination Management
 
     public func register(_ destination: LogDestination) throws {


### PR DESCRIPTION
On some of the latest changes, when removing `init`s we forgot that for them be visible from outside the module they have to be explicitly declare as `public`, otherwise the default implementation will be `internal`.