### PR TITLE
Improve cancellation handling in `NetworkStore`'s

### DIFF
--- a/Sources/Network/URLSessionNetworkStack.swift
+++ b/Sources/Network/URLSessionNetworkStack.swift
@@ -221,9 +221,7 @@ public extension Network {
                     return
                 }
 
-                let retryCancelable = fetch(resource: resource, completion: completion)
-
-                cancelableBag.add(cancelable: retryCancelable)
+                cancelableBag += fetch(resource: resource, completion: completion)
             case (.retryAfter(let delay), _) where delay > 0:
                 guard cancelableBag.isCancelled == false else {
                     completion(.failure(.retry(errors: resource.retryErrors,
@@ -242,12 +240,10 @@ public extension Network {
                         return
                     }
                     
-                    if let retryCancelable = self?.fetch(resource: resource, completion: completion) {
-                        cancelableBag.add(cancelable: retryCancelable)
-                    }
+                    cancelableBag += self?.fetch(resource: resource, completion: completion)
                 }
 
-                cancelableBag.add(cancelable: WeakCancelable(fetchWorkItem))
+                cancelableBag += WeakCancelable(fetchWorkItem)
 
                 retryQueue.asyncAfter(deadline: .now() + delay, execute: fetchWorkItem)
             case (.retryAfter, _): // retry delay is <= 0
@@ -258,9 +254,7 @@ public extension Network {
                     return
                 }
 
-                let retryCancelable = fetch(resource: resource, completion: completion)
-
-                cancelableBag.add(cancelable: retryCancelable)
+                cancelableBag += fetch(resource: resource, completion: completion)
             case (.noRetry(let retryError), _):
                 completion(.failure(.retry(errors: resource.retryErrors,
                                            totalDelay: resource.totalRetriedDelay,

--- a/Sources/Shared/Cancelable.swift
+++ b/Sources/Shared/Cancelable.swift
@@ -99,6 +99,17 @@ public final class CancelableBag: Cancelable {
 
         cancelables.swap(nil)?.forEach { $0.cancel() }
     }
+
+    /// Adds a cancelable to the bag, if it hasn't been cancelled yet. If it has, the cancelable that is passed in
+    /// **will be cancelled immediately** to ensure correctness and avoid lingering work that can't be cancelled.
+    ///
+    /// - Parameters:
+    ///   - cancelableBag: The bag to add the cancelable to.
+    ///   - cancelable: The cancelable to add.
+    public static func += (cancelableBag: CancelableBag, cancelable: Cancelable?) {
+        guard let cancelable = cancelable else { return }
+        cancelableBag.add(cancelable: cancelable)
+    }
 }
 
 /// A placeholder cancelable that doesn't cancel anything.

--- a/Tests/AlicerceTests/Shared/CancelableBagTestCase.swift
+++ b/Tests/AlicerceTests/Shared/CancelableBagTestCase.swift
@@ -114,4 +114,48 @@ class CancelableBagTestCase: XCTestCase {
 
         cancelable.cancel()
     }
+
+    // +=
+
+    func testAddOperator_WithNotCancelledBag_ShouldAddCancelableToBag() {
+        let expectation = self.expectation(description: "+=")
+        defer { waitForExpectations(timeout: 1) }
+
+        XCTAssertFalse(cancelable.isCancelled)
+
+        let mockCancelable = MockCancelable()
+
+        cancelable += mockCancelable
+
+        mockCancelable.mockCancelClosure = {
+            expectation.fulfill() // ensure it has been added
+        }
+
+        cancelable.cancel()
+    }
+
+    func testAddOperator_WithCancelledBag_ShouldNotAddCancelableToBagAndCancelIt() {
+        let expectation = self.expectation(description: "+=")
+        defer { waitForExpectations(timeout: 1) }
+
+        XCTAssertFalse(cancelable.isCancelled)
+        cancelable.cancel()
+        XCTAssertTrue(cancelable.isCancelled)
+
+        let mockCancelable = MockCancelable()
+        mockCancelable.mockCancelClosure = {
+            expectation.fulfill() // ensure it was cancelled
+        }
+
+        cancelable += mockCancelable
+    }
+
+    func testAddOperator_WithNilCancelable_ShouldIgnoreAdd() {
+        XCTAssertFalse(cancelable.isCancelled)
+
+        let mockCancelable: Cancelable? = nil
+        cancelable += mockCancelable
+
+        XCTAssertFalse(cancelable.isCancelled)
+    }
 }

--- a/Tests/AlicerceTests/Stores/NetworkStoreTestCase.swift
+++ b/Tests/AlicerceTests/Stores/NetworkStoreTestCase.swift
@@ -80,6 +80,8 @@ class NetworkStoreTestCase: XCTestCase {
 
             expectation.fulfill()
         }
+
+        networkStack.runMockFetch()
     }
 
     // MARK: Error tests
@@ -106,6 +108,8 @@ class NetworkStoreTestCase: XCTestCase {
 
             expectation.fulfill()
         }
+
+        networkStack.runMockFetch()
     }
 
     func testFetch_WithParseErrorInParse_ShouldThrowParseError() {
@@ -136,15 +140,22 @@ class NetworkStoreTestCase: XCTestCase {
 
             expectation.fulfill()
         }
+
+        networkStack.runMockFetch()
     }
 
-    func testFetch_WithCancelledURLError_ShouldThrowCancelledError() {
+    func testFetch_WithAnyErrorAndCancelledCancelable_ShouldThrowCancelledError() {
         let expectation = self.expectation(description: "testFetch")
         defer { waitForExpectations(timeout: 1.0) }
 
-        networkStack.mockError = .url(URLError(.cancelled))
+        let cancelable = CancelableBag()
 
-        networkStack.fetch(resource: testResource) { (result: NetworkStoreResult) in
+        networkStack.mockError = .url(MockOtherError.💥)
+        networkStack.beforeFetchCompletionClosure = {
+            cancelable.cancel()
+        }
+
+        cancelable += networkStack.fetch(resource: testResource) { (result: NetworkStoreResult) in
 
             switch result {
             case .success:
@@ -157,6 +168,8 @@ class NetworkStoreTestCase: XCTestCase {
 
             expectation.fulfill()
         }
+
+        networkStack.runMockFetch()
     }
 
     func testFetch_WithOtherErrorInParse_ShouldThrowOtherError() {
@@ -187,6 +200,8 @@ class NetworkStoreTestCase: XCTestCase {
 
             expectation.fulfill()
         }
+
+        networkStack.runMockFetch()
     }
 
 }


### PR DESCRIPTION
## Motivation

With the recent resource retry capabilities, the `URLSessionNetworkStack` fetches now fail with the `.retry` error by default if a retry policy returns a `.noRetry` action.

This means that if a resource fails with a `URLError.cancelled` error and a policy handles it returning `.noRetry`, it is not the "vanilla" `.url(URLErrror.cancelled)` it was before, and instead is a `.noRetry(_, _, .custom(URLError.cancelled))`.

This difference meant that our `NetworkStore`'s didn't handle these errors as `.cancelled` as they should.

To make this more robust (i.e. not dependent on `URLError.cancelled`), the error handling now looks at the `cancellable.isCancelled` flag to determine if the fetch was in fact cancelled or not. This has the extra benefit of eliminating the "false positive" cases of fetches that fail with `URLError.cancelled` because of other reasons (e.g. authentication challenges failures).

## Changes

- Updated `NetworkStore`'s default `URLSessionNetworkStack` extension and `NetworkPersistableStore` to return `.cancelled` only when the network fetch fails and the cancelable has been cancelled.

- Added a `+=` operator on `CancelableBag` to wrap `add`.

- Updated some usages of `CancelableBag.add` to use `+=`

- Improved `MockNetworkStack` to only run the fetch via a new `runMockFetch` API, to solve timing issues when using the cancelable.