### PR TITLE
Improve `DiskMemoryPersistenceStack` 📼

### DIFF
--- a/Sources/Persistence/DiskMemoryPersistenceStack.swift
+++ b/Sources/Persistence/DiskMemoryPersistenceStack.swift
@@ -1,458 +1,441 @@
 import UIKit
 import Result
 
-public final class DiskMemoryPersistenceStack: NSObject, PersistenceStack {
+public extension Persistence {
 
-    public struct Configuration {
+    public final class DiskMemoryPersistenceStack: NSObject, PersistenceStack {
 
-        /// Disk size limit in bytes.
-        let diskLimit: UInt64
+        public struct Configuration {
 
-        /// Memory size limit in bytes.
-        let memLimit: UInt64
+            /// Disk size limit in bytes.
+            let diskLimit: UInt64
 
-        /// Path where the data is persisted.
-        let path: String
+            /// Memory size limit in bytes.
+            let memLimit: UInt64
 
-        /// The manager used for file operations.
-        let fileManager: FileManager
+            /// Path where the data is persisted.
+            let path: String
 
-        /// The performance metrics tracker.
-        let performanceMetrics: PersistencePerformanceMetricsTracker?
+            /// The manager used for file operations.
+            let fileManager: FileManager
 
-        /// Set the operation Quality of Service for read and write operations
-        /// The read value should be higher than write, otherwise it will fail
-        /// Default Values:
-        ///   - read = .userInitiated
-        ///   - write = .utility
-        var qos: (read: QualityOfService, write: QualityOfService) {
-            willSet {
-                guard newValue.read.rawValue > newValue.write.rawValue else {
-                    return assertionFailure("💥 read value should be higher than write")
+            /// The performance metrics tracker.
+            let performanceMetrics: PersistencePerformanceMetricsTracker?
+
+            /// The queue to use for read operations. Set to `nil` for synchronous reads.
+            let readQueue: DispatchQueue?
+
+            /// The underlying queue to use for write operations (i.e. by the `writeOperationQueue`).
+            let writeQueue: DispatchQueue
+
+            public init(diskLimit: UInt64,
+                        memLimit: UInt64,
+                        path: String,
+                        fileManager: FileManager = .default,
+                        performanceMetrics: PersistencePerformanceMetricsTracker? = nil,
+                        readQueue: DispatchQueue?,
+                        writeQueue: DispatchQueue) {
+
+                self.diskLimit = diskLimit
+                self.memLimit = memLimit
+                self.path = path
+                self.fileManager = fileManager
+                self.performanceMetrics = performanceMetrics
+                self.readQueue = readQueue
+                self.writeQueue = writeQueue
+            }
+        }
+
+        public enum Error: Swift.Error {
+            case failedToCreateDirectory(Swift.Error)
+            case failedToGetDirectoryContents(Swift.Error)
+            case failedToRemoveFile(FileRemovalError)
+            case failedToCreateFile(FileCreationError)
+
+            public enum FileRemovalError: Swift.Error {
+                case fileResourceValuesFetchFailed(Swift.Error)
+                case invalidFileTypeAtPath(String)
+                case fileNotFound(Swift.Error)
+                case removeFailed(Swift.Error)
+            }
+
+            public enum FileCreationError: Swift.Error {
+                case fileResourceValuesFetchFailed(Swift.Error)
+                case invalidFileTypeAtPath(String)
+                case createFailed
+            }
+        }
+
+        typealias Bytes = UInt64
+
+        typealias MemoryAccessStopClosure = (_ result: Result<(blobSize: Bytes, memorySize: Bytes), Error>) -> Void
+
+        typealias DiskAccessStopClosure = (_ result: Result<(blobSize: Bytes, diskSize: Bytes), Error>) -> Void
+
+        private let cache = NSCache<NSString, NSData>()
+
+        private let configuration: Configuration
+
+        private var readQueue: DispatchQueue? { return configuration.readQueue }
+
+        private let writeOperationQueue: OperationQueue = {
+            $0.name = "com.mindera.alicerce.persistence.diskmem.write.operation-queue"
+            $0.maxConcurrentOperationCount = 1
+            return $0
+        }(OperationQueue())
+
+        // needs to be atomic since read and write operations are not always made on the same queue/thread
+        private var usedDiskSize = Atomic<Bytes>(0)
+
+        // needs to be atomic since `NSCache` operations are not always made on the same queue/thread, i.e. caller
+        private let usedMemorySize = Atomic<Bytes>(0)
+
+        public init(configuration: Configuration) throws {
+            self.configuration = configuration
+
+            super.init()
+
+            cache.totalCostLimit = Int(configuration.memLimit)
+            cache.delegate = self
+
+            writeOperationQueue.underlyingQueue = configuration.writeQueue
+
+            if hasDiskCacheDirectory() == false {
+                try createDiskCacheDirectory()
+            }
+
+            usedDiskSize.value = try calculateUsedDiskSize()
+        }
+
+        deinit {
+            writeOperationQueue.waitUntilAllOperationsAreFinished()
+        }
+
+        // MARK: - Public Methods
+
+        public func object(for key: Key, completion: @escaping ReadCompletionClosure) {
+            if let data = cachedData(for: key) {
+                return completion(.success(data))
+
+                // TODO: Check for object on disk and persist it if not present, because it might have been evicted.
+                // This is to ensure that the most accessed data is present on both caches
+                // Ideally we could even check that the data was the same, and simply "touch" the file to update the
+                // last accessed date (essentially moving it to the end of the eviction "queue").
+            }
+
+            diskData(for: key) { [weak self] in
+                completion($0)
+
+                switch $0 {
+                case .success(let data?): self?.setCachedData(data, for: key)
+                default: break
                 }
             }
         }
 
-        public init(diskLimit: UInt64,
-                    memLimit: UInt64,
-                    path: String,
-                    fileManager: FileManager = .default,
-                    performanceMetrics: PersistencePerformanceMetricsTracker? = nil,
-                    qos: (read: QualityOfService, write: QualityOfService) = (read: .userInitiated, write: .utility)) {
+        public func setObject(_ object: Data, for key: Key, completion: @escaping WriteCompletionClosure) {
+            setCachedData(object, for: key)
 
-            self.diskLimit = diskLimit
-            self.memLimit = memLimit
-            self.path = path
-            self.fileManager = fileManager
-            self.performanceMetrics = performanceMetrics
-            self.qos = qos
-        }
-    }
-
-    public enum Error: Swift.Error {
-        case diskCacheDisabled
-        case failedToRemoveFile(FileRemovalError)
-        case failedToCreateFile(FileCreationError)
-
-        public enum FileRemovalError: Swift.Error {
-            case fileResourceValuesFetchFailed(Swift.Error)
-            case invalidFileTypeAtPath(String)
-            case fileNotFound(Swift.Error)
-            case removeFailed(Swift.Error)
+            setDiskData(object, for: key, completion: completion)
         }
 
-        public enum FileCreationError: Swift.Error {
-            case fileResourceValuesFetchFailed(Swift.Error)
-            case invalidFileTypeAtPath(String)
-            case createFailed
-        }
-    }
+        public func removeObject(for key: Key, completion: @escaping WriteCompletionClosure) {
+            removeCachedData(for: key)
 
-    private let cache = NSCache<NSString, NSData>()
-
-    private let configuration: Configuration
-
-    private var diskCacheEnabled: Bool = false
-
-    let readOperationQueue: OperationQueue = {
-        $0.name = "com.mindera.alicerce.persistence.diskmem.read"
-        return $0
-    }(OperationQueue())
-    let writeOperationQueue: OperationQueue = {
-        $0.name = "com.mindera.alicerce.persistence.diskmem.write"
-        $0.maxConcurrentOperationCount = 1
-        return $0
-    }(OperationQueue())
-
-    private var usedDiskSize: UInt64 = 0 // Size in bytes
-
-    // needs to be atomic since `NSCache` operations are not always made on the same queue/thread, i.e. caller
-    private let usedMemorySize = Atomic<UInt64>(0) // Size in bytes
-
-    public init(configuration: Configuration) {
-        self.configuration = configuration
-
-        super.init()
-
-        cache.totalCostLimit = Int(configuration.memLimit)
-        cache.delegate = self
-
-        readOperationQueue.qualityOfService = configuration.qos.read
-        writeOperationQueue.qualityOfService = configuration.qos.write
-
-        diskCacheEnabled = hasDiskCacheDirectory() || createDiskCacheDirectory()
-
-        calculateUsedDiskSize()
-    }
-
-    // MARK: - Public Methods
-
-    public func object(for key: Persistence.Key, completion: @escaping PersistenceCompletionClosure<Data>) {
-        if let data = cachedData(for: key) {
-            return completion { data }
+            removeDiskData(for: key, completion: completion)
         }
 
-        // TODO: Check for object on disk and cache it if don't available
+        // MARK: - Private Methods
 
-        diskData(for: key) { [weak self] inner in
-            do {
-                let data = try inner()
+        // MARK: - NSCache Related Operations
 
-                self?.setCachedData(data, for: key)
-
-                completion { data }
-            } catch {
-                completion { throw error }
-            }
-        }
-    }
-
-    public func setObject(_ object: Data,
-                          for key: Persistence.Key,
-                          completion: @escaping PersistenceCompletionClosure<Void>) {
-        setCachedData(object, for: key)
-
-        setDiskData(object, for: key, completion: completion)
-    }
-
-    public func removeObject(for key: Persistence.Key, completion: @escaping PersistenceCompletionClosure<Void>) {
-        removeCachedData(for: key)
-
-        removeDiskData(for: key, completion: completion)
-    }
-
-    // MARK: - Private Methods
-
-    // MARK: - NSCache Related Operations
-
-    private func cachedData(for key: Persistence.Key) -> Data? {
-        guard let performanceMetrics = configuration.performanceMetrics else {
-            return cache.object(forKey: key.nsString) as Data?
-        }
-
-        return performanceMetrics.measureMemoryRead { [unowned self] (stop: @escaping MemoryAccessStopClosure) in
-            let cached = self.cache.object(forKey: key.nsString) as Data?
-
-            switch cached {
-            case let value?: stop(.success((UInt64(value.count), usedMemorySize.value)))
-            case nil: stop(.failure(.noObjectForKey))
+        private func cachedData(for key: Key) -> Data? {
+            guard let performanceMetrics = configuration.performanceMetrics else {
+                return cache.object(forKey: key.nsString) as Data?
             }
 
-            return cached
-        }
-    }
+            return performanceMetrics.measureMemoryRead { [unowned self] (stop: @escaping MemoryAccessStopClosure) in
+                let cached = self.cache.object(forKey: key.nsString) as Data?
 
-    private func setCachedData(_ data: Data, for key: Persistence.Key) {
-        guard let performanceMetrics = configuration.performanceMetrics else {
-            let blobSize = data.count
-            // update *before* setting new blob because we can trigger an eviction on set if the cache is full or small
-            usedMemorySize.modify { $0 += UInt64(blobSize) }
-            cache.setObject(data.nsData, forKey: key.nsString, cost: blobSize)
-            return
-        }
+                switch cached {
+                case let value?: stop(.success((UInt64(value.count), usedMemorySize.value)))
+                case nil: stop(.success((0, usedMemorySize.value)))
+                }
 
-        performanceMetrics.measureMemoryWrite { [unowned self] (stop: @escaping MemoryAccessStopClosure) in
-            let blobSize = data.count
-            // update *before* setting new blob because we can trigger an eviction on set if the cache is full or small
-            let newUsedMemorySize: UInt64 = self.usedMemorySize.modify {
-                $0 += UInt64(blobSize)
-                return $0
+                return cached
             }
-            self.cache.setObject(data.nsData, forKey: key.nsString, cost: blobSize)
-
-            stop(.success((UInt64(blobSize), newUsedMemorySize)))
-        }
-    }
-
-    private func removeCachedData(for key: Persistence.Key) {
-        cache.removeObject(forKey: key.nsString)
-    }
-
-    // MARK: - Disk Related Operations
-
-    private func diskData(for key: Persistence.Key, completion: @escaping PersistenceCompletionClosure<Data>) {
-        guard diskCacheEnabled else { return completion { throw Persistence.Error.other(Error.diskCacheDisabled) } }
-
-        guard let performanceMetrics = configuration.performanceMetrics else {
-            readOperationQueue.addOperation(makeReadOperation(for: key, completion: completion))
-            return
         }
 
-        performanceMetrics.measureDiskRead { stop in
-            readOperationQueue.addOperation(makeReadOperation(for: key, completion: completion, metricStop: stop))
-        }
-    }
-
-    private func setDiskData(_ data: Data,
-                             for key: Persistence.Key,
-                             completion: @escaping PersistenceCompletionClosure<Void>) {
-        guard diskCacheEnabled else { return completion { throw Persistence.Error.other(Error.diskCacheDisabled) } }
-
-        let writeOperation: DiskMemoryBlockOperation
-
-        if let performanceMetrics = configuration.performanceMetrics {
-            writeOperation = performanceMetrics.measureDiskWrite { [unowned self] stop in
-                return self.makeWriteOperation(with:data, for: key, completion: completion, metricStop: stop)
+        private func setCachedData(_ data: Data, for key: Key) {
+            guard let performanceMetrics = configuration.performanceMetrics else {
+                let blobSize = data.count
+                // update *before* setting new blob because we can trigger an eviction on set if the cache is full/small
+                usedMemorySize.modify { $0 += UInt64(blobSize) }
+                cache.setObject(data.nsData, forKey: key.nsString, cost: blobSize)
+                return
             }
-        } else {
-            writeOperation = makeWriteOperation(with: data, for: key, completion: completion)
+
+            performanceMetrics.measureMemoryWrite { (stop: @escaping MemoryAccessStopClosure) in
+                let blobSize = data.count
+                // update *before* setting new blob because we can trigger an eviction on set if the cache is full/small
+                let newUsedMemorySize: UInt64 = self.usedMemorySize.modify {
+                    $0 += UInt64(blobSize)
+                    return $0
+                }
+                cache.setObject(data.nsData, forKey: key.nsString, cost: blobSize)
+
+                stop(.success((UInt64(blobSize), newUsedMemorySize)))
+            }
         }
 
-        let evictOperation = makeEvictOperation()
-        evictOperation.addDependency(writeOperation)
+        private func removeCachedData(for key: Key) {
+            cache.removeObject(forKey: key.nsString)
+        }
 
-        writeOperationQueue.addOperation(writeOperation)
-        writeOperationQueue.addOperation(evictOperation)
-    }
+        // MARK: - Disk Related Operations
 
-    private func removeDiskData(for key: Persistence.Key, completion: @escaping PersistenceCompletionClosure<Void>) {
-        guard diskCacheEnabled else { return completion { throw Persistence.Error.other(Error.diskCacheDisabled) } }
+        private func diskData(for key: Key, completion: @escaping ReadCompletionClosure) {
+            guard let performanceMetrics = configuration.performanceMetrics else {
+                let read = makeReadClosure(for: key, completion: completion)
 
-        let removeOperation = DiskMemoryBlockOperation() { [unowned self] in
-            let path = self.diskPath(for: key)
-            let fileURL = URL(fileURLWithPath: path)
+                readQueue?.async(execute: read) ?? read()
+                return
+            }
 
-            var resourceValues: URLResourceValues? = nil
+            performanceMetrics.measureDiskRead { (stop: @escaping DiskAccessStopClosure) in
+                let read = makeReadClosure(for: key, completion: completion, metricStop: stop)
 
-            do {
-                resourceValues = try fileURL.resourceValues(forKeys: [.fileResourceTypeKey, .fileSizeKey])
+                readQueue?.async(execute: read) ?? read()
+            }
+        }
 
-                var fileSize: UInt64 = 0
+        private func setDiskData(_ data: Data, for key: Key, completion: @escaping WriteCompletionClosure) {
+            let writeOperation: DiskMemoryBlockOperation
 
-                switch resourceValues?.fileResourceType {
-                case .regular?:
-                    fileSize = UInt64(resourceValues?.fileSize ?? 0)
-                default:
-                    return completion {
-                        throw Persistence.Error.other(Error.failedToRemoveFile(.invalidFileTypeAtPath(path)))
+            if let performanceMetrics = configuration.performanceMetrics {
+                writeOperation = performanceMetrics.measureDiskWrite { [unowned self] stop in
+                    return self.makeWriteOperation(with:data, for: key, completion: completion, metricStop: stop)
+                }
+            } else {
+                writeOperation = makeWriteOperation(with: data, for: key, completion: completion)
+            }
+
+            let evictOperation = makeEvictOperation()
+            evictOperation.addDependency(writeOperation)
+
+            writeOperationQueue.addOperation(writeOperation)
+            writeOperationQueue.addOperation(evictOperation)
+        }
+
+        private func removeDiskData(for key: Key, completion: @escaping WriteCompletionClosure) {
+            let removeOperation = DiskMemoryBlockOperation() { [unowned self] in
+                let path = self.diskPath(for: key)
+                let fileURL = URL(fileURLWithPath: path)
+
+                var resourceValues: URLResourceValues? = nil
+
+                do {
+                    resourceValues = try fileURL.resourceValues(forKeys: [.fileResourceTypeKey, .fileSizeKey])
+
+                    var fileSize: UInt64 = 0
+
+                    switch resourceValues?.fileResourceType {
+                    case .regular?:
+                        fileSize = UInt64(resourceValues?.fileSize ?? 0)
+                    default:
+                        return completion(.failure(.failedToRemoveFile(.invalidFileTypeAtPath(path))))
                     }
+
+                    try self.remove(fileAtURL: fileURL, size: fileSize)
+
+                } catch let error as NSError where error.isNoSuchFileError {
+                    return completion(.failure(.failedToRemoveFile(.fileNotFound(error))))
+                } catch let error as Error {
+                    return completion(.failure(error))
+                } catch {
+                    return completion(.failure(.failedToRemoveFile(.fileResourceValuesFetchFailed(error))))
                 }
 
-                try self.remove(fileAtURL: fileURL, size: fileSize)
-
-            } catch let error as NSError where error.isNoSuchFileError {
-                return completion { throw Persistence.Error.other(Error.failedToRemoveFile(.fileNotFound(error))) }
-            } catch let error as Persistence.Error {
-                return completion { throw error }
-            } catch {
-                return completion {
-                    throw Persistence.Error.other(Error.failedToRemoveFile(.fileResourceValuesFetchFailed(error)))
-                }
+                completion(.success(()))
             }
 
-            completion { () }
+            writeOperationQueue.addOperation(removeOperation)
         }
 
-        writeOperationQueue.addOperation(removeOperation)
-    }
+        private func calculateUsedDiskSize() throws -> UInt64 {
+            let urls = try directoryContents(with: [.fileSizeKey])
 
-    private func calculateUsedDiskSize() {
-        let calculateUsedSizeOperation = DiskMemoryBlockOperation() { [weak self] in
-            guard let strongSelf = self else { return }
-
-            let urls = strongSelf.directoryContents(with: [.fileSizeKey])
-
-            strongSelf.usedDiskSize = urls.reduce(0) {
+            return urls.reduce(0) {
                 guard let fileSize = try? $1.resourceValues(forKeys: [.fileSizeKey]).fileSize else { return $0 }
                 return $0 + UInt64(fileSize ?? 0)
             }
         }
 
-        writeOperationQueue.addOperation(calculateUsedSizeOperation)
-    }
-
-    private func diskPath(for key: Persistence.Key) -> String {
-        return "\(configuration.path)/\(key)"
-    }
-
-    private func hasDiskCacheDirectory() -> Bool {
-        return configuration.fileManager.fileExists(atPath: configuration.path)
-    }
-
-    // FIX: Should this error be propagated to the top level?
-    private func createDiskCacheDirectory() -> Bool {
-        do {
-            try configuration.fileManager.createDirectory(atPath: configuration.path,
-                                                          withIntermediateDirectories: true,
-                                                          attributes: nil)
-        }
-        catch let error {
-            assertionFailure("💥 failed to create directory `\(configuration.path)` with error: \n\(error)")
-            return false
+        private func diskPath(for key: Key) -> String {
+            return "\(configuration.path)/\(key)"
         }
 
-        return true
-    }
-
-    private func directoryContents(with keys: [URLResourceKey]) -> [URL] {
-        let url = URL(fileURLWithPath: configuration.path, isDirectory: true)
-
-        guard let urls = try? configuration.fileManager.contentsOfDirectory(at: url,
-                                                                            includingPropertiesForKeys: keys,
-                                                                            options: .skipsPackageDescendants)
-        else {
-            assertionFailure("💥 failed to read directory content for path 👉 \(url.absoluteString)")
-            return []
+        private func hasDiskCacheDirectory() -> Bool {
+            return configuration.fileManager.fileExists(atPath: configuration.path)
         }
 
-        return urls
-    }
-    
-    private func remove(fileAtURL url: URL, size: UInt64) throws {
-        do {
-            try configuration.fileManager.removeItem(at: url)
-            
-            usedDiskSize -= size // Update used size if item removed with success
-        } catch let error {
-            throw Persistence.Error.other(Error.failedToRemoveFile(.removeFailed(error)))
-        }
-    }
-
-    // MARK: - Operations
-
-    typealias MemoryAccessStopClosure =
-        (_ result: Result<(blobSize: UInt64, memorySize: UInt64), Persistence.Error>) -> Void
-
-    typealias DiskAccessStopClosure =
-        (_ result: Result<(blobSize: UInt64, diskSize: UInt64), Persistence.Error>) -> Void
-
-    private func makeReadOperation(for key: Persistence.Key,
-                                   completion: @escaping PersistenceCompletionClosure<Data>,
-                                   metricStop: (DiskAccessStopClosure)? = nil)
-    -> DiskMemoryBlockOperation {
-        return DiskMemoryBlockOperation() { [unowned self] in
-            let path = self.diskPath(for: key)
-
-            guard let fileData = self.configuration.fileManager.contents(atPath: path) else {
-                let error = Persistence.Error.noObjectForKey
-                metricStop?(.failure(error))
-                return completion { throw error }
+        private func createDiskCacheDirectory() throws {
+            do {
+                try configuration.fileManager.createDirectory(atPath: configuration.path,
+                                                              withIntermediateDirectories: true,
+                                                              attributes: nil)
+            } catch {
+                throw Error.failedToCreateDirectory(error)
             }
-
-            metricStop?(.success((UInt64(fileData.count), self.usedDiskSize)))
-            completion { return fileData }
         }
-    }
 
-    private func makeWriteOperation(with data: Data,
-                                    for key: Persistence.Key,
-                                    completion: @escaping PersistenceCompletionClosure<Void>,
-                                    metricStop: (DiskAccessStopClosure)? = nil) -> DiskMemoryBlockOperation {
-        return DiskMemoryBlockOperation() { [unowned self] in
-            let path = self.diskPath(for: key)
-            let fileURL = URL(fileURLWithPath: path)
-
-            var existingFileSize: UInt64 = 0
-
-            func fail(with error: Persistence.Error) {
-                metricStop?(.failure(error))
-                completion { throw error }
-            }
+        private func directoryContents(with keys: [URLResourceKey]) throws -> [URL] {
+            let url = URL(fileURLWithPath: configuration.path, isDirectory: true)
 
             do {
-                let resourceValues = try fileURL.resourceValues(forKeys: [.fileResourceTypeKey, .fileSizeKey])
+                return try configuration.fileManager.contentsOfDirectory(at: url,
+                                                                         includingPropertiesForKeys: keys,
+                                                                         options: .skipsPackageDescendants)
+            } catch {
+                throw Error.failedToGetDirectoryContents(error)
+            }
+        }
 
-                switch resourceValues.fileResourceType {
-                case .regular?:
-                    existingFileSize = UInt64(resourceValues.fileSize ?? 0)
-                default:
-                    fail(with: .other(Error.failedToCreateFile(.invalidFileTypeAtPath(path))))
+        private func remove(fileAtURL url: URL, size: UInt64) throws {
+            do {
+                try configuration.fileManager.removeItem(at: url)
+
+                usedDiskSize.modify { $0 -= size } // Update used size if item removed with success
+            } catch let error {
+                throw Error.failedToRemoveFile(.removeFailed(error))
+            }
+        }
+
+        // MARK: - Operations
+
+        private func makeReadClosure(for key: Key,
+                                     completion: @escaping ReadCompletionClosure,
+                                     metricStop: (DiskAccessStopClosure)? = nil) -> () -> Void {
+            return { [unowned self] in
+                let path = self.diskPath(for: key)
+
+                let fileData = self.configuration.fileManager.contents(atPath: path)
+                let size = fileData.flatMap { UInt64($0.count) } ?? 0
+
+                metricStop?(.success((size, self.usedDiskSize.value)))
+                completion(.success(fileData))
+            }
+        }
+
+        private func makeWriteOperation(with data: Data,
+                                        for key: Key,
+                                        completion: @escaping WriteCompletionClosure,
+                                        metricStop: (DiskAccessStopClosure)? = nil) -> DiskMemoryBlockOperation {
+            return DiskMemoryBlockOperation() { [unowned self] in
+                let path = self.diskPath(for: key)
+                let fileURL = URL(fileURLWithPath: path)
+
+                var existingFileSize: UInt64 = 0
+
+                func fail(with error: Error) {
+                    metricStop?(.failure(error))
+                    completion(.failure(error))
+                }
+
+                do {
+                    let resourceValues = try fileURL.resourceValues(forKeys: [.fileResourceTypeKey, .fileSizeKey])
+
+                    switch resourceValues.fileResourceType {
+                    case .regular?:
+                        existingFileSize = UInt64(resourceValues.fileSize ?? 0)
+                    default:
+                        fail(with: .failedToCreateFile(.invalidFileTypeAtPath(path)))
+                        return
+                    }
+                } catch let error as NSError where error.isNoSuchFileError {
+                    // ignore, file doesn't exist
+                } catch {
+                    fail(with: .failedToCreateFile(.fileResourceValuesFetchFailed(error)))
                     return
                 }
-            } catch let error as NSError where error.isNoSuchFileError {
-                // ignore, file doesn't exist
-            } catch {
-                fail(with: .other(Error.failedToCreateFile(.fileResourceValuesFetchFailed(error))))
-                return
-            }
 
-            // create the file, which will overwrite any existing file at the same path
-            guard self.configuration.fileManager.createFile(atPath: path, contents: data) else {
-                fail(with: .other(Error.failedToCreateFile(.createFailed)))
-                return
-            }
+                // create the file, which will overwrite any existing file at the same path
+                guard self.configuration.fileManager.createFile(atPath: path, contents: data) else {
+                    fail(with: .failedToCreateFile(.createFailed))
+                    return
+                }
 
-            do {
-                // fetch the new file's size from the file system, because it can be different from the blob's size
-                let newResourceValues = try fileURL.resourceValues(forKeys: [.fileSizeKey])
-                let newFileSize = UInt64(newResourceValues.fileSize ?? 0)
+                do {
+                    // fetch the new file's size from the file system, because it can be different from the blob's size
+                    let newResourceValues = try fileURL.resourceValues(forKeys: [.fileSizeKey])
+                    let newFileSize = UInt64(newResourceValues.fileSize ?? 0)
 
-                // subtract the size of any (overwritten) existing file from the new file's size
-                self.usedDiskSize += newFileSize - existingFileSize
+                    // subtract the size of any (overwritten) existing file from the new file's size
+                    let usedDiskSize: UInt64 = self.usedDiskSize.modify {
+                        $0 += newFileSize - existingFileSize
+                        return $0
+                    }
 
-                metricStop?(.success((newFileSize, self.usedDiskSize)))
-                completion { return }
-            } catch {
-                fail(with: .other(Error.failedToCreateFile(.fileResourceValuesFetchFailed(error))))
-                return
+                    metricStop?(.success((newFileSize, usedDiskSize)))
+                    completion(.success(()))
+                } catch {
+                    fail(with: .failedToCreateFile(.fileResourceValuesFetchFailed(error)))
+                    return
+                }
             }
         }
-    }
 
-    private func makeEvictOperation() -> DiskMemoryBlockOperation {
-        return DiskMemoryBlockOperation() { [unowned self] in
+        private func makeEvictOperation() -> DiskMemoryBlockOperation {
+            return DiskMemoryBlockOperation() { [unowned self] in
 
-            // Check if should run eviction
-            guard self.configuration.diskLimit < self.usedDiskSize else { return }
+                // Check if should run eviction
+                let usedDiskSize = self.usedDiskSize.value
 
-            let extraOccupiedDiskSize = self.usedDiskSize - self.configuration.diskLimit
+                guard self.configuration.diskLimit < usedDiskSize else { return }
 
-            let urls = self.directoryContents(with: [.contentAccessDateKey, .fileSizeKey])
+                let extraOccupiedDiskSize = usedDiskSize - self.configuration.diskLimit
 
-            typealias FileAccessTimeSizeTuple = (accessTime: TimeInterval, size: UInt64)
-            typealias FileURLAttributesTuple = (url: URL, fileAttr: FileAccessTimeSizeTuple)
+                guard let urls = try? self.directoryContents(with: [.contentAccessDateKey, .fileSizeKey]) else {
+                    assertionFailure("💥 Failed to get directory contents on evict!")
 
-            let fileAttributes: [FileURLAttributesTuple] = urls
-                .map {
-                    let resourceValue = try? $0.resourceValues(forKeys: [.contentAccessDateKey, .fileSizeKey])
-
-                    return ($0, (resourceValue?.contentAccessDate?.timeIntervalSince1970 ?? 0,
-                                 UInt64(resourceValue?.fileSize ?? 0)))
+                    return print("💥[Alicerce.Persistence.DiskMemoryPersistenceStack]: Failed to get directory contents on evict")
                 }
-                .sorted { $0.fileAttr.accessTime < $1.fileAttr.accessTime } // sort by *less recently accessed* first
 
-            var evictSize: UInt64 = 0
+                typealias FileAccessTimeSizeTuple = (accessTime: TimeInterval, size: UInt64)
+                typealias FileURLAttributesTuple = (url: URL, fileAttr: FileAccessTimeSizeTuple)
 
-            let filesToRemove = fileAttributes.prefix {
-                guard evictSize < extraOccupiedDiskSize else { return false }
+                let fileAttributes: [FileURLAttributesTuple] = urls
+                    .map {
+                        let resourceValue = try? $0.resourceValues(forKeys: [.contentAccessDateKey, .fileSizeKey])
 
-                evictSize += $0.fileAttr.size
+                        return ($0, (resourceValue?.contentAccessDate?.timeIntervalSince1970 ?? 0,
+                                     UInt64(resourceValue?.fileSize ?? 0)))
+                    }
+                    .sorted { $0.fileAttr.accessTime < $1.fileAttr.accessTime } // sort by *less recently accessed* first
 
-                return true
-            }
+                var evictSize: UInt64 = 0
 
-            filesToRemove.forEach {
-                guard let _ = try? self.remove(fileAtURL: $0.url, size: $0.fileAttr.size) else {
-                    assertionFailure("💥 Failed to remove file with path 👉 \($0)")
+                let filesToRemove = fileAttributes.prefix {
+                    guard evictSize < extraOccupiedDiskSize else { return false }
 
-                    return print("💥 Failed to remove file with path 👉 \($0)")
+                    evictSize += $0.fileAttr.size
+
+                    return true
+                }
+
+                filesToRemove.forEach {
+                    guard let _ = try? self.remove(fileAtURL: $0.url, size: $0.fileAttr.size) else {
+                        assertionFailure("💥 Failed to remove file with path 👉 \($0)")
+
+                        return print("💥[Alicerce.Persistence.DiskMemoryPersistenceStack]: Failed to remove file with path 👉 \($0)")
+                    }
                 }
             }
         }
     }
 }
 
-extension DiskMemoryPersistenceStack: NSCacheDelegate {
+extension Persistence.DiskMemoryPersistenceStack: NSCacheDelegate {
 
     public func cache(_ cache: NSCache<AnyObject, AnyObject>, willEvictObject obj: Any) {
 

--- a/Sources/Persistence/Persistence.swift
+++ b/Sources/Persistence/Persistence.swift
@@ -1,12 +1,8 @@
 import Foundation
+import Result
 
 public enum Persistence {
 
     public typealias Key = String
-
-    public enum Error: Swift.Error {
-        case noObjectForKey
-        case other(Swift.Error)
-    }
 }
 

--- a/Sources/Persistence/PersistenceStack.swift
+++ b/Sources/Persistence/PersistenceStack.swift
@@ -1,13 +1,16 @@
 import Foundation
-
-public typealias PersistenceCompletionClosure<R> = (_ inner: () throws -> R) -> Void
+import Result
 
 public protocol PersistenceStack {
     associatedtype Remote
+    associatedtype Error: Swift.Error
 
-    func object(for key: Persistence.Key, completion: @escaping PersistenceCompletionClosure<Remote>)
+    typealias ReadCompletionClosure = (_ result: Result<Remote?, Error>) -> Void
+    typealias WriteCompletionClosure = (_ result: Result<Void, Error>) -> Void
 
-    func setObject(_ object: Remote, for key: Persistence.Key, completion: @escaping PersistenceCompletionClosure<Void>)
+    func object(for key: Persistence.Key, completion: @escaping ReadCompletionClosure)
 
-    func removeObject(for key: Persistence.Key, completion: @escaping PersistenceCompletionClosure<Void>)
+    func setObject(_ object: Remote, for key: Persistence.Key, completion: @escaping WriteCompletionClosure)
+
+    func removeObject(for key: Persistence.Key, completion: @escaping WriteCompletionClosure)
 }

--- a/Tests/AlicerceTests/Persistence/MockPersistenceStack.swift
+++ b/Tests/AlicerceTests/Persistence/MockPersistenceStack.swift
@@ -1,32 +1,34 @@
 import Foundation
+import Result
 @testable import Alicerce
 
 final class MockPersistenceStack: PersistenceStack {
 
-    typealias InnerCompletionClosure<R> = () throws -> R
-    typealias CompletionClosure<R> = (_ inner: InnerCompletionClosure<R>) -> Void
+    typealias Remote = Data
 
-    var objectInvokedClosure: ((Persistence.Key, CompletionClosure<Data>) -> Void)?
-    var setObjectInvokedClosure: ((Data, Persistence.Key, CompletionClosure<Void>) -> Void)?
-    var removeObjectInvokedClosure: ((String, CompletionClosure<Void>) -> Void)?
+    enum Error: Swift.Error { case 💥 }
 
-    var mockObjectCompletion: InnerCompletionClosure<Data> = { throw Persistence.Error.noObjectForKey }
-    var mockSetObjectCompletion: InnerCompletionClosure<Void> = { return () }
-    var mockRemoveObjectCompletion: InnerCompletionClosure<Void> = { return () }
+    var objectInvokedClosure: ((Persistence.Key, ReadCompletionClosure) -> Void)?
+    var setObjectInvokedClosure: ((Remote, Persistence.Key, WriteCompletionClosure) -> Void)?
+    var removeObjectInvokedClosure: ((Persistence.Key, WriteCompletionClosure) -> Void)?
 
-    func object(for key: Persistence.Key, completion: @escaping CompletionClosure<Data>) {
+    var mockObjectResult: Result<Remote?, Error> = .success(nil)
+    var mockSetObjectResult: Result<Void, Error> = .success(())
+    var mockRemoveObjectResult: Result<Void, Error> = .success(())
+
+    func object(for key: Persistence.Key, completion: @escaping ReadCompletionClosure) {
         objectInvokedClosure?(key, completion)
-        completion(mockObjectCompletion)
+        completion(mockObjectResult)
     }
 
-    func setObject(_ object: Data, for key: Persistence.Key, completion: @escaping CompletionClosure<Void>) {
+    func setObject(_ object: Remote, for key: Persistence.Key, completion: @escaping WriteCompletionClosure) {
         setObjectInvokedClosure?(object, key, completion)
-        completion(mockSetObjectCompletion)
+        completion(mockSetObjectResult)
     }
 
-    func removeObject(for key: String, completion: @escaping CompletionClosure<Void>) {
+    func removeObject(for key: Persistence.Key, completion: @escaping WriteCompletionClosure) {
         removeObjectInvokedClosure?(key, completion)
-        completion(mockRemoveObjectCompletion)
+        completion(mockRemoveObjectResult)
     }
 }
  


### PR DESCRIPTION
## Changes

- Revised `DiskMemoryPersistenceStack`'s concurrency to allow injecting custom `DispatchQueue`s for reading and writing, with the `readQueue` being optional so that when set to `nil` reads from disk are made *synchronously*, avoiding a context switch (queue jump).

- Updated `PersistenceStack` to use `Result` based completion handlers, and to have an associated Error type (instead of forcing `Persistence.Error` to be used).

- Removed `Persistence.Error`, since now cache misses are represented as returning a `nil` value (instead of `Error.noObjectForKey`, and we avoid an error nesting that didn't bring much value (using `Error.other`).

- Nested `DiskMemoryPersistenceStack` inside `Persistence` namespace.

- Did some tweaks on `NetworkPersistableStore` to improve error handling.