### PR TITLE
Implement resource retry mechanisms ♻️

### DIFF
--- a/Alicerce.xcodeproj/project.pbxproj
+++ b/Alicerce.xcodeproj/project.pbxproj
@@ -60,7 +60,7 @@
 		0A266FAC1ED59FB6009CD0D7 /* MockPersistenceStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A83886E1EB2068E00C1E835 /* MockPersistenceStack.swift */; };
 		0A266FAD1ED59FB6009CD0D7 /* CAGradientLayerTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A266F131ED33D9F009CD0D7 /* CAGradientLayerTestCase.swift */; };
 		0A266FAE1ED59FB6009CD0D7 /* CALayerTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A266F111ED33CDE009CD0D7 /* CALayerTestCase.swift */; };
-		0A266FB11ED59FB6009CD0D7 /* StoreTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A83886C1EB2064200C1E835 /* StoreTestCase.swift */; };
+		0A266FB11ED59FB6009CD0D7 /* NetworkPersistableStoreTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A83886C1EB2064200C1E835 /* NetworkPersistableStoreTestCase.swift */; };
 		0A266FB21ED59FB6009CD0D7 /* CollectionReusableViewTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7476CD1ECB4C48003024D1 /* CollectionReusableViewTestCase.swift */; };
 		0A266FB31ED59FB6009CD0D7 /* CollectionViewCellTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7476CF1ECB4D15003024D1 /* CollectionViewCellTestCase.swift */; };
 		0A266FB41ED59FB6009CD0D7 /* TableViewCellTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7476D11ECB4D5B003024D1 /* TableViewCellTestCase.swift */; };
@@ -82,6 +82,7 @@
 		0A3236E120D87E4C00D225CB /* LogDestinationTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3236E020D87E4C00D225CB /* LogDestinationTestCase.swift */; };
 		0A3236E520D88C9800D225CB /* DispatchQueueTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3236E420D88C9800D225CB /* DispatchQueueTestCase.swift */; };
 		0A3236E720D88ED400D225CB /* LoggerTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3236E620D88ED400D225CB /* LoggerTestCase.swift */; };
+		0A36837420F6691600EE2E7B /* RetryableResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A36837320F6691600EE2E7B /* RetryableResource.swift */; };
 		0A3907F71FC35E760050714A /* ReusableViewTableViewTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3907F61FC35E760050714A /* ReusableViewTableViewTestCase.swift */; };
 		0A3907F91FC366BC0050714A /* ViewModelCollectionReusableViewTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3907F81FC366BC0050714A /* ViewModelCollectionReusableViewTestCase.swift */; };
 		0A39081A1FC384B20050714A /* Views.xib in Resources */ = {isa = PBXBuildFile; fileRef = 0A3908191FC384B20050714A /* Views.xib */; };
@@ -137,6 +138,8 @@
 		0A708F6E20E99D9F001784DA /* MockAnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A708F6C20E99D9A001784DA /* MockAnalyticsTracker.swift */; };
 		0A7476C81ECB3F88003024D1 /* ReusableViewModelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7476C71ECB3F88003024D1 /* ReusableViewModelView.swift */; };
 		0A76A006209F868C00D46B63 /* Route+Tree_DescriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A76A004209F854C00D46B63 /* Route+Tree_DescriptionTests.swift */; };
+		0A77982920FCCD24008E269A /* ResourceRetryTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A77982820FCCD24008E269A /* ResourceRetryTestCase.swift */; };
+		0A77982F20FFF29D008E269A /* ResourceRetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A77982E20FFF29D008E269A /* ResourceRetry.swift */; };
 		0A79686120812130005738AF /* LockTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0ACEB2992080F0E5000D95AD /* LockTestCase.swift */; };
 		0A7B504D20B632FA005A08E7 /* *.alicerce.mindera.com.pem in Resources */ = {isa = PBXBuildFile; fileRef = 0A7B504C20B632FA005A08E7 /* *.alicerce.mindera.com.pem */; };
 		0A7B505020B6D346005A08E7 /* SecCertificate+PublicKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7B504E20B6D2C4005A08E7 /* SecCertificate+PublicKey.swift */; };
@@ -215,6 +218,12 @@
 		0AEEE10E20CF1C6300B47687 /* DefaultLogLevelFormatterTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AEEE10D20CF1C6300B47687 /* DefaultLogLevelFormatterTestCase.swift */; };
 		0AEEE11020CF1E4900B47687 /* BashLogLevelFormatterTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AEEE10F20CF1E4900B47687 /* BashLogLevelFormatterTestCase.swift */; };
 		0AEEE11820CF208A00B47687 /* MockLogItemFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AEEE11720CF208A00B47687 /* MockLogItemFormatter.swift */; };
+		0AFB0DC620F8E77300A58515 /* MockURLSessionDataTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AFB0DC420F8E76900A58515 /* MockURLSessionDataTask.swift */; };
+		0AFB0DC720F8E77700A58515 /* MockURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AFB0DC220F8E74700A58515 /* MockURLSession.swift */; };
+		0AFB0DCA20F8E7AE00A58515 /* MockNetworkAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AFB0DC920F8E7AE00A58515 /* MockNetworkAuthenticator.swift */; };
+		0AFB0DCC20F8E7F400A58515 /* MockRequestInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AFB0DCB20F8E7F400A58515 /* MockRequestInterceptor.swift */; };
+		0AFB0DCE20F8E81700A58515 /* MockAuthenticationChallengeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AFB0DCD20F8E81700A58515 /* MockAuthenticationChallengeHandler.swift */; };
+		0AFB0DD220F8FD1C00A58515 /* RetryableResourceTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AFB0DD120F8FD1C00A58515 /* RetryableResourceTestCase.swift */; };
 		1B14CDC11ECCC84D00CFAC15 /* KeyboardObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B14CDC01ECCC84D00CFAC15 /* KeyboardObserver.swift */; };
 		1B327F99207BE6C300ACEEBD /* ResourceTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B327F97207BE39400ACEEBD /* ResourceTestCase.swift */; };
 		1B327F9D207CF3C500ACEEBD /* JSON+Mappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B327F9C207CF3C500ACEEBD /* JSON+Mappable.swift */; };
@@ -293,6 +302,7 @@
 		0A3236E020D87E4C00D225CB /* LogDestinationTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogDestinationTestCase.swift; sourceTree = "<group>"; };
 		0A3236E420D88C9800D225CB /* DispatchQueueTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchQueueTestCase.swift; sourceTree = "<group>"; };
 		0A3236E620D88ED400D225CB /* LoggerTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggerTestCase.swift; sourceTree = "<group>"; };
+		0A36837320F6691600EE2E7B /* RetryableResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryableResource.swift; sourceTree = "<group>"; };
 		0A3907F61FC35E760050714A /* ReusableViewTableViewTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReusableViewTableViewTestCase.swift; sourceTree = "<group>"; };
 		0A3907F81FC366BC0050714A /* ViewModelCollectionReusableViewTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelCollectionReusableViewTestCase.swift; sourceTree = "<group>"; };
 		0A3908191FC384B20050714A /* Views.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = Views.xib; sourceTree = "<group>"; };
@@ -389,6 +399,8 @@
 		0A7476CF1ECB4D15003024D1 /* CollectionViewCellTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionViewCellTestCase.swift; sourceTree = "<group>"; };
 		0A7476D11ECB4D5B003024D1 /* TableViewCellTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewCellTestCase.swift; sourceTree = "<group>"; };
 		0A76A004209F854C00D46B63 /* Route+Tree_DescriptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Route+Tree_DescriptionTests.swift"; sourceTree = "<group>"; };
+		0A77982820FCCD24008E269A /* ResourceRetryTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceRetryTestCase.swift; sourceTree = "<group>"; };
+		0A77982E20FFF29D008E269A /* ResourceRetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceRetry.swift; sourceTree = "<group>"; };
 		0A7B504C20B632FA005A08E7 /* *.alicerce.mindera.com.pem */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "*.alicerce.mindera.com.pem"; sourceTree = "<group>"; };
 		0A7B504E20B6D2C4005A08E7 /* SecCertificate+PublicKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SecCertificate+PublicKey.swift"; sourceTree = "<group>"; };
 		0A7B505120B6D769005A08E7 /* SecCertificate+PublicKeyTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SecCertificate+PublicKeyTestCase.swift"; sourceTree = "<group>"; };
@@ -415,7 +427,7 @@
 		0A8388551EB1F6B000C1E835 /* NSPersistentStoreCoordinator+CoreDataStack.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSPersistentStoreCoordinator+CoreDataStack.swift"; sourceTree = "<group>"; };
 		0A8388561EB1F6B000C1E835 /* NSPersistentStoreDescription+CoreDataStack.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSPersistentStoreDescription+CoreDataStack.swift"; sourceTree = "<group>"; };
 		0A8388571EB1F6B000C1E835 /* SiblingContextCoreDataStack.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiblingContextCoreDataStack.swift; sourceTree = "<group>"; };
-		0A83886C1EB2064200C1E835 /* StoreTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreTestCase.swift; sourceTree = "<group>"; };
+		0A83886C1EB2064200C1E835 /* NetworkPersistableStoreTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkPersistableStoreTestCase.swift; sourceTree = "<group>"; };
 		0A83886E1EB2068E00C1E835 /* MockPersistenceStack.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockPersistenceStack.swift; sourceTree = "<group>"; };
 		0A8388711EB206C800C1E835 /* CoreDataStackOperationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreDataStackOperationTests.swift; sourceTree = "<group>"; };
 		0A8388721EB206C800C1E835 /* CoreDataStackSetupTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreDataStackSetupTests.swift; sourceTree = "<group>"; };
@@ -475,6 +487,12 @@
 		0AEEE10D20CF1C6300B47687 /* DefaultLogLevelFormatterTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultLogLevelFormatterTestCase.swift; sourceTree = "<group>"; };
 		0AEEE10F20CF1E4900B47687 /* BashLogLevelFormatterTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BashLogLevelFormatterTestCase.swift; sourceTree = "<group>"; };
 		0AEEE11720CF208A00B47687 /* MockLogItemFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLogItemFormatter.swift; sourceTree = "<group>"; };
+		0AFB0DC220F8E74700A58515 /* MockURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLSession.swift; sourceTree = "<group>"; };
+		0AFB0DC420F8E76900A58515 /* MockURLSessionDataTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLSessionDataTask.swift; sourceTree = "<group>"; };
+		0AFB0DC920F8E7AE00A58515 /* MockNetworkAuthenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNetworkAuthenticator.swift; sourceTree = "<group>"; };
+		0AFB0DCB20F8E7F400A58515 /* MockRequestInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRequestInterceptor.swift; sourceTree = "<group>"; };
+		0AFB0DCD20F8E81700A58515 /* MockAuthenticationChallengeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAuthenticationChallengeHandler.swift; sourceTree = "<group>"; };
+		0AFB0DD120F8FD1C00A58515 /* RetryableResourceTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryableResourceTestCase.swift; sourceTree = "<group>"; };
 		1B14CDC01ECCC84D00CFAC15 /* KeyboardObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardObserver.swift; sourceTree = "<group>"; };
 		1B327F97207BE39400ACEEBD /* ResourceTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceTestCase.swift; sourceTree = "<group>"; };
 		1B327F9C207CF3C500ACEEBD /* JSON+Mappable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JSON+Mappable.swift"; sourceTree = "<group>"; };
@@ -721,6 +739,8 @@
 			children = (
 				0A3C2CB71EA7E18500EFB7D4 /* NetworkResource.swift */,
 				0A3C2CB81EA7E18500EFB7D4 /* Resource.swift */,
+				0A77982E20FFF29D008E269A /* ResourceRetry.swift */,
+				0A36837320F6691600EE2E7B /* RetryableResource.swift */,
 				68DCF2381F7D0C1400D6BB88 /* StrategyFetchResource.swift */,
 			);
 			path = Resource;
@@ -804,7 +824,7 @@
 				0ABFFAC51EA8FCA300CFC8BD /* JSONTests.swift */,
 				0A3C2D201EA7E1EE00EFB7D4 /* MappableModel.swift */,
 				0A3C2D211EA7E1EE00EFB7D4 /* MappableTestCase.swift */,
-				0A83888E1EB209D100C1E835 /* MockNetworkStack.swift */,
+				0AFB0DC820F8E78900A58515 /* Mocks */,
 				0A3C2D221EA7E1EE00EFB7D4 /* NetworkTestCase.swift */,
 				0A3C2D231EA7E1EE00EFB7D4 /* ParseTestCase.swift */,
 				0A85F0E320B314E10095AFFB /* Pinning */,
@@ -995,7 +1015,7 @@
 		0A83886B1EB2062100C1E835 /* Stores */ = {
 			isa = PBXGroup;
 			children = (
-				0A83886C1EB2064200C1E835 /* StoreTestCase.swift */,
+				0A83886C1EB2064200C1E835 /* NetworkPersistableStoreTestCase.swift */,
 			);
 			path = Stores;
 			sourceTree = "<group>";
@@ -1173,6 +1193,28 @@
 			path = LevelFormatters;
 			sourceTree = "<group>";
 		};
+		0AFB0DC820F8E78900A58515 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				0AFB0DCD20F8E81700A58515 /* MockAuthenticationChallengeHandler.swift */,
+				0AFB0DC920F8E7AE00A58515 /* MockNetworkAuthenticator.swift */,
+				0A83888E1EB209D100C1E835 /* MockNetworkStack.swift */,
+				0AFB0DCB20F8E7F400A58515 /* MockRequestInterceptor.swift */,
+				0AFB0DC220F8E74700A58515 /* MockURLSession.swift */,
+				0AFB0DC420F8E76900A58515 /* MockURLSessionDataTask.swift */,
+			);
+			path = Mocks;
+			sourceTree = "<group>";
+		};
+		0AFB0DD020F8FD0800A58515 /* Resource */ = {
+			isa = PBXGroup;
+			children = (
+				0A77982820FCCD24008E269A /* ResourceRetryTestCase.swift */,
+				0AFB0DD120F8FD1C00A58515 /* RetryableResourceTestCase.swift */,
+			);
+			path = Resource;
+			sourceTree = "<group>";
+		};
 		1B14CDBF1ECCC83200CFAC15 /* Observers */ = {
 			isa = PBXGroup;
 			children = (
@@ -1221,6 +1263,7 @@
 				0A09A1A520EEEA07008EFAF3 /* PerformanceMetrics */,
 				0A3C2D251EA7E1EE00EFB7D4 /* Persistence */,
 				0A266F101ED33CCE009CD0D7 /* QuartzCore */,
+				0AFB0DD020F8FD0800A58515 /* Resource */,
 				0A83886B1EB2062100C1E835 /* Stores */,
 				0A3C2D381EA7E1EE00EFB7D4 /* UIKit */,
 				0A3C2D3B1EA7E1EE00EFB7D4 /* Utils */,
@@ -1532,18 +1575,22 @@
 				0A7CC0F1208FF76B009F3A6E /* DictionaryTests.swift in Sources */,
 				0A266F921ED59FB6009CD0D7 /* Route+Tree_InitTests.swift in Sources */,
 				0A266F931ED59FB6009CD0D7 /* Route+Tree_MatchTests.swift in Sources */,
+				0A77982920FCCD24008E269A /* ResourceRetryTestCase.swift in Sources */,
 				0A3236E120D87E4C00D225CB /* LogDestinationTestCase.swift in Sources */,
 				0AD6ACBF20B58896001426B8 /* ServerTrustEvaluator+ConfigurationTestCase.swift in Sources */,
 				0A266F941ED59FB6009CD0D7 /* Route+Tree_RemoveTests.swift in Sources */,
 				0A266F951ED59FB6009CD0D7 /* TreeRouterTests.swift in Sources */,
 				0A266F961ED59FB6009CD0D7 /* DataTestCase.swift in Sources */,
 				0A266F971ED59FB6009CD0D7 /* OptionalTests.swift in Sources */,
+				0AFB0DCC20F8E7F400A58515 /* MockRequestInterceptor.swift in Sources */,
 				0A11894D20F416EB00AF8229 /* PersistencePerformanceMetricsTrackerTestCase.swift in Sources */,
 				0A266F981ED59FB6009CD0D7 /* ThreadTestCase.swift in Sources */,
 				0AEEE11020CF1E4900B47687 /* BashLogLevelFormatterTestCase.swift in Sources */,
 				0A266F9A1ED59FB6009CD0D7 /* ConsoleLogDestinationTestCase.swift in Sources */,
 				0AB34A062085385A001F2979 /* UnfairLockTestCase.swift in Sources */,
 				0A266F9B1ED59FB6009CD0D7 /* MockMetadataLogDestination.swift in Sources */,
+				0AFB0DCE20F8E81700A58515 /* MockAuthenticationChallengeHandler.swift in Sources */,
+				0AFB0DC720F8E77700A58515 /* MockURLSession.swift in Sources */,
 				0AB34A0820853873001F2979 /* PthreadLockTestCase.swift in Sources */,
 				0A3236E720D88ED400D225CB /* LoggerTestCase.swift in Sources */,
 				0A266F9C1ED59FB6009CD0D7 /* FileLogDestinationTestCase.swift in Sources */,
@@ -1570,6 +1617,7 @@
 				0AD6ACBA20B4913D001426B8 /* ServerTrustEvaluatorTestCase.swift in Sources */,
 				0ACEB2962080ED90000D95AD /* AtomicTestCase.swift in Sources */,
 				0A266FAA1ED59FB6009CD0D7 /* MockCoreDataStack.swift in Sources */,
+				0AFB0DC620F8E77300A58515 /* MockURLSessionDataTask.swift in Sources */,
 				0A76A006209F868C00D46B63 /* Route+Tree_DescriptionTests.swift in Sources */,
 				0A5836E820CF41C10090E987 /* Log+Item.swift in Sources */,
 				0A11894820F3BAB800AF8229 /* MockPerformanceMetricsTracker.swift in Sources */,
@@ -1581,10 +1629,12 @@
 				0A266FAD1ED59FB6009CD0D7 /* CAGradientLayerTestCase.swift in Sources */,
 				0A266FAE1ED59FB6009CD0D7 /* CALayerTestCase.swift in Sources */,
 				0A9AF8B61FC30B660076458E /* NibViewTestCase.swift in Sources */,
+				0AFB0DCA20F8E7AE00A58515 /* MockNetworkAuthenticator.swift in Sources */,
 				1BBEB60C1F333E6E00D06526 /* UIImageTestCase.swift in Sources */,
 				1B327F99207BE6C300ACEEBD /* ResourceTestCase.swift in Sources */,
 				9DEC00AE209A052300F94353 /* BuilderCacheTestCase.swift in Sources */,
-				0A266FB11ED59FB6009CD0D7 /* StoreTestCase.swift in Sources */,
+				0A266FB11ED59FB6009CD0D7 /* NetworkPersistableStoreTestCase.swift in Sources */,
+				0AFB0DD220F8FD1C00A58515 /* RetryableResourceTestCase.swift in Sources */,
 				0A266FB21ED59FB6009CD0D7 /* CollectionReusableViewTestCase.swift in Sources */,
 				0A3907F71FC35E760050714A /* ReusableViewTableViewTestCase.swift in Sources */,
 				0A266FB31ED59FB6009CD0D7 /* CollectionViewCellTestCase.swift in Sources */,
@@ -1675,6 +1725,7 @@
 				1B4033581ED8927E00B4B03D /* ViewModelCollectionViewCell.swift in Sources */,
 				0A3C2D8C1EA7E5DD00EFB7D4 /* Router.swift in Sources */,
 				0A3C2D8E1EA7E5DD00EFB7D4 /* Dictionary.swift in Sources */,
+				0A36837420F6691600EE2E7B /* RetryableResource.swift in Sources */,
 				73C6051B20F3BBA300D0B643 /* Token.swift in Sources */,
 				0A266F0F1ED33B65009CD0D7 /* CAGradientLayer.swift in Sources */,
 				68DCF2391F7D0C1400D6BB88 /* StrategyFetchResource.swift in Sources */,
@@ -1697,6 +1748,7 @@
 				0A83884B1EB1F55A00C1E835 /* PersistableResource.swift in Sources */,
 				0A3C2DAA1EA7E5DD00EFB7D4 /* DiskMemoryPersistenceStack.swift in Sources */,
 				0A3C2D9C1EA7E5DD00EFB7D4 /* Log+StringLogItemFormatter.swift in Sources */,
+				0A77982F20FFF29D008E269A /* ResourceRetry.swift in Sources */,
 				0A3C2D911EA7E5DD00EFB7D4 /* Sequence.swift in Sources */,
 				0A7B505020B6D346005A08E7 /* SecCertificate+PublicKey.swift in Sources */,
 				0A3C2D951EA7E5DD00EFB7D4 /* Log+BashLogLevelFormatter.swift in Sources */,

--- a/Sources/Network/Network.swift
+++ b/Sources/Network/Network.swift
@@ -16,6 +16,7 @@ public enum Network {
         case url(Swift.Error)
         case badResponse
         case authenticator(Swift.Error)
+        case retry(errors: [Swift.Error], totalDelay: ResourceRetry.Delay, retryError: ResourceRetry.Error)
     }
 
     // MARK: - Network Configuration
@@ -28,12 +29,16 @@ public enum Network {
         
         let requestInterceptors: [RequestInterceptor]
 
+        let retryQueue: DispatchQueue
+
         public init(authenticationChallengeHandler: AuthenticationChallengeHandler? = nil,
                     authenticator: NetworkAuthenticator? = nil,
-                    requestInterceptors: [RequestInterceptor] = []) {
+                    requestInterceptors: [RequestInterceptor] = [],
+                    retryQueue: DispatchQueue) {
             self.authenticationChallengeHandler = authenticationChallengeHandler
             self.authenticator = authenticator
             self.requestInterceptors = requestInterceptors
+            self.retryQueue = retryQueue
         }
     }
 }

--- a/Sources/Network/NetworkAuthenticator.swift
+++ b/Sources/Network/NetworkAuthenticator.swift
@@ -1,13 +1,16 @@
 import Foundation
 import Result
 
-public protocol NetworkAuthenticator {
+public protocol NetworkAuthenticator: class {
+
     typealias PerformRequestClosure = (Result<URLRequest, AnyError>) -> Cancelable
 
     func authenticate(request: URLRequest, performRequest: @escaping PerformRequestClosure) -> Cancelable
+}
 
-    func isAuthenticationInvalid(for request: URLRequest,
-                                 data: Data?,
-                                 response: HTTPURLResponse?,
-                                 error: Swift.Error?) -> Bool
+public protocol RetryableNetworkAuthenticator: NetworkAuthenticator {
+
+    typealias RetryPolicy = ResourceRetry.Policy<Data, URLRequest, URLResponse>
+
+    func retryPolicyRule() -> RetryPolicy.Rule
 }

--- a/Sources/Network/NetworkStack.swift
+++ b/Sources/Network/NetworkStack.swift
@@ -1,8 +1,10 @@
 import Foundation
 
-public protocol NetworkStack {
+public protocol NetworkStack: class {
     associatedtype Remote
+    associatedtype Request
+    associatedtype Response
 
-    func fetch<R: NetworkResource>(resource: R, completion: @escaping Network.CompletionClosure<R.Remote>)
-    -> Cancelable where R.Remote == Remote
+    func fetch<R>(resource: R, completion: @escaping Network.CompletionClosure<R.Remote>) -> Cancelable
+    where R: NetworkResource & RetryableResource, R.Remote == Remote, R.Request == Request, R.Response == Response
 }

--- a/Sources/Persistence/PersistenceStack.swift
+++ b/Sources/Persistence/PersistenceStack.swift
@@ -7,7 +7,7 @@ public protocol PersistenceStack {
 
     func object(for key: Persistence.Key, completion: @escaping PersistenceCompletionClosure<Remote>)
 
-    func setObject(_ object: Data, for key: Persistence.Key, completion: @escaping PersistenceCompletionClosure<Void>)
+    func setObject(_ object: Remote, for key: Persistence.Key, completion: @escaping PersistenceCompletionClosure<Void>)
 
-    func removeObject(for key: String, completion: @escaping PersistenceCompletionClosure<Void>)
+    func removeObject(for key: Persistence.Key, completion: @escaping PersistenceCompletionClosure<Void>)
 }

--- a/Sources/Resource/ResourceRetry.swift
+++ b/Sources/Resource/ResourceRetry.swift
@@ -73,13 +73,13 @@ public enum ResourceRetry {
         /// limit the retries (either by number of retries, or total delay time).
         public enum Backoff {
 
-            /// A backoff strategy that delays each retry by a constant amount of time, while a truncation rule allows.
-            /// See `Backoff.Truncation` for more details on the available truncation rules.
+            /// A backoff strategy that delays each retry by a constant amount of time, while a truncation rule allows
+            /// it. See `Backoff.Truncation` for more details on the available truncation rules.
             case constant(Delay, Truncation)
 
             /// A backoff strategy that delays each retry according to a scaling function (typically exponential)
-            /// calculated from a base delay, while a truncation rule allows. See `Backoff.Truncation` for more details
-            /// on the available truncation rules.
+            /// calculated from a base delay, while a truncation rule allows it. See `Backoff.Truncation` for more
+            /// details on the available truncation rules.
             case exponential(Delay, Scale, Truncation)
 
             /// An exponential backoff scaling function, which takes into consideration the base delay and current

--- a/Sources/Resource/ResourceRetry.swift
+++ b/Sources/Resource/ResourceRetry.swift
@@ -1,0 +1,148 @@
+import Foundation
+
+/// A type representing the resource retry namespace (case-less enum).
+public enum ResourceRetry {
+
+    /// An action to take after evaluating a retry policy.
+    public enum Action {
+
+        /// No retry action should be taken, and normal error handling should be made.
+        case none
+
+        /// The resource shouldn't be retried, due to an error.
+        case noRetry(Error)
+
+        /// The resource should be retried *immediately*.
+        case retry
+
+        /// The resource should be retried *after* the specified delay.
+        case retryAfter(Delay)
+    }
+
+    /// An error produced during retry policy evaluation, when a retry shouldn't be made (i.e. on `Action.noRetry`).
+    public enum Error: Swift.Error {
+
+        /// The maximum retries of a policy have been reached.
+        case retries(Retries)
+
+        /// The maximum delay of a policy has been reached.
+        case delay(Delay)
+
+        /// An arbitrary error prevented the resource from being retried.
+        case custom(Swift.Error)
+    }
+
+    /// A number of retries.
+    public typealias Retries = Int
+
+    /// An amount of delay time.
+    public typealias Delay = TimeInterval
+
+    /// A retry policy.
+    public enum Policy<Remote, Request, Response> {
+
+        /// A policy that limits the total number of retries.
+        case retries(Retries)
+
+        /// A policy that applies a backoff strategy to delay and limit retries. See `Backoff` for more details on the
+        /// available strategies.
+        case backoff(Backoff)
+
+        /// A policy that applies a custom rule. See `Rule` for more details on the rule closure signature.
+        case custom(Rule)
+
+        /// A custom policy rule.
+        ///
+        /// - Parameters:
+        ///   - previousErrors: The errors that have occured so far (i.e. have resulted in a previous retry), excluding
+        /// the current error.
+        ///   - totalDelay: The total amount of delay that has been used on retries.
+        ///   - request: The request that originated the error.
+        ///   - error: The error that occurred.
+        ///   - payload: The received remote payload.
+        ///   - response: The received response
+        /// - Returns: The action to take.
+        public typealias Rule = (_ previousErrors: [Swift.Error],
+                                 _ totalDelay: Delay,
+                                 _ request: Request,
+                                 _ error: Swift.Error,
+                                 _ payload: Remote?,
+                                 _ response: Response?) -> Action
+
+        /// A backoff strategy that defines an amount of time for each retry, as well as a truncation mechanism to
+        /// limit the retries (either by number of retries, or total delay time).
+        public enum Backoff {
+
+            /// A backoff strategy that delays each retry by a constant amount of time, while a truncation rule allows.
+            /// See `Backoff.Truncation` for more details on the available truncation rules.
+            case constant(Delay, Truncation)
+
+            /// A backoff strategy that delays each retry according to a scaling function (typically exponential)
+            /// calculated from a base delay, while a truncation rule allows. See `Backoff.Truncation` for more details
+            /// on the available truncation rules.
+            case exponential(Delay, Scale, Truncation)
+
+            /// An exponential backoff scaling function, which takes into consideration the base delay and current
+            /// retries to calculate (scale) each retry's delay.
+            ///
+            /// - Parameters:
+            ///   - baseDelay: The base delay of the strategy.
+            ///   - numRetries: The number of retries.
+            /// - Returns: The delay time to use for the next retry.
+            public typealias Scale = (_ baseDelay: Delay, _ numRetries: Retries) -> Delay
+
+            /// A backoff strategy truncation rule, to limit retries.
+            public enum Truncation {
+
+                /// A rule that limits the total number of retries.
+                case retries(Retries)
+
+                /// A rule that limits the total amount of *scheduled* delay time used by retries.
+                /// - Note: When used in conjunction with an `Backoff.exponential` strategy, the resulting delay for
+                /// each retry will be the *minimum* between the scaling function's output and the configured maximum.
+                case delay(Delay)
+            }
+        }
+
+        /// Evaluates the policy to determine if a retry should be made under the current circumstances.
+        ///
+        /// - Parameters:
+        ///   - previousErrors: The errors that have occured so far (i.e. have resulted in a previous retry), excluding
+        /// the current error.
+        ///   - totalDelay: The total amount of delay that has been used on retries.
+        ///   - request: The request that originated the error.
+        ///   - error: The error that occurred.
+        ///   - payload: The received remote payload.
+        ///   - response: The received response
+        /// - Returns: The action to take.
+        public func shouldRetry(previousErrors: [Swift.Error],
+                                totalDelay: Delay,
+                                request: Request,
+                                error: Swift.Error,
+                                payload: Remote?,
+                                response: Response?) -> Action {
+
+            let numRetries = previousErrors.count
+
+            switch self {
+            case .retries(let max) where numRetries >= max,
+                 .backoff(.constant(_, .retries(let max))) where numRetries >= max,
+                 .backoff(.exponential(_, _, .retries(let max))) where numRetries >= max:
+                return .noRetry(.retries(max))
+            case .backoff(.constant(_, .delay(let max))) where totalDelay >= max,
+                 .backoff(.exponential(_, _, .delay(let max))) where totalDelay >= max:
+                return .noRetry(.delay(max))
+            case .retries:
+                return .retry
+            case .backoff(.constant(let delay, _)):
+                return .retryAfter(delay)
+            case .backoff(.exponential(let base, let scale, .delay(let max))):
+                return .retryAfter(.minimum(scale(base, numRetries), max))
+            case .backoff(.exponential(let base, let scale, _)):
+                return .retryAfter(scale(base, numRetries))
+            case .custom(let rule):
+                return rule(previousErrors, totalDelay, request, error, payload, response)
+            }
+        }
+    }
+}

--- a/Sources/Resource/RetryableResource.swift
+++ b/Sources/Resource/RetryableResource.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+/// A type representing a resource that can be retried after failing.
+public protocol RetryableResource {
+
+    /// A type that represents a received remote payload.
+    associatedtype Remote
+
+    /// A type that represents a network request.
+    associatedtype Request
+
+    /// A type that represents a network response.
+    associatedtype Response
+
+    /// The resource's specialized retry policy.
+    typealias RetryPolicy = ResourceRetry.Policy<Remote, Request, Response>
+
+    /// The errors that have resulted in a retry after having occurred.
+    var retriedAfterErrors: [Error] { get set }
+
+    /// The total amount of delay that has been used on retries. Only the *scheduled* retry delay should be counted.
+    var totalRetriedDelay: ResourceRetry.Delay { get set }
+
+    /// The retry policies used to evaluate which action to take when an error occurs.
+    var retryPolicies: [RetryPolicy] { get }
+
+    /// Evaluates if a resource's fetch should be retried after having failed, according to the defined retry policies.
+    ///
+    /// - Parameters:
+    ///   - request: The request that originated the error.
+    ///   - error: The error that occurred.
+    ///   - payload: The received remote payload.
+    ///   - response: The received response
+    /// - Returns: The action to take.
+    func shouldRetry(with request: Request, error: Error, payload: Remote?, response: Response?) -> ResourceRetry.Action
+}
+
+public extension RetryableResource {
+
+    /// The number of times a resource has been retried (according to the retried after errors).
+    var numRetries: Int { return retriedAfterErrors.count }
+
+    func shouldRetry(with request: Request,
+                     error: Error,
+                     payload: Remote?,
+                     response: Response?) -> ResourceRetry.Action {
+
+        guard retryPolicies.isEmpty == false else { return .none }
+
+        var candidateAction: ResourceRetry.Action = .none
+
+        for policy in retryPolicies {
+            let action = policy.shouldRetry(previousErrors: retriedAfterErrors,
+                                            totalDelay: totalRetriedDelay,
+                                            request: request,
+                                            error: error,
+                                            payload: payload,
+                                            response: response)
+
+            switch (action, candidateAction) {
+            case (.noRetry, _):
+                // exit immediately if any policy does not allow retry
+                return action
+            case (.retry, .none), (.retryAfter, .none), (.retryAfter, .retry):
+                // `retry` and `retryAfter prevail over `.none`, `retryAfter` prevails over `retry`
+                candidateAction = action
+            case (.retryAfter(let newDelay), .retryAfter(let candidateDelay)) where newDelay > candidateDelay:
+                // `retryAfter` with the longer delay prevails
+                candidateAction = action
+            default:
+                // do nothing on all other cases
+                break
+            }
+        }
+
+        return candidateAction
+    }
+}

--- a/Sources/Resource/RetryableResource.swift
+++ b/Sources/Resource/RetryableResource.swift
@@ -15,8 +15,8 @@ public protocol RetryableResource {
     /// The resource's specialized retry policy.
     typealias RetryPolicy = ResourceRetry.Policy<Remote, Request, Response>
 
-    /// The errors that have resulted in a retry after having occurred.
-    var retriedAfterErrors: [Error] { get set }
+    /// The errors that have occurred on each retry.
+    var retryErrors: [Error] { get set }
 
     /// The total amount of delay that has been used on retries. Only the *scheduled* retry delay should be counted.
     var totalRetriedDelay: ResourceRetry.Delay { get set }
@@ -38,7 +38,7 @@ public protocol RetryableResource {
 public extension RetryableResource {
 
     /// The number of times a resource has been retried (according to the retried after errors).
-    var numRetries: Int { return retriedAfterErrors.count }
+    var numRetries: Int { return retryErrors.count }
 
     func shouldRetry(with request: Request,
                      error: Error,
@@ -50,7 +50,7 @@ public extension RetryableResource {
         var candidateAction: ResourceRetry.Action = .none
 
         for policy in retryPolicies {
-            let action = policy.shouldRetry(previousErrors: retriedAfterErrors,
+            let action = policy.shouldRetry(previousErrors: retryErrors,
                                             totalDelay: totalRetriedDelay,
                                             request: request,
                                             error: error,

--- a/Sources/Shared/Cancelable.swift
+++ b/Sources/Shared/Cancelable.swift
@@ -1,3 +1,98 @@
+import Foundation
+
+/// A type that can be cancelled.
 public protocol Cancelable {
+
+    /// Cancels the cancelable.
     func cancel()
+}
+
+// MARK: - Extensions
+
+extension URLSessionTask: Cancelable {}
+
+extension DispatchWorkItem: Cancelable {}
+
+// MARK: - Wrapper Cancelables
+
+/// A cancelable reference type.
+public typealias CancelableClass = Cancelable & AnyObject
+
+/// A cancelable that wraps another cancelable as a weak reference.
+public final class WeakCancelable: Cancelable {
+
+    /// The wrapped (weak) cancelable.
+    private weak var cancelable: CancelableClass?
+
+    /// Creates a new cancelable wrapping another one as a weak reference.
+    ///
+    /// - Parameter cancelable: The wrapped cancelable.
+    public init(_ cancelable: CancelableClass) {
+        self.cancelable = cancelable
+    }
+
+    /// Cancels the cancelable.
+    public func cancel() {
+        cancelable?.cancel()
+    }
+}
+
+/// A cancelable that wraps multiple cancelables.
+public final class CancelableBag: Cancelable {
+
+    /// The wrapped cancelables.
+    private var cancelables: Atomic<[Cancelable]?>
+
+    /// An atomic flag indicating if the cancelable has been cancelled (i.e. all wrapped cancelables).
+    private var _isCancelled: Atomic<Bool>
+
+    /// A flag indicating if the cancelable has been cancelled (i.e. all wrapped cancelables).
+    public var isCancelled: Bool { return _isCancelled.value }
+
+    /// Creates an instance of a cancelable bag.
+    ///
+    /// - Parameters:
+    ///   - cancelables: The cancelables to initialize the bag with.
+    public init<S: Sequence>(_ cancelables: S) where S.Iterator.Element == Cancelable {
+        self.cancelables = Atomic(Array(cancelables))
+        self._isCancelled = Atomic(false)
+    }
+
+    /// Creates an instance of a cancelable bag with no initial cancelables.
+    public convenience init() {
+        self.init([])
+    }
+
+    /// Adds a cancelable to the bag, if it hasn't been cancelled yet.
+    ///
+    /// - Parameters:
+    ///   - cancelable: The cancelable to add.
+    public func add(cancelable: Cancelable) {
+        guard isCancelled == false else { return }
+
+        cancelables.modify { $0?.append(cancelable) }
+    }
+
+    /// Cancels all the cancelables contained in the bag, if it hasn't been cancelled yet.
+    public func cancel() {
+        let shouldCancel: Bool = _isCancelled.modify {
+            guard $0 == false else { return false }
+            $0 = true
+            return true
+        }
+
+        guard shouldCancel else { return }
+
+        cancelables.swap(nil)?.forEach { $0.cancel() }
+    }
+}
+
+/// A placeholder cancelable that doesn't cancel anything.
+public struct DummyCancelable: Cancelable {
+
+    /// Creates a new dummy cancelable.
+    public init() {}
+
+    /// Cancels the cancelable.
+    public func cancel() {}
 }

--- a/Sources/Stores/NetworkStore.swift
+++ b/Sources/Stores/NetworkStore.swift
@@ -18,9 +18,12 @@ public typealias NetworkStoreCompletionClosure<T, E: Error> = (Result<NetworkSto
 public protocol NetworkStore {
 
     associatedtype Remote
+    associatedtype Request
+    associatedtype Response
     associatedtype E: Error
 
     @discardableResult
     func fetch<R>(resource: R, completion: @escaping NetworkStoreCompletionClosure<R.Local, E>) -> Cancelable
-    where R: NetworkResource & PersistableResource & StrategyFetchResource, R.Remote == Remote
+    where R: NetworkResource & PersistableResource & StrategyFetchResource & RetryableResource,
+          R.Remote == Remote, R.Request == Request, R.Response == Response
 }

--- a/Tests/AlicerceTests/Network/Mocks/MockAuthenticationChallengeHandler.swift
+++ b/Tests/AlicerceTests/Network/Mocks/MockAuthenticationChallengeHandler.swift
@@ -1,0 +1,18 @@
+// Copyright © 2018 Mindera. All rights reserved.
+
+import Foundation
+@testable import Alicerce
+
+final class MockAuthenticationChallengeHandler: AuthenticationChallengeHandler {
+
+    var mockHandleClosure: ((URLAuthenticationChallenge) -> (URLSession.AuthChallengeDisposition, URLCredential?))?
+
+    func handle(_ challenge: URLAuthenticationChallenge,
+                completionHandler: @escaping Network.AuthenticationCompletionClosure) {
+        if let (authChallengeDisposition, credential) = mockHandleClosure?(challenge) {
+            return completionHandler(authChallengeDisposition, credential)
+        }
+
+        completionHandler(.performDefaultHandling, nil)
+    }
+}

--- a/Tests/AlicerceTests/Network/Mocks/MockNetworkAuthenticator.swift
+++ b/Tests/AlicerceTests/Network/Mocks/MockNetworkAuthenticator.swift
@@ -1,0 +1,21 @@
+import Foundation
+import Result
+@testable import Alicerce
+
+final class MockNetworkAuthenticator: NetworkAuthenticator, RetryableNetworkAuthenticator {
+
+    enum Error: Swift.Error {
+        case 🚫
+    }
+
+    var mockAuthenticateClosure: ((URLRequest) -> Result<URLRequest, AnyError>)?
+    var mockRetryPolicyRule: RetryPolicy.Rule = { _, _, _, _, _, _ in .noRetry(.custom(Error.🚫)) }
+
+    func authenticate(request: URLRequest,
+                      performRequest: @escaping NetworkAuthenticator.PerformRequestClosure) -> Cancelable {
+
+        return performRequest(mockAuthenticateClosure?(request) ?? .success(request))
+    }
+
+    func retryPolicyRule() -> RetryPolicy.Rule { return mockRetryPolicyRule }
+}

--- a/Tests/AlicerceTests/Network/Mocks/MockNetworkStack.swift
+++ b/Tests/AlicerceTests/Network/Mocks/MockNetworkStack.swift
@@ -12,6 +12,8 @@ final class MockNetworkCancelable: Cancelable {
 }
 
 final class MockNetworkStack: NetworkStack {
+    typealias Request = URLRequest
+    typealias Response = URLResponse
     typealias Remote = Data
 
     var mockData: Data?
@@ -28,8 +30,8 @@ final class MockNetworkStack: NetworkStack {
         self.queue = queue
     }
 
-    func fetch<R: NetworkResource>(resource: R, completion: @escaping Network.CompletionClosure<R.Remote>)
-    -> Cancelable where R.Remote == Data {
+    func fetch<R>(resource: R, completion: @escaping Network.CompletionClosure<R.Remote>) -> Cancelable
+    where R: NetworkResource & RetryableResource, R.Remote == Data, R.Request == URLRequest, R.Response == URLResponse {
         queue.async {
             self.beforeFetchCompletionClosure?()
 
@@ -45,5 +47,6 @@ final class MockNetworkStack: NetworkStack {
         }
 
         return mockCancelable
+
     }
 }

--- a/Tests/AlicerceTests/Network/Mocks/MockRequestInterceptor.swift
+++ b/Tests/AlicerceTests/Network/Mocks/MockRequestInterceptor.swift
@@ -1,0 +1,14 @@
+import Foundation
+@testable import Alicerce
+
+final class MockRequestInterceptor: RequestInterceptor {
+    var interceptRequestClosure: ((URLRequest) -> Void)?
+    var interceptResponseClosure: ((URLResponse?, Data?, Error?, URLRequest?) -> Void)?
+
+    func intercept(request: URLRequest) {
+        interceptRequestClosure?(request)
+    }
+    func intercept(response: URLResponse?, data: Data?, error: Error?, for request: URLRequest) {
+        interceptResponseClosure?(response, data, error, request)
+    }
+}

--- a/Tests/AlicerceTests/Network/Mocks/MockURLSession.swift
+++ b/Tests/AlicerceTests/Network/Mocks/MockURLSession.swift
@@ -1,0 +1,68 @@
+import Foundation
+@testable import Alicerce
+
+final class MockURLSession: URLSession {
+
+    var mockDataTaskData: Data? = Data()
+    var mockDataTaskError: Error? = nil
+    var mockURLResponse: URLResponse = URLResponse()
+
+    var mockDataTaskResumeInvokedClosure: (() -> Void)?
+    var mockDataTaskCancelInvokedClosure: (() -> Void)?
+
+    var mockAuthenticationChallenge: URLAuthenticationChallenge = URLAuthenticationChallenge()
+    var mockAuthenticationCompletionHandler: Network.AuthenticationCompletionClosure = { _, _  in }
+
+    private let _configuration: URLSessionConfiguration
+    private let _delegate: URLSessionDelegate?
+    private let _delegateQueue: OperationQueue
+
+    private var mockDataTask: MockURLSessionDataTask?
+
+    @objc
+    override var configuration: URLSessionConfiguration { return _configuration }
+
+    @objc
+    override var delegate: URLSessionDelegate? { return _delegate }
+
+    @objc
+    override var delegateQueue: OperationQueue { return _delegateQueue }
+
+    init(configuration: URLSessionConfiguration = .default,
+         delegate: URLSessionDelegate?,
+         delegateQueue queue: OperationQueue = OperationQueue()) {
+
+        _configuration = configuration
+        _delegate = delegate
+        _delegateQueue = queue
+
+        super.init()
+    }
+
+    override func dataTask(with request: URLRequest,
+                           completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
+
+        let dataTask = MockURLSessionDataTask()
+
+        dataTask.resumeInvokedClosure = { [weak self] in
+            guard let strongSelf = self else { fatalError("🔥: `self` must be defined!") }
+
+            strongSelf.mockDataTaskResumeInvokedClosure?()
+
+            strongSelf.delegate?.urlSession?(strongSelf,
+                                             didReceive: strongSelf.mockAuthenticationChallenge,
+                                             completionHandler: strongSelf.mockAuthenticationCompletionHandler)
+
+            completionHandler(strongSelf.mockDataTaskData, strongSelf.mockURLResponse, strongSelf.mockDataTaskError)
+        }
+
+        dataTask.cancelInvokedClosure = { [weak self] in
+            self?.mockDataTaskCancelInvokedClosure?()
+        }
+
+        // keep a strong reference to the task, otherwise it gets deallocated
+        self.mockDataTask = dataTask
+
+        return dataTask
+    }
+}

--- a/Tests/AlicerceTests/Network/Mocks/MockURLSessionDataTask.swift
+++ b/Tests/AlicerceTests/Network/Mocks/MockURLSessionDataTask.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+final class MockURLSessionDataTask: URLSessionDataTask {
+
+    var resumeInvokedClosure: (() -> Void)?
+    var cancelInvokedClosure: (() -> Void)?
+
+    override func resume() {
+        resumeInvokedClosure?()
+    }
+
+    override func cancel() {
+        cancelInvokedClosure?()
+    }
+}

--- a/Tests/AlicerceTests/Network/NetworkTestCase.swift
+++ b/Tests/AlicerceTests/Network/NetworkTestCase.swift
@@ -6,7 +6,7 @@ final class NetworkTestCase: XCTestCase {
 
     func testConfiguration_WhenCreateWithFullInit_ItShouldPopulateAllTheValues() {
 
-        let networkConfiguration = Network.Configuration()
+        let networkConfiguration = Network.Configuration(retryQueue: DispatchQueue(label: "configuration-retry-queue"))
 
         XCTAssertNil(networkConfiguration.authenticationChallengeHandler)
         XCTAssertNil(networkConfiguration.authenticator)
@@ -18,7 +18,8 @@ final class NetworkTestCase: XCTestCase {
         
         let requestInterceptors = [dummyRequestInterceptor]
         
-        let networkConfiguration = Network.Configuration(requestInterceptors: requestInterceptors)
+        let networkConfiguration = Network.Configuration(requestInterceptors: requestInterceptors,
+                                                         retryQueue: DispatchQueue(label: "configuration-retry-queue"))
         
         XCTAssertNil(networkConfiguration.authenticationChallengeHandler)
         XCTAssertNil(networkConfiguration.authenticator)

--- a/Tests/AlicerceTests/Network/URLSessionNetworkStackTestCase.swift
+++ b/Tests/AlicerceTests/Network/URLSessionNetworkStackTestCase.swift
@@ -13,7 +13,7 @@ private struct URLSessionMockResource<T, Error: Swift.Error>: StaticNetworkResou
     var query: HTTP.Query?
     var body: Data?
 
-    var retriedAfterErrors: [Swift.Error]
+    var retryErrors: [Swift.Error]
     var totalRetriedDelay: ResourceRetry.Delay
     var retryPolicies: [ResourceRetry.Policy<Data, URLRequest, URLResponse>]
 
@@ -107,7 +107,7 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
                                       headers: nil,
                                       query: nil,
                                       body: nil,
-                                      retriedAfterErrors: [],
+                                      retryErrors: [],
                                       totalRetriedDelay: 0,
                                       retryPolicies: [],
                                       parse: parse,

--- a/Tests/AlicerceTests/Resource/ResourceRetryTestCase.swift
+++ b/Tests/AlicerceTests/Resource/ResourceRetryTestCase.swift
@@ -1,0 +1,413 @@
+import XCTest
+@testable import Alicerce
+
+class ResourceRetryTestCase: XCTestCase {
+
+    typealias Remote = Float
+    typealias Request = Int
+    typealias Response = String
+
+    private typealias Policy = ResourceRetry.Policy<Remote, Request, Response>
+
+    private enum MockError: Error {
+        case 💩, 👻
+    }
+
+    // MARK: - shouldRetry -> noRetry
+
+    // retries
+
+    func testShouldRetry_WhenMaxRetriesExceededOnRetriesPolicy_ShouldReturnNoRetry() {
+
+        let maxRetries = 3
+        let policy = Policy.retries(maxRetries)
+
+        let previousErrors = [MockError.👻, .👻, .👻]
+
+        let action = policy.shouldRetry(previousErrors: previousErrors,
+                                        totalDelay: 0,
+                                        request: 1337,
+                                        error: MockError.💩,
+                                        payload: nil,
+                                        response: nil)
+
+        switch action {
+        case let .noRetry(.retries(max)): XCTAssertEqual(max, maxRetries)
+        default: XCTFail("💥: unexpected action \(action) returned!")
+        }
+    }
+
+    func testShouldRetry_WhenMaxRetriesExceededOnConstantBackoffPolicyWithRetriesTruncation_ShouldReturnNoRetry() {
+
+        let maxRetries = 3
+        let policy = Policy.backoff(.constant(0, .retries(maxRetries)))
+
+        let action = policy.shouldRetry(previousErrors: [MockError.👻, .👻, .👻],
+                                        totalDelay: 0,
+                                        request: 1337,
+                                        error: MockError.💩,
+                                        payload: nil,
+                                        response: nil)
+
+        switch action {
+        case let .noRetry(.retries(max)): XCTAssertEqual(max, maxRetries)
+        default: XCTFail("💥: unexpected action \(action) returned!")
+        }
+    }
+
+    func testShouldRetry_WhenMaxRetriesExceededOnExponentialBackoffPolicyWithRetriesTruncation_ShouldReturnNoRetry() {
+
+        let previousErrors = [MockError.👻, .👻, .👻, .👻]
+
+        let maxRetries = 3
+        let baseDelay = 0.1337
+        let scale: Policy.Backoff.Scale = { delay, numRetries in
+            XCTAssertEqual(delay, baseDelay)
+            XCTAssertEqual(numRetries, previousErrors.count)
+
+            return baseDelay
+        }
+        let policy = Policy.backoff(.exponential(0, scale, .retries(maxRetries)))
+
+        let action = policy.shouldRetry(previousErrors: previousErrors,
+                                        totalDelay: 0,
+                                        request: 1337,
+                                        error: MockError.💩,
+                                        payload: nil,
+                                        response: nil)
+
+        switch action {
+        case let .noRetry(.retries(max)): XCTAssertEqual(max, maxRetries)
+        default: XCTFail("💥: unexpected action \(action) returned!")
+        }
+    }
+
+    // MARK: - shouldRetry -> noRetry
+
+    // delay
+
+    func testShouldRetry_WhenMaxDelayExceededOnConstantBackoffPolicyWithDelayTruncation_ShouldReturnNoRetry() {
+
+        let maxDelay = 0.1337
+        let delay = 0.1337
+        let policy = Policy.backoff(.constant(delay, .delay(maxDelay)))
+
+        let totalDelay = maxDelay + 0.001337
+
+        let action = policy.shouldRetry(previousErrors: [],
+                                        totalDelay: totalDelay,
+                                        request: 1337,
+                                        error: MockError.💩,
+                                        payload: nil,
+                                        response: nil)
+
+        switch action {
+        case let .noRetry(.delay(max)): XCTAssertEqual(max, maxDelay)
+        default: XCTFail("💥: unexpected action \(action) returned!")
+        }
+    }
+
+    func testShouldRetry_WhenMaxDelayExceededOnExponentialBackoffPolicyWithDelayTruncation_ShouldReturnNoRetry() {
+
+        let previousErrors = [MockError.👻, .👻, .👻]
+
+        let maxDelay = 0.7331
+        let baseDelay = 0.1337
+        let scale: Policy.Backoff.Scale = { delay, numRetries in
+            XCTAssertEqual(delay, baseDelay)
+            XCTAssertEqual(numRetries, previousErrors.count)
+
+            return baseDelay
+        }
+        let policy = Policy.backoff(.exponential(baseDelay, scale, .delay(maxDelay)))
+
+        let totalDelay = maxDelay + 0.001337
+
+        let action = policy.shouldRetry(previousErrors: previousErrors,
+                                        totalDelay: totalDelay,
+                                        request: 1337,
+                                        error: MockError.💩,
+                                        payload: nil,
+                                        response: nil)
+
+        switch action {
+        case let .noRetry(.delay(max)): XCTAssertEqual(max, maxDelay)
+        default: XCTFail("💥: unexpected action \(action) returned!")
+        }
+    }
+
+    func testShouldRetry_WhenCustomRuleReturnsRetry_ShouldReturnRetry() {
+
+        enum CustomError: Error {
+            case 🔨
+        }
+
+        let previousErrors = [MockError.👻, .👻]
+        let totalDelay = 0.1337
+        let request = 1337
+        let error = MockError.💩
+        let payload = Float.pi
+        let response = "π"
+
+        let rule: Policy.Rule = { ruleErrors, ruleTotalDelay, ruleRequest, ruleError, rulePayload, ruleResponse in
+
+            XCTAssertDumpsEqual(ruleErrors, previousErrors)
+            XCTAssertEqual(ruleTotalDelay, totalDelay)
+            XCTAssertEqual(ruleRequest, request)
+            XCTAssertDumpsEqual(ruleError, error)
+            XCTAssertEqual(rulePayload, payload)
+            XCTAssertEqual(ruleResponse, response)
+
+            return .noRetry(.custom(CustomError.🔨))
+        }
+
+        let policy = Policy.custom(rule)
+
+        let action = policy.shouldRetry(previousErrors: previousErrors,
+                                        totalDelay: totalDelay,
+                                        request: request,
+                                        error: error,
+                                        payload: payload,
+                                        response: response)
+
+        switch action {
+        case .noRetry(.custom(CustomError.🔨)): break // expected action
+        default: XCTFail("💥: unexpected action \(action) returned!")
+        }
+    }
+
+    // MARK: - shouldRetry -> retry
+
+    func testShouldRetry_WhenMaxRetriesNotExceededOnRetriesPolicy_ShouldReturnRetry() {
+
+        let maxRetries = 3
+        let policy = Policy.retries(maxRetries)
+
+        let previousErrors = [MockError.👻, .👻]
+
+        let action = policy.shouldRetry(previousErrors: previousErrors,
+                                        totalDelay: 0,
+                                        request: 1337,
+                                        error: MockError.💩,
+                                        payload: nil,
+                                        response: nil)
+
+        switch action {
+        case .retry: break // expected action
+        default: XCTFail("💥: unexpected action \(action) returned!")
+        }
+    }
+
+    func testShouldRetry_WhenCustomRuleReturnsNoRetry_ShouldReturnNoRetry() {
+
+        let previousErrors = [MockError.👻, .👻]
+        let totalDelay = 0.1337
+        let request = 1337
+        let error = MockError.💩
+        let payload = Float.pi
+        let response = "π"
+
+        let rule: Policy.Rule = { ruleErrors, ruleTotalDelay, ruleRequest, ruleError, rulePayload, ruleResponse in
+
+            XCTAssertDumpsEqual(ruleErrors, previousErrors)
+            XCTAssertEqual(ruleTotalDelay, totalDelay)
+            XCTAssertEqual(ruleRequest, request)
+            XCTAssertDumpsEqual(ruleError, error)
+            XCTAssertEqual(rulePayload, payload)
+            XCTAssertEqual(ruleResponse, response)
+
+            return .retry
+        }
+
+        let policy = Policy.custom(rule)
+
+        let action = policy.shouldRetry(previousErrors: previousErrors,
+                                        totalDelay: totalDelay,
+                                        request: request,
+                                        error: error,
+                                        payload: payload,
+                                        response: response)
+
+        switch action {
+        case .retry: break // expected action
+        default: XCTFail("💥: unexpected action \(action) returned!")
+        }
+    }
+
+    // MARK: - shouldRetry -> retryAfter
+
+    // retries truncation
+
+    func testShouldRetry_WhenMaxRetriesNotExceededOnConstantBackoffPolicyWithRetriesTruncation_ShouldReturnRetryAfter() {
+
+        let constantDelay = 0.1337
+        let maxRetries = 3
+        let policy = Policy.backoff(.constant(constantDelay, .retries(maxRetries)))
+
+        let previousErrors = [MockError.👻, .👻]
+
+        let action = policy.shouldRetry(previousErrors: previousErrors,
+                                        totalDelay: 0,
+                                        request: 1337,
+                                        error: MockError.💩,
+                                        payload: nil,
+                                        response: nil)
+
+        switch action {
+        case .retryAfter(let delay): XCTAssertEqual(delay, constantDelay)
+        default: XCTFail("💥: unexpected action \(action) returned!")
+        }
+    }
+
+    func testShouldRetry_WhenMaxRetriesNotExceededOnExponentialBackoffPolicyWithRetriesTruncation_ShouldReturnRetryAfter() {
+
+        let previousErrors = [MockError.👻, .👻]
+
+        let maxRetries = 3
+        let baseDelay = 0.1337
+        let scaledDelay = 0.7331
+        let scale: Policy.Backoff.Scale = { delay, numRetries in
+            XCTAssertEqual(delay, baseDelay)
+            XCTAssertEqual(numRetries, previousErrors.count)
+
+            return scaledDelay
+        }
+        let policy = Policy.backoff(.exponential(baseDelay, scale, .retries(maxRetries)))
+
+        let action = policy.shouldRetry(previousErrors: previousErrors,
+                                        totalDelay: 0,
+                                        request: 1337,
+                                        error: MockError.💩,
+                                        payload: nil,
+                                        response: nil)
+
+        switch action {
+        case .retryAfter(let delay): XCTAssertEqual(delay, scaledDelay)
+        default: XCTFail("💥: unexpected action \(action) returned!")
+        }
+    }
+
+    // delay truncation
+
+    func testShouldRetry_WhenMaxDelayNotExceededOnConstantBackoffPolicyWithDelayTruncation_ShouldReturnRetryAfter() {
+
+        let maxDelay = 0.1337
+        let constantDelay = 0.01337
+        let policy = Policy.backoff(.constant(constantDelay, .delay(maxDelay)))
+
+        let totalDelay = maxDelay - constantDelay
+
+        let action = policy.shouldRetry(previousErrors: [],
+                                        totalDelay: totalDelay,
+                                        request: 1337,
+                                        error: MockError.💩,
+                                        payload: nil,
+                                        response: nil)
+
+        switch action {
+        case .retryAfter(let delay): XCTAssertEqual(delay, constantDelay)
+        default: XCTFail("💥: unexpected action \(action) returned!")
+        }
+    }
+
+    func testShouldRetry_WhenMaxDelayNotExceededOnExponentialBackoffPolicyWithDelayTruncationAndScaledDelayBelowMaxDelay_ShouldReturnRetryAfterWithScaledDelay() {
+
+        let previousErrors = [MockError.👻, .👻, .👻]
+
+        let maxDelay = 0.7331
+        let baseDelay = 0.1337
+        let scaledDelay = 0.7331
+        let scale: Policy.Backoff.Scale = { delay, numRetries in
+            XCTAssertEqual(delay, baseDelay)
+            XCTAssertEqual(numRetries, previousErrors.count)
+
+            return scaledDelay
+        }
+        let policy = Policy.backoff(.exponential(baseDelay, scale, .delay(maxDelay)))
+
+        let totalDelay = maxDelay - 0.001337
+
+        let action = policy.shouldRetry(previousErrors: previousErrors,
+                                        totalDelay: totalDelay,
+                                        request: 1337,
+                                        error: MockError.💩,
+                                        payload: nil,
+                                        response: nil)
+
+        switch action {
+        case .retryAfter(let delay): XCTAssertEqual(delay, scaledDelay)
+        default: XCTFail("💥: unexpected action \(action) returned!")
+        }
+    }
+
+    func testShouldRetry_WhenMaxDelayNotExceededByScaledDelayOnExponentialBackoffPolicyWithDelayTruncationAndScaledDelayAboveMaxDelay_ShouldReturnRetryAfterWithMaxDelay() {
+
+        let previousErrors = [MockError.👻, .👻, .👻]
+
+        let maxDelay = 0.7331
+        let baseDelay = 0.1337
+        let scaledDelay = maxDelay + 0.001337 // greater than maxDelay, so that `max` is used on retryAfter
+        let scale: Policy.Backoff.Scale = { delay, numRetries in
+            XCTAssertEqual(delay, baseDelay)
+            XCTAssertEqual(numRetries, previousErrors.count)
+
+            return scaledDelay
+        }
+        let policy = Policy.backoff(.exponential(baseDelay, scale, .delay(maxDelay)))
+
+        let totalDelay = maxDelay - 0.001337
+
+        let action = policy.shouldRetry(previousErrors: previousErrors,
+                                        totalDelay: totalDelay,
+                                        request: 1337,
+                                        error: MockError.💩,
+                                        payload: nil,
+                                        response: nil)
+
+        switch action {
+        case .retryAfter(let delay): XCTAssertEqual(delay, maxDelay)
+        default: XCTFail("💥: unexpected action \(action) returned!")
+        }
+    }
+
+    // custom rule
+
+    func testShouldRetry_WhenCustomRuleReturnsRetryAfter_ShouldReturnRetryAfter() {
+
+        let previousErrors = [MockError.👻, .👻]
+        let totalDelay = 0.1337
+        let request = 1337
+        let error = MockError.💩
+        let payload = Float.pi
+        let response = "π"
+
+        let retryDelay = 1.337
+
+        let rule: Policy.Rule = { ruleErrors, ruleTotalDelay, ruleRequest, ruleError, rulePayload, ruleResponse in
+
+            XCTAssertDumpsEqual(ruleErrors, previousErrors)
+            XCTAssertEqual(ruleTotalDelay, totalDelay)
+            XCTAssertEqual(ruleRequest, request)
+            XCTAssertDumpsEqual(ruleError, error)
+            XCTAssertEqual(rulePayload, payload)
+            XCTAssertEqual(ruleResponse, response)
+
+            return .retryAfter(retryDelay)
+        }
+
+        let policy = Policy.custom(rule)
+
+        let action = policy.shouldRetry(previousErrors: previousErrors,
+                                        totalDelay: totalDelay,
+                                        request: request,
+                                        error: error,
+                                        payload: payload,
+                                        response: response)
+
+        switch action {
+        case .retryAfter(let delay): XCTAssertEqual(delay, retryDelay)
+        default: XCTFail("💥: unexpected action \(action) returned!")
+        }
+    }
+    
+}

--- a/Tests/AlicerceTests/Resource/RetryableResourceTestCase.swift
+++ b/Tests/AlicerceTests/Resource/RetryableResourceTestCase.swift
@@ -9,7 +9,7 @@ class RetryableResourceTestCase: XCTestCase {
         typealias Request = Int
         typealias Response = String
 
-        var retriedAfterErrors: [Error]
+        var retryErrors: [Error]
         var totalRetriedDelay: ResourceRetry.Delay
 
         var retryPolicies: [RetryPolicy]
@@ -26,7 +26,7 @@ class RetryableResourceTestCase: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        resource = MockRetryableResource(retriedAfterErrors: [], totalRetriedDelay: 0, retryPolicies: [])
+        resource = MockRetryableResource(retryErrors: [], totalRetriedDelay: 0, retryPolicies: [])
     }
 
     override func tearDown() {
@@ -38,10 +38,10 @@ class RetryableResourceTestCase: XCTestCase {
 
     func testNumRetries_MatchesNumberOfRetriedAfterErrors() {
 
-        XCTAssertEqual(resource.numRetries, resource.retriedAfterErrors.count)
+        XCTAssertEqual(resource.numRetries, resource.retryErrors.count)
 
-        resource.retriedAfterErrors.append(MockError.💣)
-        XCTAssertEqual(resource.numRetries, resource.retriedAfterErrors.count)
+        resource.retryErrors.append(MockError.💣)
+        XCTAssertEqual(resource.numRetries, resource.retryErrors.count)
     }
 
     // shouldRetry

--- a/Tests/AlicerceTests/Resource/RetryableResourceTestCase.swift
+++ b/Tests/AlicerceTests/Resource/RetryableResourceTestCase.swift
@@ -1,0 +1,150 @@
+import XCTest
+@testable import Alicerce
+
+class RetryableResourceTestCase: XCTestCase {
+
+    private struct MockRetryableResource: RetryableResource {
+
+        typealias Remote = Float
+        typealias Request = Int
+        typealias Response = String
+
+        var retriedAfterErrors: [Error]
+        var totalRetriedDelay: ResourceRetry.Delay
+
+        var retryPolicies: [RetryPolicy]
+    }
+
+    private typealias RetryPolicy = MockRetryableResource.RetryPolicy
+
+    private enum MockError: Error {
+        case 💣, 💥
+    }
+
+    private var resource: MockRetryableResource!
+
+    override func setUp() {
+        super.setUp()
+
+        resource = MockRetryableResource(retriedAfterErrors: [], totalRetriedDelay: 0, retryPolicies: [])
+    }
+
+    override func tearDown() {
+        resource = nil
+        super.tearDown()
+    }
+
+    // numRetries
+
+    func testNumRetries_MatchesNumberOfRetriedAfterErrors() {
+
+        XCTAssertEqual(resource.numRetries, resource.retriedAfterErrors.count)
+
+        resource.retriedAfterErrors.append(MockError.💣)
+        XCTAssertEqual(resource.numRetries, resource.retriedAfterErrors.count)
+    }
+
+    // shouldRetry
+
+    func testShouldRetry_WhenRetryPoliciesAreEmpty_ShouldReturnNone() {
+
+        XCTAssert(resource.retryPolicies.isEmpty)
+
+        switch resource.shouldRetry(with: 1337, error: MockError.💥, payload: nil, response: nil) {
+        case .none: break // expected action
+        default: XCTFail("💥: unexpected action returned!")
+        }
+    }
+
+    func testShouldRetry_WhenAnyPolicyReturnsNoRetry_ShouldReturnNoRetryAndSkipOtherPolicies() {
+        let retryExpectation = expectation(description: "retryRule")
+        let noRetryExpectation = expectation(description: "noRetryRule")
+        defer { waitForExpectations(timeout: 1) }
+
+        let retryRule: RetryPolicy.Rule = { _, _, _, _, _, _ in
+            retryExpectation.fulfill()
+            return .retry
+        }
+
+        let noRetryRule: RetryPolicy.Rule = { _, _, _, _, _, _ in
+            noRetryExpectation.fulfill()
+            return .noRetry(.custom(MockError.💣))
+        }
+
+        let anotherRetryRule: RetryPolicy.Rule = { _, _, _, _, _, _ in
+            XCTFail("😱: shouldn't call retry rule after another returning noRetry!")
+            return .retry
+        }
+
+        resource.retryPolicies = [.custom(retryRule), .custom(noRetryRule), .custom(anotherRetryRule)]
+
+        switch resource.shouldRetry(with: 1337, error: MockError.💥, payload: nil, response: nil) {
+        case .noRetry(.custom(MockError.💣)): break // expected action
+        default: XCTFail("💥: unexpected action returned!")
+        }
+    }
+
+    func testShouldRetry_WhenAPolicyReturnsRetryAfterAfterAnotherHasReturnedRetry_ShouldReturnRetryAfter() {
+        let retryExpectation = expectation(description: "retryRule")
+        let retryAfterExpectation = expectation(description: "retryAfterRule")
+        let anotherRetryExpectation = expectation(description: "anotherRetryRule")
+        defer { waitForExpectations(timeout: 1) }
+
+        let testDelay: ResourceRetry.Delay = 1337
+
+        let retryRule: RetryPolicy.Rule = { _, _, _, _, _, _ in
+            retryExpectation.fulfill()
+            return .retry
+        }
+
+        let retryAfterRule: RetryPolicy.Rule = { _, _, _, _, _, _ in
+            retryAfterExpectation.fulfill()
+            return .retryAfter(testDelay)
+        }
+
+        let anotherRetryRule: RetryPolicy.Rule = { _, _, _, _, _, _ in
+            anotherRetryExpectation.fulfill()
+            return .retry
+        }
+
+        resource.retryPolicies = [.custom(retryRule), .custom(retryAfterRule), .custom(anotherRetryRule)]
+
+        switch resource.shouldRetry(with: 1337, error: MockError.💥, payload: nil, response: nil) {
+        case .retryAfter(let delay) where delay == testDelay: break // expected action
+        default: XCTFail("💥: unexpected action returned!")
+        }
+    }
+
+    func testShouldRetry_WhenMultiplePoliciesReturnRetryAfter_ShouldReturnRetryAfterWithTheMaximumDelay() {
+        let retryAfterExpectationA = expectation(description: "retryAfterRuleA")
+        let retryAfterExpectationB = expectation(description: "retryAfterRuleB")
+        let retryAfterExpectationC = expectation(description: "retryAfterRuleC")
+        defer { waitForExpectations(timeout: 1) }
+
+        let testDelayA: ResourceRetry.Delay = 1337
+        let testDelayB: ResourceRetry.Delay = 133337
+        let testDelayC: ResourceRetry.Delay = 13337
+
+        let retryAfterRuleA: RetryPolicy.Rule = { _, _, _, _, _, _ in
+            retryAfterExpectationA.fulfill()
+            return .retryAfter(testDelayA)
+        }
+
+        let retryAfterRuleB: RetryPolicy.Rule = { _, _, _, _, _, _ in
+            retryAfterExpectationB.fulfill()
+            return .retryAfter(testDelayB)
+        }
+
+        let retryAfterRuleC: RetryPolicy.Rule = { _, _, _, _, _, _ in
+            retryAfterExpectationC.fulfill()
+            return .retryAfter(testDelayC)
+        }
+
+        resource.retryPolicies = [.custom(retryAfterRuleA), .custom(retryAfterRuleB), .custom(retryAfterRuleC)]
+
+        switch resource.shouldRetry(with: 1337, error: MockError.💥, payload: nil, response: nil) {
+        case .retryAfter(let delay) where delay == testDelayB: break // expected action
+        default: XCTFail("💥: unexpected action returned!")
+        }
+    }
+}

--- a/Tests/AlicerceTests/Stores/NetworkPersistableStoreTestCase.swift
+++ b/Tests/AlicerceTests/Stores/NetworkPersistableStoreTestCase.swift
@@ -99,7 +99,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
     //          Strategy: PersistenceThenNetwork
     //   Expected Result: Failed with Network Error
     func testFetch_WithFailingNetwork_ShouldFailWithNetworkError() {
-        let expectation = self.expectation(description: "testFetch")
+        let fetchExpectation = expectation(description: "testFetch")
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
@@ -108,7 +108,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
         let resource = testResourcePersistenceThenNetwork // Parser is OK
         // When
         store.fetch(resource: resource) { result in
-            defer { expectation.fulfill() }
+            defer { fetchExpectation.fulfill() }
 
             // Should
             guard let error = result.error else {
@@ -127,7 +127,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
     //          Strategy: NetworkThenPersistence
     //   Expected Result: Failed with Network Error
     func testFetch_NetworkFirst_WithFailingNetwork_ShouldFailWithNetworkError() {
-        let expectation = self.expectation(description: "testFetch")
+        let fetchExpectation = expectation(description: "testFetch")
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
@@ -137,7 +137,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
 
         // When
         store.fetch(resource: resource) { result in
-            defer { expectation.fulfill() }
+            defer { fetchExpectation.fulfill() }
 
             // Should
             guard let error = result.error else {
@@ -156,7 +156,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
     //          Strategy: PersistenceThenNetwork
     //   Expected Result: Failed with Parser Error
     func testFetch_WithFailingParser_ShouldFailWithParseError() {
-        let expectation = self.expectation(description: "testFetch")
+        let fetchExpectation = expectation(description: "testFetch")
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
@@ -172,7 +172,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                                     retryPolicies: [])
 
         store.fetch(resource: resource) { result in
-            defer { expectation.fulfill() }
+            defer { fetchExpectation.fulfill() }
 
             // Should
             guard let error = result.error else {
@@ -191,7 +191,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
     //          Strategy: PersistenceThenNetwork
     //   Expected Result: Failed with Parser Error
     func testFetch_WithCachedDataAndFailingParser_ShouldFail() {
-        let expectation = self.expectation(description: "testFetch")
+        let fetchExpectation = expectation(description: "testFetch")
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
@@ -208,7 +208,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
 
         // When
         store.fetch(resource: resource) { result in
-            defer { expectation.fulfill() }
+            defer { fetchExpectation.fulfill() }
 
             // Should
             guard let error = result.error else {
@@ -227,7 +227,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
     //          Strategy: NetworkThenPersistence
     //   Expected Result: Failed with Parser Error
     func testFetch_NetworkFirst_WithCachedDataAndFailingParser_ShouldFail() {
-        let expectation = self.expectation(description: "testFetch")
+        let fetchExpectation = expectation(description: "testFetch")
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
@@ -244,7 +244,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
 
         // When
         store.fetch(resource: resource) { result in
-            defer { expectation.fulfill() }
+            defer { fetchExpectation.fulfill() }
 
             // Should
             guard let error = result.error else {
@@ -263,7 +263,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
     //          Strategy: PersistenceThenNetwork
     //   Expected Result: Failed with Cancelled Error
     func testFetch_WithCancelledNetworkFetch_ShouldFailWithCancelledError() {
-        let expectation = self.expectation(description: "testFetch")
+        let fetchExpectation = expectation(description: "testFetch")
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
@@ -273,7 +273,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
 
         // When
         store.fetch(resource: resource) { result in
-            defer { expectation.fulfill() }
+            defer { fetchExpectation.fulfill() }
 
             // Should
             guard let error = result.error else {
@@ -292,7 +292,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
     //          Strategy: NetworkThenPersistence
     //   Expected Result: Failed with Cancelled Error
     func testFetch_NetworkFirst_WithCancelledNetworkFetch_ShouldFailWithCancelledError() {
-        let expectation = self.expectation(description: "testFetch")
+        let fetchExpectation = expectation(description: "testFetch")
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
@@ -302,7 +302,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
 
         // When
         store.fetch(resource: resource) { result in
-            defer { expectation.fulfill() }
+            defer { fetchExpectation.fulfill() }
 
             // Should
             guard let error = result.error else {
@@ -322,14 +322,14 @@ class NetworkPersistableStoreTestCase: XCTestCase {
     //            Action: Cancel before parse
     //   Expected Result: Failed with Cancelled Error
     func testFetchCancel_BeforeParseeUsingPersistenceThenNetwork_ShouldFailWithCancelledError() {
-        let expectation = self.expectation(description: "testFetch")
-        let expectation2 = self.expectation(description: "fetchCancel")
+        let fetchExpectation = expectation(description: "testFetch")
+        let cancelExpectation = expectation(description: "fetchCancel")
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
         networkStack.mockData = testDataNetwork
         networkStack.mockCancelable.mockCancelClosure = {
-            expectation2.fulfill()
+            cancelExpectation.fulfill()
         }
         persistenceStack.mockObjectCompletion = { throw Persistence.Error.noObjectForKey }
         let resource = testResourcePersistenceThenNetwork
@@ -340,7 +340,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
 
         // When
         let cancelable = store.fetch(resource: resource) { result in
-            defer { expectation.fulfill() }
+            defer { fetchExpectation.fulfill() }
 
             // Should
             guard let error = result.error else {
@@ -367,14 +367,14 @@ class NetworkPersistableStoreTestCase: XCTestCase {
     //            Action: Cancel before parse
     //   Expected Result: Failed with Cancelled Error
     func testFetchCancel_BeforeParseUsingNetworkThenPersistence_ShouldFailWithCancelledError() {
-        let expectation = self.expectation(description: "testFetch")
-        let expectation2 = self.expectation(description: "fetchCancel")
+        let fetchExpectation = expectation(description: "testFetch")
+        let cancelExpectation = expectation(description: "fetchCancel")
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
         networkStack.mockData = testDataNetwork
         networkStack.mockCancelable.mockCancelClosure = {
-            expectation2.fulfill()
+            cancelExpectation.fulfill()
         }
         let resource = testResourceNetworkThenPersistence
 
@@ -384,7 +384,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
 
         // When
         let cancelable = store.fetch(resource: resource) { result in
-            defer { expectation.fulfill() }
+            defer { fetchExpectation.fulfill() }
 
             // Should
             guard let error = result.error else {
@@ -411,14 +411,14 @@ class NetworkPersistableStoreTestCase: XCTestCase {
     //            Action: Cancel before parse
     //   Expected Result: Failed with Cancelled Error
     func testFetchCancel_AfterFetchErrorUsingNetworkThenPersistence_ShouldFailWithFetchErrorAndSkipPersistenceCheck() {
-        let expectation = self.expectation(description: "testFetch")
-        let expectation2 = self.expectation(description: "fetchCancel")
+        let fetchExpectation = expectation(description: "testFetch")
+        let cancelExpectation = expectation(description: "fetchCancel")
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
         networkStack.mockError = .noData
         networkStack.mockCancelable.mockCancelClosure = {
-            expectation2.fulfill()
+            cancelExpectation.fulfill()
         }
         let resource = testResourceNetworkThenPersistence
 
@@ -428,7 +428,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
 
         // When
         let cancelable = store.fetch(resource: resource) { result in
-            defer { expectation.fulfill() }
+            defer { fetchExpectation.fulfill() }
 
             // Should
             guard let error = result.error else {
@@ -455,14 +455,14 @@ class NetworkPersistableStoreTestCase: XCTestCase {
     //            Action: Cancel before persist
     //   Expected Result: Failed with Cancelled Error
     func testFetchCancel_BeforePersist_ShouldFailWithCancelledError() {
-        let expectation = self.expectation(description: "testFetch")
-        let expectation2 = self.expectation(description: "fetchCancel")
+        let fetchExpectation = expectation(description: "testFetch")
+        let cancelExpectation = expectation(description: "fetchCancel")
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
         networkStack.mockData = testDataNetwork
         networkStack.mockCancelable.mockCancelClosure = {
-            expectation2.fulfill()
+            cancelExpectation.fulfill()
         }
 
         // closure to cancel the cancelable
@@ -490,7 +490,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
 
         // When
         let cancelable = store.fetch(resource: resource) { result in
-            defer { expectation.fulfill() }
+            defer { fetchExpectation.fulfill() }
 
             // Should
             guard let error = result.error else {
@@ -518,7 +518,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
     //          Strategy: PersistenceThenNetwork
     //   Expected Result: Success from Network: isCached = false
     func testFetch_WithValidData_ShouldSucceed() {
-        let expectation = self.expectation(description: "testFetch")
+        let fetchExpectation = expectation(description: "testFetch")
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
@@ -528,7 +528,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
 
         // When
         store.fetch(resource: resource) { result in
-            defer { expectation.fulfill() }
+            defer { fetchExpectation.fulfill() }
 
             // Should
             guard let value = result.value else {
@@ -546,7 +546,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
     //          Strategy: PersistenceThenNetwork
     //   Expected Result: Success from Network: isCached = true
     func testFetch_WithCachedData_ShouldSucceed() {
-        let expectation = self.expectation(description: "testFetch")
+        let fetchExpectation = expectation(description: "testFetch")
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
@@ -556,7 +556,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
 
         // When
         store.fetch(resource: resource) { result in
-            defer { expectation.fulfill() }
+            defer { fetchExpectation.fulfill() }
 
             // Should
             guard let value = result.value else {
@@ -574,7 +574,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
     //          Strategy: PersistenceThenNetwork
     //   Expected Result: Success from Network: isCached = true
     func testFetch_WithValidDataAndFailingPersistenceGet_ShouldSucceed() {
-        let expectation = self.expectation(description: "testFetch")
+        let fetchExpectation = expectation(description: "testFetch")
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
@@ -585,7 +585,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
 
         // When
         store.fetch(resource: resource) { result in
-            defer { expectation.fulfill() }
+            defer { fetchExpectation.fulfill() }
 
             // Should
             guard let value = result.value else {
@@ -603,7 +603,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
     //          Strategy: NetworkThenPersistence
     //   Expected Result: Success from Network: isCached = false
     func testFetch_withNetworkFirst_ShouldRetrieveFromNetwork() {
-        let expectation = self.expectation(description: "testFetch")
+        let fetchExpectation = expectation(description: "testFetch")
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
@@ -613,7 +613,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
 
         // When
         store.fetch(resource: resource) { result in
-            defer { expectation.fulfill() }
+            defer { fetchExpectation.fulfill() }
 
             // Should
             guard let value = result.value else {
@@ -631,7 +631,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
     //          Strategy: NetworkThenPersistence
     //   Expected Result: Success from Network: isCached = true
     func testFetch_withNetworkFirstAndFailing_ShouldRetrieveFromPersistence() {
-        let expectation = self.expectation(description: "testFetch")
+        let fetchExpectation = expectation(description: "testFetch")
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
@@ -641,7 +641,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
 
         // When
         store.fetch(resource: resource) { result in
-            defer { expectation.fulfill() }
+            defer { fetchExpectation.fulfill() }
 
             // Should
             guard let value = result.value else {
@@ -659,7 +659,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
     //          Strategy: PersistenceThenNetwork
     //   Expected Result: Success from Network: isCached = true
     func testFetch_withPersistenceFirst_ShouldRetrieveFromPersistence() {
-        let expectation = self.expectation(description: "testFetch")
+        let fetchExpectation = expectation(description: "testFetch")
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
@@ -669,7 +669,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
 
         // When
         store.fetch(resource: resource) { result in
-            defer { expectation.fulfill() }
+            defer { fetchExpectation.fulfill() }
 
             // Should
             guard let value = result.value else {
@@ -687,7 +687,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
     //          Strategy: PersistenceThenNetwork
     //   Expected Result: Success from Network: isCached = false
     func testFetch_withPersistenceFirstAndFailing_ShouldRetrieveFromNetwork() {
-        let expectation = self.expectation(description: "testFetch")
+        let fetchExpectation = expectation(description: "testFetch")
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
@@ -697,7 +697,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
 
         // When
         store.fetch(resource: resource) { result in
-            defer { expectation.fulfill() }
+            defer { fetchExpectation.fulfill() }
 
             // Should
             guard let value = result.value else {

--- a/Tests/AlicerceTests/Stores/NetworkPersistableStoreTestCase.swift
+++ b/Tests/AlicerceTests/Stores/NetworkPersistableStoreTestCase.swift
@@ -24,7 +24,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
         let request = URLRequest(url: URL(string: "http://localhost")!)
         static var empty = Data()
 
-        var retriedAfterErrors: [Error]
+        var retryErrors: [Error]
         var totalRetriedDelay: ResourceRetry.Delay
         var retryPolicies: [ResourceRetry.Policy<Data, URLRequest, URLResponse>]
     }
@@ -45,7 +45,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                             parse: { String(data: $0, encoding: .utf8)! },
                             serialize: { $0.data(using: .utf8)! },
                             errorParser: { _ in .🔥 },
-                            retriedAfterErrors: [],
+                            retryErrors: [],
                             totalRetriedDelay: 0,
                             retryPolicies: [])
     }()
@@ -55,7 +55,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                             parse: { String(data: $0, encoding: .utf8)! },
                             serialize: { $0.data(using: .utf8)! },
                             errorParser: { _ in .🔥 },
-                            retriedAfterErrors: [],
+                            retryErrors: [],
                             totalRetriedDelay: 0,
                             retryPolicies: [])
     }()
@@ -167,7 +167,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                                     parse: { _ in throw Parse.Error.json(TestParseError.💩) },
                                     serialize: { _ in throw Serialize.Error.json(TestSerializeError.💩) },
                                     errorParser: { _ in nil },
-                                    retriedAfterErrors: [],
+                                    retryErrors: [],
                                     totalRetriedDelay: 0,
                                     retryPolicies: [])
 
@@ -202,7 +202,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                                     parse: { _ in throw Parse.Error.json(TestParseError.💩) },
                                     serialize: { _ in throw Serialize.Error.json(TestSerializeError.💩) },
                                     errorParser: { _ in nil },
-                                    retriedAfterErrors: [],
+                                    retryErrors: [],
                                     totalRetriedDelay: 0,
                                     retryPolicies: [])
 
@@ -238,7 +238,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                                     parse: { _ in throw Parse.Error.json(TestParseError.💩) },
                                     serialize: { _ in throw Serialize.Error.json(TestSerializeError.💩) },
                                     errorParser: { _ in nil },
-                                    retriedAfterErrors: [],
+                                    retryErrors: [],
                                     totalRetriedDelay: 0,
                                     retryPolicies: [])
 
@@ -478,7 +478,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                                     parse: cancellingParse,
                                     serialize: { _ in throw Serialize.Error.json(TestSerializeError.💩) },
                                     errorParser: { _ in nil },
-                                    retriedAfterErrors: [],
+                                    retryErrors: [],
                                     totalRetriedDelay: 0,
                                     retryPolicies: [])
 


### PR DESCRIPTION
## Changes

- Created new `RetryableResource` protocol, to represent a resource that can be retried.

  + A default handling logic has been implemented, which combines multiple policies into an action, each time an error occurs.

- Created new `ResourceRetry` namespace, containing most types used for the resource retry logic. Most relevant ones are:

  + `ResourceRetry.Action` represents an action to take after evaluating a policy.

  + `ResourceRetry.Policy` represents a retry policy, with multiple available strategies.

  + `ResourceRetry.Policy.Rule` represents a custom retry policy rule.

- Updated `URLSessionNetworkStack` to take advantage of the new `RetryableResource` capabilities, while also deprecating the usage of `authenticator.isAuthenticationInvalid` for auth related retries.

- Removed `NetworkAuthenticator`'s `isAuthenticationInvalid` method, which essentially has been deprecated in favor of using a custom retry policy rule.

- Created new `RetryableNetworkAuthenticator` extending `NetworkAuthenticator`, which requires the implementation of a method to return a custom `RetryPolicy.Rule` for authentication related retries.

- Updated `NetworkStack`, `NetworkStore` and conforming types to also require a `RetryableResource`, and thus have a `Request` and `Response` associated types.

- Revised `PersistenceStack` APIs to use correct types.

- Revised `NetworkPersistableStore` by unnesting some types, revising some API's and `Cancelable` related logic.

- Unified `Cancelable` and conforming base types in the same place, added conformance to `URLSessionTask` and `DispatchWorkItem`.

- Created dedicated files for some Network related mocks.