### PR TITLE
Propagate errors on .cancelled network store errors

### DIFF
--- a/Sources/Stores/NetworkStore.swift
+++ b/Sources/Stores/NetworkStore.swift
@@ -50,8 +50,8 @@ where Self: NetworkStack, Self.Remote == Remote, Self.Request == Request, Self.R
                 } catch {
                     completion(.failure(.other(error)))
                 }
-            case .failure where cancelable.isCancelled:
-                completion(.failure(.cancelled))
+            case .failure(let error) where cancelable.isCancelled:
+                completion(.failure(.cancelled(error)))
             case .failure(let error):
                 completion(.failure(.network(error)))
             }

--- a/Tests/AlicerceTests/Stores/NetworkPersistableStoreTestCase.swift
+++ b/Tests/AlicerceTests/Stores/NetworkPersistableStoreTestCase.swift
@@ -359,7 +359,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                 return XCTFail("🔥: unexpected success!")
             }
 
-            guard case .cancelled = error else {
+            guard case .cancelled(Network.Error.url(URLError.cancelled)?) = error else {
                 return XCTFail("🔥: unexpected error \(error)!")
             }
         }
@@ -394,7 +394,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                 return XCTFail("🔥: unexpected success!")
             }
 
-            guard case .cancelled = error else {
+            guard case .cancelled(Network.Error.badResponse?) = error else {
                 return XCTFail("🔥: unexpected error \(error)!")
             }
         }
@@ -430,7 +430,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                 return XCTFail("🔥: unexpected success!")
             }
 
-            guard case .cancelled = error else {
+            guard case .cancelled(nil) = error else {
                 return XCTFail("🔥: unexpected error \(error)!")
             }
         }
@@ -470,7 +470,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                 return XCTFail("🔥: unexpected success!")
             }
 
-            guard case .cancelled = error else {
+            guard case .cancelled(nil) = error else {
                 return XCTFail("🔥: unexpected error \(error)!")
             }
         }
@@ -510,7 +510,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                 return XCTFail("🔥: unexpected success!")
             }
 
-            guard case .cancelled = error else {
+            guard case .cancelled(Network.Error.noData?) = error else {
                 return XCTFail("🔥: unexpected error \(error)!")
             }
         }
@@ -566,7 +566,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                 return XCTFail("🔥: unexpected success!")
             }
 
-            guard case .cancelled = error else {
+            guard case .cancelled(nil) = error else {
                 return XCTFail("🔥: unexpected error \(error)!")
             }
         }

--- a/Tests/AlicerceTests/Stores/NetworkStoreTestCase.swift
+++ b/Tests/AlicerceTests/Stores/NetworkStoreTestCase.swift
@@ -160,7 +160,7 @@ class NetworkStoreTestCase: XCTestCase {
             switch result {
             case .success:
                 XCTFail("🔥 should throw an error 🤔")
-            case .failure(.cancelled):
+            case .failure(.cancelled(Network.Error.url(MockOtherError.💥)?)):
                 break // expected error
             case let .failure(error):
                 XCTFail("🔥 received unexpected error 👉 \(error) 😱")


### PR DESCRIPTION
With the latest changes, fetches return a `.cancelled` error if their `Cancelable` was cancelled and the fetch had failed with an error. However, this "original" error was not propagated to the outside, which on some cases might be handy since now more fetches will be marked as
cancelled.

Updating the `NetworkPersistableStoreError.cancelled` error case to have a new `Swift.Error?` associated value will allow us to propagate these errors upstream when they occur. The `nil` case is saved for when no explicit error has occurred leading to the cancellation.