### PR TITLE
Avoid over-release bug when nesting errors

### DIFF
--- a/Sources/Resource/AuthenticatedHTTPNetworkResource.swift
+++ b/Sources/Resource/AuthenticatedHTTPNetworkResource.swift
@@ -16,6 +16,6 @@ extension AuthenticatedHTTPNetworkResource {
     @discardableResult
     public func makeRequest(_ handler: @escaping MakeRequestHandler) -> Cancelable {
 
-        return authenticator.authenticate(endpoint.request) { handler($0.mapError(AnyError.init)) }
+        return authenticator.authenticate(endpoint.request) { handler($0.mapError { AnyError($0) }) }
     }
 }

--- a/Sources/Stores/NetworkPersistableStore.swift
+++ b/Sources/Stores/NetworkPersistableStore.swift
@@ -47,7 +47,7 @@ Persistence.Remote == Data {
     }
 
     public func clearPersistence(completion: @escaping (Result<Void, E>) -> Void) {
-        persistenceStack.removeAll(completion: { completion($0.mapError(E.persistence)) })
+        persistenceStack.removeAll(completion: { completion($0.mapError { E.persistence($0) }) })
     }
 
     // MARK: - Private Methods


### PR DESCRIPTION
When passing an enum's case or init as a closure to another function receiving a T (e.g. to wrap a `T` and create a new instance), if the type `T` is an `associatedtype` on a protocol (specialized in the generic of the function's parent type), an over-release is made, causing a `EXC_BAD_ACCESS` runtime crash.

This is most likely the bug https://bugs.swift.org/browse/SR-9176.

On our particular case, since the `RequestAuthenticator` now has an `associatedtype Error`, it started manifesting this issue on `AuthenticatedHTTPNetworkResource`'s protocol extension `makeRequest()` implementation, as the `$0.mapError(AnyError.init)` operates over the authenticator's generic `Error` type (i.e. `$0` is a `Result<Request, Error>`).

As mentioned on the bug report, using an explicit closure (i.e. not passing in the enum's case or a method) avoids the issue.