### PR TITLE
Remove cached value from Store on parse error 🚽

### DIFF
--- a/Sources/Persistence/DiskMemoryPersistenceStack.swift
+++ b/Sources/Persistence/DiskMemoryPersistenceStack.swift
@@ -462,5 +462,7 @@ fileprivate final class DiskMemoryBlockOperation: BlockOperation {
 
 private extension NSError {
 
-    var isNoSuchFileError: Bool { return domain == NSCocoaErrorDomain && code == NSFileReadNoSuchFileError }
+    var isNoSuchFileError: Bool {
+        return domain == NSCocoaErrorDomain && (code == NSFileReadNoSuchFileError || code == NSFileNoSuchFileError)
+    }
 }

--- a/Sources/Stores/NetworkPersistableStore.swift
+++ b/Sources/Stores/NetworkPersistableStore.swift
@@ -182,6 +182,17 @@ where Network.Remote == Data, Network.Request == URLRequest, Network.Response ==
 
         } catch let error as Parse.Error {
             completion(.failure(.parse(error)))
+
+            // remove any persisted object from the cache if the parsing failed
+            if fromCache {
+                persistenceStack.removeObject(for: resource.persistenceKey) {
+                    switch $0 {
+                    case .success: break
+                    case .failure(let error):
+                        print("⚠️ [Alicerce.NetworkPersistableStore]: Failed to remove value for '\(resource)': \(error)")
+                    }
+                }
+            }
         } catch {
             completion(.failure(.other(error)))
         }


### PR DESCRIPTION
In some scenarios, it's possible that the cached data becomes outdated (e.g. the API and parsing logic were updated) and breaks when being parsed. Until now, these values where never cleaned up unless
explicitly evicted by the user, or automatically by the `NSCache` and/or disk eviction process (total size based only).

To address this, the cached values are now evicted whenever parsing fails (if being read from the cache).