### PR TITLE
Propagate URLResponse on NetworkStack

### DIFF
--- a/Sources/Network/Network.swift
+++ b/Sources/Network/Network.swift
@@ -5,18 +5,35 @@ public enum Network {
 
     // MARK: - TypeAlias
 
-    public typealias CompletionClosure<R> = (Result<R, Error>) -> Void
+    public typealias CompletionClosure<R> = (Result<Value<R>, Error>) -> Void
     public typealias AuthenticationCompletionClosure = (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
 
-    // MARK: - Network Error
+    // MARK: - Response value
 
-    public enum Error: Swift.Error {
-        case http(code: HTTP.StatusCode, apiError: Swift.Error?)
-        case noData
-        case url(Swift.Error)
-        case badResponse
-        case authenticator(Swift.Error)
-        case retry(errors: [Swift.Error], totalDelay: ResourceRetry.Delay, retryError: ResourceRetry.Error)
+    public struct Value<R> {
+
+        let value: R
+
+        let response: URLResponse
+    }
+
+    // MARK: - Response error
+
+    public struct Error: Swift.Error {
+
+        let type: ErrorType
+
+        let response: URLResponse?
+
+        enum ErrorType {
+
+            case http(code: HTTP.StatusCode, apiError: Swift.Error?)
+            case noData
+            case url(Swift.Error)
+            case badResponse
+            case authenticator(Swift.Error)
+            case retry(errors: [Swift.Error], totalDelay: ResourceRetry.Delay, retryError: ResourceRetry.Error)
+        }
     }
 
     // MARK: - Network Configuration

--- a/Sources/Network/Network.swift
+++ b/Sources/Network/Network.swift
@@ -14,6 +14,11 @@ public enum Network {
 
         let value: R
         let response: URLResponse
+
+        public init(value: R, response: URLResponse) {
+            self.value = value
+            self.response = response
+        }
     }
 
     // MARK: - Response error

--- a/Sources/Network/Network.swift
+++ b/Sources/Network/Network.swift
@@ -25,11 +25,11 @@ public enum Network {
 
     public enum Error: Swift.Error {
 
-        case http(code: HTTP.StatusCode, apiError: Swift.Error?, response: URLResponse?)
-        case noData(response: URLResponse?)
+        case http(code: HTTP.StatusCode, apiError: Swift.Error?, response: URLResponse)
+        case noData(response: URLResponse)
         case url(Swift.Error, response: URLResponse?)
         case badResponse(response: URLResponse?)
-        case authenticator(Swift.Error, response: URLResponse?)
+        case authenticator(Swift.Error)
         case retry(errors: [Swift.Error],
             totalDelay: ResourceRetry.Delay,
             retryError: ResourceRetry.Error,
@@ -72,8 +72,8 @@ extension Network.Error {
             return response
         case let .badResponse(response):
             return response
-        case let .authenticator(_, response):
-            return response
+        case .authenticator:
+            return nil
         case let .retry(_, _, _, response):
             return response
         }

--- a/Sources/Network/Network.swift
+++ b/Sources/Network/Network.swift
@@ -12,8 +12,8 @@ public enum Network {
 
     public struct Value<R> {
 
-        let value: R
-        let response: URLResponse
+        public let value: R
+        public let response: URLResponse
 
         public init(value: R, response: URLResponse) {
             self.value = value

--- a/Sources/Network/Network.swift
+++ b/Sources/Network/Network.swift
@@ -31,9 +31,9 @@ public enum Network {
         case badResponse(response: URLResponse?)
         case authenticator(Swift.Error)
         case retry(errors: [Swift.Error],
-            totalDelay: ResourceRetry.Delay,
-            retryError: ResourceRetry.Error,
-            response: URLResponse?)
+                   totalDelay: ResourceRetry.Delay,
+                   retryError: ResourceRetry.Error,
+                   response: URLResponse?)
     }
 
     // MARK: - Network Configuration
@@ -61,7 +61,6 @@ public enum Network {
 }
 
 extension Network.Error {
-    
     var response: URLResponse? {
         switch self {
         case let .http(_, _, response):

--- a/Sources/Network/Network.swift
+++ b/Sources/Network/Network.swift
@@ -13,27 +13,22 @@ public enum Network {
     public struct Value<R> {
 
         let value: R
-
         let response: URLResponse
     }
 
     // MARK: - Response error
 
-    public struct Error: Swift.Error {
+    public enum Error: Swift.Error {
 
-        let type: ErrorType
-
-        let response: URLResponse?
-
-        enum ErrorType {
-
-            case http(code: HTTP.StatusCode, apiError: Swift.Error?)
-            case noData
-            case url(Swift.Error)
-            case badResponse
-            case authenticator(Swift.Error)
-            case retry(errors: [Swift.Error], totalDelay: ResourceRetry.Delay, retryError: ResourceRetry.Error)
-        }
+        case http(code: HTTP.StatusCode, apiError: Swift.Error?, response: URLResponse?)
+        case noData(response: URLResponse?)
+        case url(Swift.Error, response: URLResponse?)
+        case badResponse(response: URLResponse?)
+        case authenticator(Swift.Error, response: URLResponse?)
+        case retry(errors: [Swift.Error],
+            totalDelay: ResourceRetry.Delay,
+            retryError: ResourceRetry.Error,
+            response: URLResponse?)
     }
 
     // MARK: - Network Configuration
@@ -56,6 +51,26 @@ public enum Network {
             self.authenticator = authenticator
             self.requestInterceptors = requestInterceptors
             self.retryQueue = retryQueue
+        }
+    }
+}
+
+extension Network.Error {
+    
+    var response: URLResponse? {
+        switch self {
+        case let .http(_, _, response):
+            return response
+        case let .noData(response):
+            return response
+        case let .url(_, response):
+            return response
+        case let .badResponse(response):
+            return response
+        case let .authenticator(_, response):
+            return response
+        case let .retry(_, _, _, response):
+            return response
         }
     }
 }

--- a/Sources/Network/URLSessionNetworkStack.swift
+++ b/Sources/Network/URLSessionNetworkStack.swift
@@ -135,8 +135,6 @@ public extension Network {
                     return
                 }
 
-
-
                 guard
                     let urlResponse = response,
                     let httpResponse = urlResponse as? HTTPURLResponse
@@ -195,7 +193,7 @@ public extension Network {
                     return strongSelf.perform(request: authenticatedRequest, resource: resource, completion: completion)
 
                 case let .failure(error):
-                    completion(.failure(.authenticator(error.error, response: nil)))
+                    completion(.failure(.authenticator(error.error)))
                     return DummyCancelable()
                 }
             }

--- a/Sources/Stores/NetworkPersistableStore.swift
+++ b/Sources/Stores/NetworkPersistableStore.swift
@@ -200,9 +200,9 @@ Persistence.Remote == Data {
     }
 
     private func processFromCache<R>(_ payload: Remote,
-                                       resource: R,
-                                       cancelable: CancelableBag,
-                                       completion: @escaping NetworkStoreCompletionClosure<R.Local, E>)
+                                     resource: R,
+                                     cancelable: CancelableBag,
+                                     completion: @escaping NetworkStoreCompletionClosure<R.Local, E>)
     where R: NetworkResource & PersistableResource, R.Remote == Remote {
 
         do {
@@ -237,7 +237,6 @@ Persistence.Remote == Data {
             completion(.failure(.other(error)))
         }
     }
-
 
     // MARK: Fetch Methods
 

--- a/Sources/Stores/NetworkStore.swift
+++ b/Sources/Stores/NetworkStore.swift
@@ -2,12 +2,12 @@ import Foundation
 import Result
 
 public enum NetworkStoreValue<T> {
-    case network(T)
+    case network(T, URLResponse)
     case persistence(T)
 
     public var value: T {
         switch self {
-        case .network(let value): return value
+        case .network(let value, _): return value
         case .persistence(let value): return value
         }
     }
@@ -39,12 +39,12 @@ where Self: NetworkStack, Self.Remote == Remote, Self.Request == Request, Self.R
 
         let cancelable = CancelableBag()
 
-        cancelable += fetch(resource: resource) { (result: Result<R.Remote, Network.Error>) in
+        cancelable += fetch(resource: resource) { (result: Result<Network.Value<R.Remote>, Network.Error>) in
 
             switch result {
-            case .success(let remote):
+            case .success(let response):
                 do {
-                    completion(.success(.network(try resource.parse(remote))))
+                    completion(.success(.network(try resource.parse(response.value), response.response)))
                 } catch let error as Parse.Error {
                     completion(.failure(.parse(error)))
                 } catch {

--- a/Tests/AlicerceTests/Network/Mocks/MockNetworkStack.swift
+++ b/Tests/AlicerceTests/Network/Mocks/MockNetworkStack.swift
@@ -7,6 +7,7 @@ final class MockNetworkStack: NetworkStack {
     typealias Response = URLResponse
     typealias Remote = Data
 
+    var mockResponse: URLResponse = URLResponse()
     var mockData: Data?
     var mockError: Network.Error?
     var mockCancelable: MockCancelable = MockCancelable()
@@ -42,7 +43,7 @@ final class MockNetworkStack: NetworkStack {
             if let error = self.mockError {
                 completion(.failure(error))
             } else if let data = self.mockData {
-                completion(.success(data))
+                completion(.success(Network.Value.init(value: data, response: self.mockResponse)))
             } else {
                 fatalError("🔥: either `mockData` or `mockError` must be defined!")
             }

--- a/Tests/AlicerceTests/Network/Mocks/MockNetworkStack.swift
+++ b/Tests/AlicerceTests/Network/Mocks/MockNetworkStack.swift
@@ -43,7 +43,7 @@ final class MockNetworkStack: NetworkStack {
             if let error = self.mockError {
                 completion(.failure(error))
             } else if let data = self.mockData {
-                completion(.success(Network.Value.init(value: data, response: self.mockResponse)))
+                completion(.success(Network.Value(value: data, response: self.mockResponse)))
             } else {
                 fatalError("🔥: either `mockData` or `mockError` must be defined!")
             }

--- a/Tests/AlicerceTests/Network/URLSessionNetworkStackTestCase.swift
+++ b/Tests/AlicerceTests/Network/URLSessionNetworkStackTestCase.swift
@@ -749,7 +749,7 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
             switch result {
             case .success:
                 XCTFail("🔥 should throw an error 🤔")
-            case .failure(.authenticator(MockError.🔥, _)):
+            case .failure(.authenticator(MockError.🔥)):
                 // 🤠 well done sir
                 break
             case let .failure(error):

--- a/Tests/AlicerceTests/Network/URLSessionNetworkStackTestCase.swift
+++ b/Tests/AlicerceTests/Network/URLSessionNetworkStackTestCase.swift
@@ -554,8 +554,11 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
             switch result {
             case .success:
                 XCTFail("🔥 should throw an error 🤔")
+            case let .failure(.url(receivedError as NSError, receivedResponse)):
+                XCTAssertEqual(receivedError, mockError)
+                XCTAssertEqual(receivedResponse, mockResponse)
             case let .failure(error):
-                XCTAssertDumpsEqual(error, Network.Error.init(type: .url(mockError), response: mockResponse))
+                XCTFail("🔥 received unexpected error 👉 \(error) 😱")
             }
 
             expectation.fulfill()
@@ -573,10 +576,11 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
             switch result {
             case .success:
                 XCTFail("🔥 should throw an error 🤔")
+            case .failure(.badResponse):
+                // 🤠 well done sir
+                break
             case let .failure(error):
-                guard case .badResponse = error.type else {
-                    return XCTFail("🔥 received unexpected error 👉 \(error) 😱")
-                }
+                XCTFail("🔥 received unexpected error 👉 \(error) 😱")
             }
 
             expectation.fulfill()
@@ -605,11 +609,11 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
             switch result {
             case .success:
                 XCTFail("🔥 should throw an error 🤔")
+            case let .failure(.http(code: receiveStatusCode, apiError: nil, response: receivedResponse)):
+                XCTAssertEqual(receiveStatusCode.statusCode, statusCode)
+                XCTAssertEqual(receivedResponse, mockResponse)
             case let .failure(error):
-                let expectedError = Network.Error(type: .http(code: .serverError(statusCode), apiError: nil),
-                                                  response: mockResponse)
-
-                XCTAssertDumpsEqual(error, expectedError)
+                XCTFail("🔥 received unexpected error 👉 \(error) 😱")
             }
 
             expectation.fulfill()
@@ -639,11 +643,11 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
             switch result {
             case .success:
                 XCTFail("🔥 should throw an error 🤔")
+            case let .failure(.http(code: receiveStatusCode, apiError: APIError.💩?, response: receivedResponse)):
+                XCTAssertEqual(receiveStatusCode.statusCode, statusCode)
+                XCTAssertEqual(receivedResponse, mockResponse)
             case let .failure(error):
-                let expectedError = Network.Error(type: .http(code: .serverError(statusCode), apiError: APIError.💩),
-                                                  response: mockResponse)
-
-                XCTAssertDumpsEqual(error, expectedError)
+                XCTFail("🔥 received unexpected error 👉 \(error) 😱")
             }
 
             expectation.fulfill()
@@ -667,8 +671,10 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
             switch result {
             case .success:
                 XCTFail("🔥 should throw an error 🤔")
+            case let .failure(.noData(response)):
+                XCTAssertEqual(response, mockResponse)
             case let .failure(error):
-                XCTAssertDumpsEqual(error, Network.Error(type: .noData, response: mockResponse))
+                XCTFail("🔥 received unexpected error 👉 \(error) 😱")
             }
 
             expectation.fulfill()
@@ -743,8 +749,11 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
             switch result {
             case .success:
                 XCTFail("🔥 should throw an error 🤔")
+            case .failure(.authenticator(MockError.🔥, _)):
+                // 🤠 well done sir
+                break
             case let .failure(error):
-                XCTAssertDumpsEqual(error, Network.Error(type: .authenticator(MockError.🔥), response: nil))
+                XCTFail("🔥 received unexpected error 👉 \(error) 😱")
             }
 
             expectation.fulfill()
@@ -800,15 +809,15 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
             switch result {
             case .success:
                 XCTFail("🔥 should throw an error 🤔")
-            case let .failure(error):
-                guard
-                    case let .retry(errors, delay, .custom(MockNetworkAuthenticator.Error.🚫)) = error.type
-                else {
-                    return XCTFail("🔥 received unexpected error 👉 \(error) 😱")
-                }
-
+             case let .failure(.retry(errors,
+                                      delay,
+                                      ResourceRetry.Error.custom(MockNetworkAuthenticator.Error.🚫),
+                                      response)):
+                XCTAssertEqual(response, mockResponse)
                 XCTAssertDumpsEqual(errors, (0..<numRetries).map { _ in MockError.🔥 })
                 XCTAssertEqual(delay, baseRetryDelay * Double(numRetries-1))
+            case let .failure(error):
+                XCTFail("🔥 received unexpected error 👉 \(error) 😱")
             }
 
             expectation.fulfill()

--- a/Tests/AlicerceTests/Network/URLSessionNetworkStackTestCase.swift
+++ b/Tests/AlicerceTests/Network/URLSessionNetworkStackTestCase.swift
@@ -156,11 +156,12 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
         defer { waitForExpectations(timeout: expectationTimeout) }
 
         let baseURL = URL(string: "http://")!
+        let mockResponse = HTTPURLResponse(url: baseURL,
+                                           statusCode: 200,
+                                           httpVersion: nil,
+                                           headerFields: nil)!
 
-        mockSession.mockURLResponse = HTTPURLResponse(url: baseURL,
-                                                      statusCode: 200,
-                                                      httpVersion: nil,
-                                                      headerFields: nil)!
+        mockSession.mockURLResponse = mockResponse
 
         let mockData = "🎉".data(using: .utf8)
         mockSession.mockDataTaskData = mockData
@@ -170,8 +171,9 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
         networkStack.fetch(resource: resource) { result in
 
             switch result {
-            case let .success(data):
-                XCTAssertEqual(data, mockData)
+            case let .success(response):
+                XCTAssertEqual(response.value, mockData)
+                XCTAssertEqual(response.response, mockResponse)
             case let .failure(error):
                 XCTFail("🔥 received unexpected error 👉 \(error) 😱")
             }
@@ -251,10 +253,11 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
 
         let baseURL = URL(string: "http://")!
 
-        mockAuthenticatorSession.mockURLResponse = HTTPURLResponse(url: baseURL,
-                                                                   statusCode: 200,
-                                                                   httpVersion: nil,
-                                                                   headerFields: nil)!
+        let mockResponse = HTTPURLResponse(url: baseURL,
+                                           statusCode: 200,
+                                           httpVersion: nil,
+                                           headerFields: nil)!
+        mockAuthenticatorSession.mockURLResponse = mockResponse
 
         let mockData = "🎉".data(using: .utf8)
         mockAuthenticatorSession.mockDataTaskData = mockData
@@ -269,8 +272,9 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
         authenticatorNetworkStack.fetch(resource: resource) { result in
 
             switch result {
-            case let .success(data):
-                XCTAssertEqual(data, mockData)
+            case let .success(response):
+                XCTAssertEqual(response.value, mockData)
+                XCTAssertEqual(response.response, mockResponse)
             case let .failure(error):
                 XCTFail("🔥 received unexpected error 👉 \(error) 😱")
             }
@@ -334,8 +338,9 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
         authenticatorNetworkStack.fetch(resource: resource) { result in
 
             switch result {
-            case let .success(data):
-                XCTAssertEqual(data, mockData)
+            case let .success(response):
+                XCTAssertEqual(response.value, mockData)
+                XCTAssertEqual(response.response, mockResponse)
             case let .failure(error):
                 XCTFail("🔥 received unexpected error 👉 \(error) 😱")
             }
@@ -423,8 +428,9 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
         networkStack.fetch(resource: resource) { result in
 
             switch result {
-            case let .success(data):
-                XCTAssertEqual(data, mockData)
+            case let .success(response):
+                XCTAssertEqual(response.value, mockData)
+                XCTAssertEqual(response.response, mockResponse)
             case let .failure(error):
                 XCTFail("🔥 received unexpected error 👉 \(error) 😱")
             }
@@ -481,8 +487,9 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
         networkStack.fetch(resource: resource) { result in
 
             switch result {
-            case let .success(data):
-                XCTAssertEqual(data, mockData)
+            case let .success(response):
+                XCTAssertEqual(response.value, mockData)
+                XCTAssertEqual(response.response, mockResponse)
             case let .failure(error):
                 XCTFail("🔥 received unexpected error 👉 \(error) 😱")
             }
@@ -532,11 +539,12 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
         let baseURL = URL(string: "http://")!
         let statusCode = 500
         let mockError = NSError(domain: "☠️", code: statusCode, userInfo: nil)
+        let mockResponse = HTTPURLResponse(url: baseURL,
+                                           statusCode: statusCode,
+                                           httpVersion: nil,
+                                           headerFields: nil)!
 
-        mockSession.mockURLResponse = HTTPURLResponse(url: baseURL,
-                                                      statusCode: statusCode,
-                                                      httpVersion: nil,
-                                                      headerFields: nil)!
+        mockSession.mockURLResponse = mockResponse
         mockSession.mockDataTaskError = mockError
 
         let resource = buildResource(url: baseURL)
@@ -546,10 +554,8 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
             switch result {
             case .success:
                 XCTFail("🔥 should throw an error 🤔")
-            case let .failure(.url(receivedError as NSError)):
-                XCTAssertEqual(receivedError, mockError)
             case let .failure(error):
-                XCTFail("🔥 received unexpected error 👉 \(error) 😱")
+                XCTAssertDumpsEqual(error, Network.Error.init(type: .url(mockError), response: mockResponse))
             }
 
             expectation.fulfill()
@@ -567,11 +573,10 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
             switch result {
             case .success:
                 XCTFail("🔥 should throw an error 🤔")
-            case .failure(.badResponse):
-                // 🤠 well done sir
-                break
             case let .failure(error):
-                XCTFail("🔥 received unexpected error 👉 \(error) 😱")
+                guard case .badResponse = error.type else {
+                    return XCTFail("🔥 received unexpected error 👉 \(error) 😱")
+                }
             }
 
             expectation.fulfill()
@@ -584,14 +589,13 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
 
         let baseURL = URL(string: "http://")!
         let statusCode = 500
+        let mockResponse = HTTPURLResponse(url: baseURL,
+                                           statusCode: statusCode,
+                                           httpVersion: nil,
+                                           headerFields: nil)!
 
 
-
-        mockSession.mockURLResponse = HTTPURLResponse(url: baseURL,
-                                                      statusCode: statusCode,
-                                                      httpVersion: nil,
-                                                      headerFields: nil)!
-
+        mockSession.mockURLResponse = mockResponse
         mockSession.mockDataTaskData = nil
 
         let resource = buildResource(url: baseURL)
@@ -601,10 +605,11 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
             switch result {
             case .success:
                 XCTFail("🔥 should throw an error 🤔")
-            case let .failure(.http(code: receiveStatusCode, apiError: nil)):
-                XCTAssertEqual(receiveStatusCode.statusCode, statusCode)
             case let .failure(error):
-                XCTFail("🔥 received unexpected error 👉 \(error) 😱")
+                let expectedError = Network.Error(type: .http(code: .serverError(statusCode), apiError: nil),
+                                                  response: mockResponse)
+
+                XCTAssertDumpsEqual(error, expectedError)
             }
 
             expectation.fulfill()
@@ -617,11 +622,9 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
 
         let baseURL = URL(string: "http://")!
         let statusCode = 500
+        let mockResponse = HTTPURLResponse(url: baseURL, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
 
-        mockSession.mockURLResponse = HTTPURLResponse(url: baseURL,
-                                                      statusCode: statusCode,
-                                                      httpVersion: nil,
-                                                      headerFields: nil)!
+        mockSession.mockURLResponse = mockResponse
 
         let mockData = "💩".data(using: .utf8)!
         mockSession.mockDataTaskData = mockData
@@ -636,10 +639,11 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
             switch result {
             case .success:
                 XCTFail("🔥 should throw an error 🤔")
-            case let .failure(.http(code: receiveStatusCode, apiError: APIError.💩?)):
-                XCTAssertEqual(receiveStatusCode.statusCode, statusCode)
             case let .failure(error):
-                XCTFail("🔥 received unexpected error 👉 \(error) 😱")
+                let expectedError = Network.Error(type: .http(code: .serverError(statusCode), apiError: APIError.💩),
+                                                  response: mockResponse)
+
+                XCTAssertDumpsEqual(error, expectedError)
             }
 
             expectation.fulfill()
@@ -651,11 +655,9 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
         defer { waitForExpectations(timeout: expectationTimeout) }
 
         let baseURL = URL(string: "http://")!
+        let mockResponse = HTTPURLResponse(url: baseURL, statusCode: 200, httpVersion: nil, headerFields: nil)!
 
-        mockSession.mockURLResponse = HTTPURLResponse(url: baseURL,
-                                                      statusCode: 200,
-                                                      httpVersion: nil,
-                                                      headerFields: nil)!
+        mockSession.mockURLResponse = mockResponse
         mockSession.mockDataTaskData = nil
 
         let resource = buildResource(url: baseURL)
@@ -665,11 +667,8 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
             switch result {
             case .success:
                 XCTFail("🔥 should throw an error 🤔")
-            case .failure(.noData):
-                // 🤠 well done sir
-                break
             case let .failure(error):
-                XCTFail("🔥 received unexpected error 👉 \(error) 😱")
+                XCTAssertDumpsEqual(error, Network.Error(type: .noData, response: mockResponse))
             }
 
             expectation.fulfill()
@@ -744,11 +743,8 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
             switch result {
             case .success:
                 XCTFail("🔥 should throw an error 🤔")
-            case .failure(.authenticator(MockError.🔥)):
-                // 🤠 well done sir
-                break
             case let .failure(error):
-                XCTFail("🔥 received unexpected error 👉 \(error) 😱")
+                XCTAssertDumpsEqual(error, Network.Error(type: .authenticator(MockError.🔥), response: nil))
             }
 
             expectation.fulfill()
@@ -804,11 +800,15 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
             switch result {
             case .success:
                 XCTFail("🔥 should throw an error 🤔")
-            case let .failure(.retry(errors, delay, ResourceRetry.Error.custom(MockNetworkAuthenticator.Error.🚫))):
+            case let .failure(error):
+                guard
+                    case let .retry(errors, delay, .custom(MockNetworkAuthenticator.Error.🚫)) = error.type
+                else {
+                    return XCTFail("🔥 received unexpected error 👉 \(error) 😱")
+                }
+
                 XCTAssertDumpsEqual(errors, (0..<numRetries).map { _ in MockError.🔥 })
                 XCTAssertEqual(delay, baseRetryDelay * Double(numRetries-1))
-            case let .failure(error):
-                XCTFail("🔥 received unexpected error 👉 \(error) 😱")
             }
 
             expectation.fulfill()

--- a/Tests/AlicerceTests/Stores/NetworkPersistableStoreTestCase.swift
+++ b/Tests/AlicerceTests/Stores/NetworkPersistableStoreTestCase.swift
@@ -102,7 +102,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
-        networkStack.mockError = .noData
+        networkStack.mockError = Network.Error(type: .noData, response: nil)
         persistenceStack.mockObjectResult = .success(nil)
         let resource = testResourcePersistenceThenNetwork // Parser is OK
         // When
@@ -114,9 +114,11 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                 return XCTFail("🔥: unexpected success!")
             }
 
-            guard case .network(Network.Error.noData) = error else {
+            guard case let .network(networkError) = error else {
                 return XCTFail("🔥: unexpected error \(error)!")
             }
+
+            XCTAssertDumpsEqual(networkError, Network.Error(type: .noData, response: nil))
         }
 
         networkStack.runMockFetch()
@@ -132,7 +134,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
-        networkStack.mockError = .noData
+        networkStack.mockError = Network.Error(type: .noData, response: nil)
         persistenceStack.mockObjectResult = .success(nil)
         let resource = testResourceNetworkThenPersistence // Parser is OK
 
@@ -145,9 +147,11 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                 return XCTFail("🔥: unexpected success!")
             }
 
-            guard case .network(Network.Error.noData) = error else {
+            guard case let .network(networkError) = error else {
                 return XCTFail("🔥: unexpected error \(error)!")
             }
+
+            XCTAssertDumpsEqual(networkError, Network.Error(type: .noData, response: nil))
         }
 
         networkStack.runMockFetch()
@@ -276,7 +280,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
-        networkStack.mockError = .noData
+        networkStack.mockError = Network.Error(type: .noData, response: nil)
         persistenceStack.mockObjectResult = .failure(.💥)
         let resource = testResourceNetworkThenPersistence
 
@@ -293,7 +297,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                 return XCTFail("🔥: unexpected error \(error)!")
             }
 
-            XCTAssertDumpsEqual(errors, [Network.Error.noData, MockPersistenceStack.Error.💥])
+            XCTAssertDumpsEqual(errors, [Network.Error(type: .noData, response: nil), MockPersistenceStack.Error.💥])
         }
 
         networkStack.runMockFetch()
@@ -309,7 +313,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
-        networkStack.mockError = .noData
+        networkStack.mockError = Network.Error(type: .noData, response: nil)
         persistenceStack.mockObjectResult = .failure(.💥)
         let resource = testResourcePersistenceThenNetwork
 
@@ -326,7 +330,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                 return XCTFail("🔥: unexpected error \(error)!")
             }
 
-            XCTAssertDumpsEqual(errors, [MockPersistenceStack.Error.💥, Network.Error.noData])
+            XCTAssertDumpsEqual(errors, [MockPersistenceStack.Error.💥, Network.Error(type: .noData, response: nil)])
         }
 
         networkStack.runMockFetch()
@@ -343,7 +347,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
 
         // Given
         let cancelable = CancelableBag()
-        networkStack.mockError = .url(URLError(.cancelled))
+        networkStack.mockError = Network.Error(type: .url(URLError(.cancelled)), response: nil)
         networkStack.beforeFetchCompletionClosure = {
             cancelable.cancel()
         }
@@ -359,9 +363,11 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                 return XCTFail("🔥: unexpected success!")
             }
 
-            guard case .cancelled(Network.Error.url(URLError.cancelled)?) = error else {
+            guard case let .cancelled(networkError) = error else {
                 return XCTFail("🔥: unexpected error \(error)!")
             }
+
+            XCTAssertDumpsEqual(networkError, Network.Error(type: .url(URLError(.cancelled)), response: nil))
         }
 
         networkStack.runMockFetch()
@@ -378,7 +384,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
 
         // Given
         let cancelable = CancelableBag()
-        networkStack.mockError = .badResponse
+        networkStack.mockError = Network.Error(type: .badResponse, response: nil)
         networkStack.beforeFetchCompletionClosure = {
             cancelable.cancel()
         }
@@ -394,9 +400,11 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                 return XCTFail("🔥: unexpected success!")
             }
 
-            guard case .cancelled(Network.Error.badResponse?) = error else {
+            guard case let .cancelled(networkError) = error else {
                 return XCTFail("🔥: unexpected error \(error)!")
             }
+
+            XCTAssertDumpsEqual(networkError, Network.Error(type: .badResponse, response: nil))
         }
 
         networkStack.runMockFetch()
@@ -495,7 +503,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
-        networkStack.mockError = .noData
+        networkStack.mockError = Network.Error(type: .noData, response: nil)
         networkStack.mockCancelable.mockCancelClosure = {
             cancelExpectation.fulfill()
         }
@@ -510,9 +518,11 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                 return XCTFail("🔥: unexpected success!")
             }
 
-            guard case .cancelled(Network.Error.noData?) = error else {
+            guard case let .cancelled(networkError) = error else {
                 return XCTFail("🔥: unexpected error \(error)!")
             }
+
+            XCTAssertDumpsEqual(networkError, Network.Error(type: .noData, response: nil))
         }
 
         // trigger the cancel before the fetch completion closure is invoked
@@ -731,7 +741,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
-        networkStack.mockError = .noData
+        networkStack.mockError = Network.Error(type: .noData, response: nil)
         persistenceStack.mockObjectResult = .success(testDataPersistence)
         let resource = testResourceNetworkThenPersistence
 

--- a/Tests/AlicerceTests/Stores/NetworkPersistableStoreTestCase.swift
+++ b/Tests/AlicerceTests/Stores/NetworkPersistableStoreTestCase.swift
@@ -102,7 +102,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
-        networkStack.mockError = Network.Error(type: .noData, response: nil)
+        networkStack.mockError = .noData(response: nil)
         persistenceStack.mockObjectResult = .success(nil)
         let resource = testResourcePersistenceThenNetwork // Parser is OK
         // When
@@ -114,11 +114,9 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                 return XCTFail("🔥: unexpected success!")
             }
 
-            guard case let .network(networkError) = error else {
+            guard case .network(.noData(response: nil)) = error else {
                 return XCTFail("🔥: unexpected error \(error)!")
             }
-
-            XCTAssertDumpsEqual(networkError, Network.Error(type: .noData, response: nil))
         }
 
         networkStack.runMockFetch()
@@ -134,7 +132,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
-        networkStack.mockError = Network.Error(type: .noData, response: nil)
+        networkStack.mockError = .noData(response: nil)
         persistenceStack.mockObjectResult = .success(nil)
         let resource = testResourceNetworkThenPersistence // Parser is OK
 
@@ -147,11 +145,9 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                 return XCTFail("🔥: unexpected success!")
             }
 
-            guard case let .network(networkError) = error else {
+            guard case .network(.noData(response: nil)) = error else {
                 return XCTFail("🔥: unexpected error \(error)!")
             }
-
-            XCTAssertDumpsEqual(networkError, Network.Error(type: .noData, response: nil))
         }
 
         networkStack.runMockFetch()
@@ -280,7 +276,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
-        networkStack.mockError = Network.Error(type: .noData, response: nil)
+        networkStack.mockError = .noData(response: nil)
         persistenceStack.mockObjectResult = .failure(.💥)
         let resource = testResourceNetworkThenPersistence
 
@@ -297,7 +293,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                 return XCTFail("🔥: unexpected error \(error)!")
             }
 
-            XCTAssertDumpsEqual(errors, [Network.Error(type: .noData, response: nil), MockPersistenceStack.Error.💥])
+            XCTAssertDumpsEqual(errors, [Network.Error.noData(response: nil), MockPersistenceStack.Error.💥])
         }
 
         networkStack.runMockFetch()
@@ -313,7 +309,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
-        networkStack.mockError = Network.Error(type: .noData, response: nil)
+        networkStack.mockError = .noData(response: nil)
         persistenceStack.mockObjectResult = .failure(.💥)
         let resource = testResourcePersistenceThenNetwork
 
@@ -330,7 +326,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                 return XCTFail("🔥: unexpected error \(error)!")
             }
 
-            XCTAssertDumpsEqual(errors, [MockPersistenceStack.Error.💥, Network.Error(type: .noData, response: nil)])
+            XCTAssertDumpsEqual(errors, [MockPersistenceStack.Error.💥, Network.Error.noData(response: nil)])
         }
 
         networkStack.runMockFetch()
@@ -347,7 +343,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
 
         // Given
         let cancelable = CancelableBag()
-        networkStack.mockError = Network.Error(type: .url(URLError(.cancelled)), response: nil)
+        networkStack.mockError = .url(URLError(.cancelled), response: nil)
         networkStack.beforeFetchCompletionClosure = {
             cancelable.cancel()
         }
@@ -363,11 +359,9 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                 return XCTFail("🔥: unexpected success!")
             }
 
-            guard case let .cancelled(networkError) = error else {
+            guard case .cancelled(Network.Error.url(URLError.cancelled, response: nil)?) = error else {
                 return XCTFail("🔥: unexpected error \(error)!")
             }
-
-            XCTAssertDumpsEqual(networkError, Network.Error(type: .url(URLError(.cancelled)), response: nil))
         }
 
         networkStack.runMockFetch()
@@ -384,7 +378,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
 
         // Given
         let cancelable = CancelableBag()
-        networkStack.mockError = Network.Error(type: .badResponse, response: nil)
+        networkStack.mockError = .badResponse(response: nil)
         networkStack.beforeFetchCompletionClosure = {
             cancelable.cancel()
         }
@@ -400,11 +394,9 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                 return XCTFail("🔥: unexpected success!")
             }
 
-            guard case let .cancelled(networkError) = error else {
+            guard case .cancelled(Network.Error.badResponse(nil)?) = error else {
                 return XCTFail("🔥: unexpected error \(error)!")
             }
-
-            XCTAssertDumpsEqual(networkError, Network.Error(type: .badResponse, response: nil))
         }
 
         networkStack.runMockFetch()
@@ -503,7 +495,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
-        networkStack.mockError = Network.Error(type: .noData, response: nil)
+        networkStack.mockError = .noData(response: nil)
         networkStack.mockCancelable.mockCancelClosure = {
             cancelExpectation.fulfill()
         }
@@ -518,11 +510,9 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                 return XCTFail("🔥: unexpected success!")
             }
 
-            guard case let .cancelled(networkError) = error else {
+            guard case .cancelled(Network.Error.noData(nil)?) = error else {
                 return XCTFail("🔥: unexpected error \(error)!")
             }
-
-            XCTAssertDumpsEqual(networkError, Network.Error(type: .noData, response: nil))
         }
 
         // trigger the cancel before the fetch completion closure is invoked
@@ -741,7 +731,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
-        networkStack.mockError = Network.Error(type: .noData, response: nil)
+        networkStack.mockError = .noData(response: nil)
         persistenceStack.mockObjectResult = .success(testDataPersistence)
         let resource = testResourceNetworkThenPersistence
 

--- a/Tests/AlicerceTests/Stores/NetworkPersistableStoreTestCase.swift
+++ b/Tests/AlicerceTests/Stores/NetworkPersistableStoreTestCase.swift
@@ -102,7 +102,13 @@ class NetworkPersistableStoreTestCase: XCTestCase {
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
-        networkStack.mockError = .noData(response: nil)
+        let baseURL = URL(string: "http://")!
+        let mockResponse = HTTPURLResponse(url: baseURL,
+                                           statusCode: 200,
+                                           httpVersion: nil,
+                                           headerFields: nil)!
+
+        networkStack.mockError = .noData(response: mockResponse)
         persistenceStack.mockObjectResult = .success(nil)
         let resource = testResourcePersistenceThenNetwork // Parser is OK
         // When
@@ -114,7 +120,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                 return XCTFail("🔥: unexpected success!")
             }
 
-            guard case .network(.noData(response: nil)) = error else {
+            guard case .network(.noData(response: mockResponse)) = error else {
                 return XCTFail("🔥: unexpected error \(error)!")
             }
         }
@@ -132,7 +138,13 @@ class NetworkPersistableStoreTestCase: XCTestCase {
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
-        networkStack.mockError = .noData(response: nil)
+        let baseURL = URL(string: "http://")!
+        let mockResponse = HTTPURLResponse(url: baseURL,
+                                           statusCode: 200,
+                                           httpVersion: nil,
+                                           headerFields: nil)!
+
+        networkStack.mockError = .noData(response: mockResponse)
         persistenceStack.mockObjectResult = .success(nil)
         let resource = testResourceNetworkThenPersistence // Parser is OK
 
@@ -145,7 +157,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                 return XCTFail("🔥: unexpected success!")
             }
 
-            guard case .network(.noData(response: nil)) = error else {
+            guard case .network(.noData(response: mockResponse)) = error else {
                 return XCTFail("🔥: unexpected error \(error)!")
             }
         }
@@ -276,7 +288,13 @@ class NetworkPersistableStoreTestCase: XCTestCase {
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
-        networkStack.mockError = .noData(response: nil)
+        let baseURL = URL(string: "http://")!
+        let mockResponse = HTTPURLResponse(url: baseURL,
+                                           statusCode: 200,
+                                           httpVersion: nil,
+                                           headerFields: nil)!
+
+        networkStack.mockError = .noData(response: mockResponse)
         persistenceStack.mockObjectResult = .failure(.💥)
         let resource = testResourceNetworkThenPersistence
 
@@ -293,7 +311,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                 return XCTFail("🔥: unexpected error \(error)!")
             }
 
-            XCTAssertDumpsEqual(errors, [Network.Error.noData(response: nil), MockPersistenceStack.Error.💥])
+            XCTAssertDumpsEqual(errors, [Network.Error.noData(response: mockResponse), MockPersistenceStack.Error.💥])
         }
 
         networkStack.runMockFetch()
@@ -309,7 +327,13 @@ class NetworkPersistableStoreTestCase: XCTestCase {
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
-        networkStack.mockError = .noData(response: nil)
+        let baseURL = URL(string: "http://")!
+        let mockResponse = HTTPURLResponse(url: baseURL,
+                                           statusCode: 200,
+                                           httpVersion: nil,
+                                           headerFields: nil)!
+
+        networkStack.mockError = .noData(response: mockResponse)
         persistenceStack.mockObjectResult = .failure(.💥)
         let resource = testResourcePersistenceThenNetwork
 
@@ -326,7 +350,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                 return XCTFail("🔥: unexpected error \(error)!")
             }
 
-            XCTAssertDumpsEqual(errors, [MockPersistenceStack.Error.💥, Network.Error.noData(response: nil)])
+            XCTAssertDumpsEqual(errors, [MockPersistenceStack.Error.💥, Network.Error.noData(response: mockResponse)])
         }
 
         networkStack.runMockFetch()
@@ -495,7 +519,13 @@ class NetworkPersistableStoreTestCase: XCTestCase {
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
-        networkStack.mockError = .noData(response: nil)
+        let baseURL = URL(string: "http://")!
+        let mockResponse = HTTPURLResponse(url: baseURL,
+                                           statusCode: 200,
+                                           httpVersion: nil,
+                                           headerFields: nil)!
+
+        networkStack.mockError = .noData(response: mockResponse)
         networkStack.mockCancelable.mockCancelClosure = {
             cancelExpectation.fulfill()
         }
@@ -510,7 +540,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                 return XCTFail("🔥: unexpected success!")
             }
 
-            guard case .cancelled(Network.Error.noData(nil)?) = error else {
+            guard case .cancelled(Network.Error.noData(mockResponse)?) = error else {
                 return XCTFail("🔥: unexpected error \(error)!")
             }
         }
@@ -731,7 +761,13 @@ class NetworkPersistableStoreTestCase: XCTestCase {
         defer { waitForExpectations(timeout: expectationTimeout, handler: expectationHandler) }
 
         // Given
-        networkStack.mockError = .noData(response: nil)
+        let baseURL = URL(string: "http://")!
+        let mockResponse = HTTPURLResponse(url: baseURL,
+                                           statusCode: 200,
+                                           httpVersion: nil,
+                                           headerFields: nil)!
+
+        networkStack.mockError = .noData(response: mockResponse)
         persistenceStack.mockObjectResult = .success(testDataPersistence)
         let resource = testResourceNetworkThenPersistence
 

--- a/Tests/AlicerceTests/Stores/NetworkStoreTestCase.swift
+++ b/Tests/AlicerceTests/Stores/NetworkStoreTestCase.swift
@@ -70,7 +70,7 @@ class NetworkStoreTestCase: XCTestCase {
         networkStack.fetch(resource: testResource) { (result: NetworkStoreResult) in
 
             switch result {
-            case .success(.network(let value)):
+            case .success(.network(let value, _)):
                 XCTAssertEqual(value, mockValue)
             case .success(let value):
                 XCTFail("🔥 received unexpected success 👉 \(value) 😱")
@@ -93,15 +93,15 @@ class NetworkStoreTestCase: XCTestCase {
         let statusCode = 500
         let mockError = NSError(domain: "☠️", code: statusCode, userInfo: nil)
 
-        networkStack.mockError = .url(mockError)
+        networkStack.mockError = Network.Error(type: .url(mockError), response: nil)
 
         networkStack.fetch(resource: testResource) { (result: NetworkStoreResult) in
 
             switch result {
             case .success:
                 XCTFail("🔥 should throw an error 🤔")
-            case let .failure(.network(.url(receivedError as NSError))):
-                XCTAssertEqual(receivedError, mockError)
+            case let .failure(.network(networkError)):
+                XCTAssertDumpsEqual(networkError, Network.Error(type: .url(mockError), response: nil))
             case let .failure(error):
                 XCTFail("🔥 received unexpected error 👉 \(error) 😱")
             }
@@ -150,7 +150,7 @@ class NetworkStoreTestCase: XCTestCase {
 
         let cancelable = CancelableBag()
 
-        networkStack.mockError = .url(MockOtherError.💥)
+        networkStack.mockError = Network.Error(type: .url(MockOtherError.💥), response: nil)
         networkStack.beforeFetchCompletionClosure = {
             cancelable.cancel()
         }
@@ -160,8 +160,8 @@ class NetworkStoreTestCase: XCTestCase {
             switch result {
             case .success:
                 XCTFail("🔥 should throw an error 🤔")
-            case .failure(.cancelled(Network.Error.url(MockOtherError.💥)?)):
-                break // expected error
+            case let .failure(.cancelled(networkError)):
+                XCTAssertDumpsEqual(networkError, Network.Error(type: .url(MockOtherError.💥), response: nil))
             case let .failure(error):
                 XCTFail("🔥 received unexpected error 👉 \(error) 😱")
             }

--- a/Tests/AlicerceTests/Stores/NetworkStoreTestCase.swift
+++ b/Tests/AlicerceTests/Stores/NetworkStoreTestCase.swift
@@ -67,11 +67,16 @@ class NetworkStoreTestCase: XCTestCase {
         let mockValue = "🎉"
         networkStack.mockData = mockValue.data(using: .utf8)
 
+        let baseURL = URL(string: "http://")!
+        let mockResponse = HTTPURLResponse(url: baseURL, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        networkStack.mockResponse = mockResponse
+
         networkStack.fetch(resource: testResource) { (result: NetworkStoreResult) in
 
             switch result {
-            case .success(.network(let value, _)):
+            case .success(.network(let value, let response)):
                 XCTAssertEqual(value, mockValue)
+                XCTAssertEqual(response, mockResponse)
             case .success(let value):
                 XCTFail("🔥 received unexpected success 👉 \(value) 😱")
             case let .failure(error):
@@ -93,15 +98,15 @@ class NetworkStoreTestCase: XCTestCase {
         let statusCode = 500
         let mockError = NSError(domain: "☠️", code: statusCode, userInfo: nil)
 
-        networkStack.mockError = Network.Error(type: .url(mockError), response: nil)
+        networkStack.mockError = .url(mockError, response: nil)
 
         networkStack.fetch(resource: testResource) { (result: NetworkStoreResult) in
 
             switch result {
             case .success:
                 XCTFail("🔥 should throw an error 🤔")
-            case let .failure(.network(networkError)):
-                XCTAssertDumpsEqual(networkError, Network.Error(type: .url(mockError), response: nil))
+            case let .failure(.network(.url(receivedError as NSError, nil))):
+                XCTAssertEqual(receivedError, mockError)
             case let .failure(error):
                 XCTFail("🔥 received unexpected error 👉 \(error) 😱")
             }
@@ -150,7 +155,7 @@ class NetworkStoreTestCase: XCTestCase {
 
         let cancelable = CancelableBag()
 
-        networkStack.mockError = Network.Error(type: .url(MockOtherError.💥), response: nil)
+        networkStack.mockError = .url(MockOtherError.💥, response: nil)
         networkStack.beforeFetchCompletionClosure = {
             cancelable.cancel()
         }
@@ -160,8 +165,8 @@ class NetworkStoreTestCase: XCTestCase {
             switch result {
             case .success:
                 XCTFail("🔥 should throw an error 🤔")
-            case let .failure(.cancelled(networkError)):
-                XCTAssertDumpsEqual(networkError, Network.Error(type: .url(MockOtherError.💥), response: nil))
+            case .failure(.cancelled(Network.Error.url(MockOtherError.💥, nil)?)):
+                 break // expected error
             case let .failure(error):
                 XCTFail("🔥 received unexpected error 👉 \(error) 😱")
             }


### PR DESCRIPTION
Sometimes the URLResponse brings valuable information (in the headers, as an example) for the application.
As such, it's good to be able to access them when performing network operations 🙂