### PR TITLE
Keyboard Observer - Ignore custom controls

### DIFF
--- a/Sources/Observers/KeyboardObserver.swift
+++ b/Sources/Observers/KeyboardObserver.swift
@@ -15,11 +15,15 @@ public final class KeyboardObserver: NSObject {
 
     /// List of view subclasses that should be ignored by the gesture recognizer. Touches on these views won't get
     /// the keyboard resigned. Default is `[UIControl.self]`.
-    public var ignoredViews: [UIView.Type] = [UIControl.self]
+    public var ignoredViews: [UIView.Type]
 
-    public init(window: UIWindow, shouldTapCancelTouches: Bool = false) {
+    public init(window: UIWindow,
+                shouldTapCancelTouches: Bool = false,
+                ignoredViews: [UIView.Type] = [UIControl.self]) {
+
         self.window = window
         self.shouldTapCancelTouches = shouldTapCancelTouches
+        self.ignoredViews = ignoredViews
 
         super.init()
 
@@ -70,12 +74,6 @@ extension KeyboardObserver: UIGestureRecognizerDelegate {
 
         guard isKeyboardVisible, let view = touch.view else { return false }
 
-        for cls in ignoredViews {
-            if view.isKind(of: cls) {
-                return false
-            }
-        }
-
-        return true
+        return ignoredViews.contains(where: view.isKind) == false
     }
 }

--- a/Sources/Observers/KeyboardObserver.swift
+++ b/Sources/Observers/KeyboardObserver.swift
@@ -13,6 +13,10 @@ public final class KeyboardObserver: NSObject {
         }
     }
 
+    /// List of view subclasses that should be ignored by the gesture recognizer. Touches on these views won't get
+    /// the keyboard resigned. Default is `[UIControl.self]`.
+    public var ignoredViews: [UIView.Type] = [UIControl.self]
+
     public init(window: UIWindow, shouldTapCancelTouches: Bool = false) {
         self.window = window
         self.shouldTapCancelTouches = shouldTapCancelTouches
@@ -61,7 +65,17 @@ public final class KeyboardObserver: NSObject {
 }
 
 extension KeyboardObserver: UIGestureRecognizerDelegate {
-    public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-        return isKeyboardVisible
+
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
+
+        guard isKeyboardVisible, let view = touch.view else { return false }
+
+        for cls in ignoredViews {
+            if view.isKind(of: cls) {
+                return false
+            }
+        }
+
+        return true
     }
 }


### PR DESCRIPTION
Add list of views whose touches should be ignored by the gesture recognizer in the keyboard observer. 

The keyboard observer hides the keyboard when tapping on a `UIButton` (and the button receives the touch as well). However, a custom `UIControl` don't get the touch because the recognizer doesn't forward the touch at all. This pull request allows one to specify a list of custom subclasses of `UIView` to be ignored by the observer.