### PR TITLE
Fix retry after delay conversion

### DIFF
--- a/Sources/Network/URLSessionNetworkStack.swift
+++ b/Sources/Network/URLSessionNetworkStack.swift
@@ -231,7 +231,7 @@ public extension Network {
                 let retryCancelable = fetch(resource: resource, completion: completion)
 
                 cancelableBag.add(cancelable: retryCancelable)
-            case (.retryAfter(let delay), _) where delay >= 0:
+            case (.retryAfter(let delay), _) where delay > 0:
                 resource.totalRetriedDelay += delay
 
                 let fetchWorkItem = DispatchWorkItem { [weak self] in

--- a/Sources/Network/URLSessionNetworkStack.swift
+++ b/Sources/Network/URLSessionNetworkStack.swift
@@ -231,7 +231,7 @@ public extension Network {
                 let retryCancelable = fetch(resource: resource, completion: completion)
 
                 cancelableBag.add(cancelable: retryCancelable)
-            case (.retryAfter(let delay), _):
+            case (.retryAfter(let delay), _) where delay >= 0:
                 resource.totalRetriedDelay += delay
 
                 let fetchWorkItem = DispatchWorkItem { [weak self] in
@@ -242,9 +242,11 @@ public extension Network {
 
                 cancelableBag.add(cancelable: WeakCancelable(fetchWorkItem))
 
-                let nanos = Int(delay * Double(NSEC_PER_SEC))
+                retryQueue.asyncAfter(deadline: .now() + delay, execute: fetchWorkItem)
+            case (.retryAfter, _): // retry delay is <= 0
+                let retryCancelable = fetch(resource: resource, completion: completion)
 
-                retryQueue.asyncAfter(deadline: .now() + .nanoseconds(nanos), execute: fetchWorkItem)
+                cancelableBag.add(cancelable: retryCancelable)
             case (.noRetry(let retryError), _):
                 completion(.failure(.retry(errors: resource.retryErrors,
                                            totalDelay: resource.totalRetriedDelay,


### PR DESCRIPTION
On 32 bit devices, the conversion from `ResourceRetry.Delay`
(`TimeInterval`) to nanoseconds was greater than `Int32.max` if the
value was greater than `Int32.max/NSEC_PER_SEC` (2.147483647), which
resulted in a runtime crash.

After closer inspection, we realized that we can simply send in the
seconds directly to `asyncAfter`, and simply add them to `.now()`. 😅

Additionally, a slight optimization was made so that on negative or 0
delay we simply retry immediately after (we also don't add possibly
negative values to `totalRetriedDelay`.