### PR TITLE
UIImage Convenience Init - Base64 String

### DIFF
--- a/Sources/UIKit/UIImage.swift
+++ b/Sources/UIKit/UIImage.swift
@@ -3,4 +3,9 @@ import UIKit
 public extension UIImage {
     public var original: UIImage { return withRenderingMode(.alwaysOriginal) }
     public var template: UIImage { return withRenderingMode(.alwaysTemplate) }
+
+    convenience init?(base64Encoded encodedString: String) {
+        guard let data = Data(base64Encoded: encodedString) else { return nil }
+        self.init(data: data)
+    }
 }

--- a/Tests/AlicerceTests/UIKit/UIImageTestCase.swift
+++ b/Tests/AlicerceTests/UIKit/UIImageTestCase.swift
@@ -20,4 +20,28 @@ final class UIImageTestCase: XCTestCase {
 
         XCTAssertEqual(mrMinderTemplate.renderingMode, .alwaysTemplate)
     }
+
+    func testConvenienceInit_WithBase64String_ShouldReturnUIImage() {
+        let mrMinder = imageFromFile(withName: "mr-minder", type: "png")
+
+        guard let pngImageData = UIImagePNGRepresentation(mrMinder) else {
+            XCTFail("Could not convert mr-minder image to PNG representation")
+            return
+        }
+
+        let base64String = pngImageData.base64EncodedString()
+
+        guard let image = UIImage(base64Encoded: base64String) else {
+            XCTFail("Could not init UIImage from base64 representation")
+            return
+        }
+
+        XCTAssertEqual(UIImagePNGRepresentation(image), pngImageData)
+    }
+
+    func testConvenienceInit_WithNoneBase64String_ShouldReturnNilFromInit() {
+        let image = UIImage(base64Encoded: "💥")
+
+        XCTAssertNil(image)
+    }
 }

--- a/Tests/AlicerceTests/UIKit/UIImageTestCase.swift
+++ b/Tests/AlicerceTests/UIKit/UIImageTestCase.swift
@@ -21,7 +21,7 @@ final class UIImageTestCase: XCTestCase {
         XCTAssertEqual(mrMinderTemplate.renderingMode, .alwaysTemplate)
     }
 
-    func testConvenienceInit_WithBase64String_ShouldReturnUIImage() {
+    func testConvenienceInit_WithImageInBase64_ShouldReturnUIImage() {
         let mrMinder = imageFromFile(withName: "mr-minder", type: "png")
 
         guard let pngImageData = UIImagePNGRepresentation(mrMinder) else {
@@ -37,6 +37,12 @@ final class UIImageTestCase: XCTestCase {
         }
 
         XCTAssertEqual(UIImagePNGRepresentation(image), pngImageData)
+    }
+
+    func testConvenienceInit_WithPlainTextInBase64_ShouldReturnNilFromInit() {
+        let image = UIImage(base64Encoded: "Ym9vbQ==")
+
+        XCTAssertNil(image)
     }
 
     func testConvenienceInit_WithNoneBase64String_ShouldReturnNilFromInit() {


### PR DESCRIPTION
This PR just adds a convenience init to `UIImage` for initialising from base64 encoded strings. Currently this is a two step process requiring you to construct a `Data` object and then a `UIImage` object. Both of these init's are optional meaning the caller has to account for two cases of `nil`. This convenience init wraps these two optionals calls into one.