### PR TITLE
Make `NetworkStack` conditionally a `NetworkStore`

### DIFF
--- a/Alicerce.xcodeproj/project.pbxproj
+++ b/Alicerce.xcodeproj/project.pbxproj
@@ -126,6 +126,7 @@
 		0A3C2DBE1EA7E5DD00EFB7D4 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3C2CC21EA7E18500EFB7D4 /* Box.swift */; };
 		0A3C2DC01EA7E5DD00EFB7D4 /* Placeholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3C2CC41EA7E18500EFB7D4 /* Placeholder.swift */; };
 		0A3C2DC11EA7E5DD00EFB7D4 /* ServiceLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3C2CC51EA7E18500EFB7D4 /* ServiceLocator.swift */; };
+		0A50DDD521555D2C00C15A0A /* NetworkStoreTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A50DDD421555D2C00C15A0A /* NetworkStoreTestCase.swift */; };
 		0A5836E820CF41C10090E987 /* Log+Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A5836E620CF41890090E987 /* Log+Item.swift */; };
 		0A708F5420E932EB001784DA /* ModuleLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A708F5320E932EB001784DA /* ModuleLogger.swift */; };
 		0A708F5920E9360A001784DA /* MetadataLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A708F5820E9360A001784DA /* MetadataLogger.swift */; };
@@ -380,6 +381,7 @@
 		0A3C2D681EA7E34C00EFB7D4 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		0A3C2D6A1EA7E35200EFB7D4 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		0A3C2D711EA7E3E800EFB7D4 /* Alicerce.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Alicerce.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0A50DDD421555D2C00C15A0A /* NetworkStoreTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkStoreTestCase.swift; sourceTree = "<group>"; };
 		0A5836E620CF41890090E987 /* Log+Item.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Log+Item.swift"; sourceTree = "<group>"; };
 		0A5CBC0420B31D7100A1447A /* AmazonRootCA3.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = AmazonRootCA3.cer; sourceTree = "<group>"; };
 		0A5CBC0620B31D7200A1447A /* DigiCertGlobalRootG2.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = DigiCertGlobalRootG2.cer; sourceTree = "<group>"; };
@@ -1016,6 +1018,7 @@
 			isa = PBXGroup;
 			children = (
 				0A83886C1EB2064200C1E835 /* NetworkPersistableStoreTestCase.swift */,
+				0A50DDD421555D2C00C15A0A /* NetworkStoreTestCase.swift */,
 			);
 			path = Stores;
 			sourceTree = "<group>";
@@ -1571,6 +1574,7 @@
 				0A266F8C1ED59FB6009CD0D7 /* MultiTrackerTestCase.swift in Sources */,
 				0A85F0E720B3177E0095AFFB /* PublicKeyAlgorithmTestCase.swift in Sources */,
 				0A266F901ED59FB6009CD0D7 /* Route+ComponentTests.swift in Sources */,
+				0A50DDD521555D2C00C15A0A /* NetworkStoreTestCase.swift in Sources */,
 				0A266F911ED59FB6009CD0D7 /* Route+Tree_AddTests.swift in Sources */,
 				0A7CC0F1208FF76B009F3A6E /* DictionaryTests.swift in Sources */,
 				0A266F921ED59FB6009CD0D7 /* Route+Tree_InitTests.swift in Sources */,

--- a/Tests/AlicerceTests/Stores/NetworkStoreTestCase.swift
+++ b/Tests/AlicerceTests/Stores/NetworkStoreTestCase.swift
@@ -1,0 +1,171 @@
+import XCTest
+import Result
+@testable import Alicerce
+
+extension MockNetworkStack: NetworkStore {
+    public typealias E = NetworkPersistableStoreError
+}
+
+class NetworkStoreTestCase: XCTestCase {
+
+    private enum MockAPIError: Error { case 🔥 }
+    private enum MockParseError: Error { case 💩 }
+    private enum MockOtherError: Error { case 💥 }
+
+    private struct MockResource: NetworkResource & PersistableResource & StrategyFetchResource & RetryableResource {
+
+        let value: String
+        let strategy: StoreFetchStrategy
+
+        let parse: (Data) throws -> String
+        let serialize: (String) throws -> Data
+        let errorParser: (Data) -> MockAPIError?
+
+        var persistenceKey: Persistence.Key { return value }
+
+        let request = URLRequest(url: URL(string: "http://localhost")!)
+        static var empty = Data()
+
+        var retryErrors: [Error]
+        var totalRetriedDelay: ResourceRetry.Delay
+        var retryPolicies: [ResourceRetry.Policy<Data, URLRequest, URLResponse>]
+    }
+
+    private typealias NetworkStoreResult = Result<NetworkStoreValue<MockResource.Local>, NetworkPersistableStoreError>
+
+    private lazy var testResource: MockResource = {
+        return MockResource(value: "network",
+                            strategy: .networkThenPersistence,
+                            parse: { String(data: $0, encoding: .utf8)! },
+                            serialize: { $0.data(using: .utf8)! },
+                            errorParser: { _ in .🔥 },
+                            retryErrors: [],
+                            totalRetriedDelay: 0,
+                            retryPolicies: [])
+    }()
+
+    var networkStack: MockNetworkStack!
+
+    override func setUp() {
+        super.setUp()
+
+        networkStack = MockNetworkStack()
+    }
+
+    override func tearDown() {
+        networkStack = nil
+
+        super.tearDown()
+    }
+
+    // MARK: Success tests
+
+    func testFetch_WithSuccessResponse_ShouldCallCompletionClosureWithValue() {
+        let expectation = self.expectation(description: "testFetch")
+        defer { waitForExpectations(timeout: 1.0) }
+
+        let mockValue = "🎉"
+        networkStack.mockData = mockValue.data(using: .utf8)
+
+        networkStack.fetch(resource: testResource) { (result: NetworkStoreResult) in
+
+            switch result {
+            case .success(.network(let value)):
+                XCTAssertEqual(value, mockValue)
+            case .success(let value):
+                XCTFail("🔥 received unexpected success 👉 \(value) 😱")
+            case let .failure(error):
+                XCTFail("🔥 received unexpected error 👉 \(error) 😱")
+            }
+
+            expectation.fulfill()
+        }
+    }
+
+    // MARK: Error tests
+
+    func testFetch_WithNetworkFailureError_ShouldThrowNetworkError() {
+        let expectation = self.expectation(description: "testFetch")
+        defer { waitForExpectations(timeout: 1.0) }
+
+        let statusCode = 500
+        let mockError = NSError(domain: "☠️", code: statusCode, userInfo: nil)
+
+        networkStack.mockError = .url(mockError)
+
+        networkStack.fetch(resource: testResource) { (result: NetworkStoreResult) in
+
+            switch result {
+            case .success:
+                XCTFail("🔥 should throw an error 🤔")
+            case let .failure(.network(.url(receivedError as NSError))):
+                XCTAssertEqual(receivedError, mockError)
+            case let .failure(error):
+                XCTFail("🔥 received unexpected error 👉 \(error) 😱")
+            }
+
+            expectation.fulfill()
+        }
+    }
+
+    func testFetch_WithParseErrorInParse_ShouldThrowParseError() {
+        let expectation = self.expectation(description: "testFetch")
+        defer { waitForExpectations(timeout: 1.0) }
+
+        let resource = MockResource(value: "network",
+                                    strategy: .networkThenPersistence,
+                                    parse: { _ in throw Parse.Error.json(MockParseError.💩) },
+                                    serialize: { $0.data(using: .utf8)! },
+                                    errorParser: { _ in .🔥 },
+                                    retryErrors: [],
+                                    totalRetriedDelay: 0,
+                                    retryPolicies: [])
+
+        networkStack.mockData = "🤔".data(using: .utf8)
+
+        networkStack.fetch(resource: resource) { (result: NetworkStoreResult) in
+
+            switch result {
+            case .success:
+                XCTFail("🔥 should throw an error 🤔")
+            case .failure(.parse(.json(MockParseError.💩))):
+                break // expected error
+            case let .failure(error):
+                XCTFail("🔥 received unexpected error 👉 \(error) 😱")
+            }
+
+            expectation.fulfill()
+        }
+    }
+
+    func testFetch_WithOtherErrorInParse_ShouldThrowOtherError() {
+        let expectation = self.expectation(description: "testFetch")
+        defer { waitForExpectations(timeout: 1.0) }
+
+        let resource = MockResource(value: "network",
+                                    strategy: .networkThenPersistence,
+                                    parse: { _ in throw MockOtherError.💥 },
+                                    serialize: { $0.data(using: .utf8)! },
+                                    errorParser: { _ in .🔥 },
+                                    retryErrors: [],
+                                    totalRetriedDelay: 0,
+                                    retryPolicies: [])
+
+        networkStack.mockData = "🤔".data(using: .utf8)
+
+        networkStack.fetch(resource: resource) { (result: NetworkStoreResult) in
+
+            switch result {
+            case .success:
+                XCTFail("🔥 should throw an error 🤔")
+            case .failure(.other(MockOtherError.💥)):
+            break // expected error
+            case let .failure(error):
+                XCTFail("🔥 received unexpected error 👉 \(error) 😱")
+            }
+
+            expectation.fulfill()
+        }
+    }
+
+}


### PR DESCRIPTION
Created a protocol extension on `NetworkStore` when `Self: NetworkStack` and the Error is `NetworkPersistableStoreError`. This enables using a `NetworkStack` implementation (e.g. `Network.URLSessionNetworkStack`) as a `NetworkStore` directly (more like a `NetworkPersistableStore`), when one doesn't want/need persistence. This avoids having the overhead of using a `NetworkPersistableStore` with a dummy persistence stack.

Cleaned up `Network.URLSessionNetworkStack` internal API's to not have to pass `apiErrorParser` around, since it's on the resource.