### PR TITLE
Add more missing tests, minor improvements 🕵️‍♂️

### DIFF
--- a/Alicerce.xcodeproj/project.pbxproj
+++ b/Alicerce.xcodeproj/project.pbxproj
@@ -150,6 +150,7 @@
 		0A3C2DBE1EA7E5DD00EFB7D4 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3C2CC21EA7E18500EFB7D4 /* Box.swift */; };
 		0A3C2DC01EA7E5DD00EFB7D4 /* Placeholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3C2CC41EA7E18500EFB7D4 /* Placeholder.swift */; };
 		0A3C2DC11EA7E5DD00EFB7D4 /* ServiceLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3C2CC51EA7E18500EFB7D4 /* ServiceLocator.swift */; };
+		0A3CC4942221FEB1006C7FB4 /* SerializeTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3CC4932221FEB1006C7FB4 /* SerializeTestCase.swift */; };
 		0A50DDD521555D2C00C15A0A /* NetworkStoreTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A50DDD421555D2C00C15A0A /* NetworkStoreTestCase.swift */; };
 		0A5836E820CF41C10090E987 /* Log+Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A5836E620CF41890090E987 /* Log+Item.swift */; };
 		0A708F5420E932EB001784DA /* ModuleLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A708F5320E932EB001784DA /* ModuleLogger.swift */; };
@@ -436,6 +437,7 @@
 		0A3C2D681EA7E34C00EFB7D4 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		0A3C2D6A1EA7E35200EFB7D4 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		0A3C2D711EA7E3E800EFB7D4 /* Alicerce.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Alicerce.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0A3CC4932221FEB1006C7FB4 /* SerializeTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SerializeTestCase.swift; sourceTree = "<group>"; };
 		0A50DDD421555D2C00C15A0A /* NetworkStoreTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkStoreTestCase.swift; sourceTree = "<group>"; };
 		0A5836E620CF41890090E987 /* Log+Item.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Log+Item.swift"; sourceTree = "<group>"; };
 		0A5CBC0420B31D7100A1447A /* AmazonRootCA3.cer */ = {isa = PBXFileReference; lastKnownFileType = file; path = AmazonRootCA3.cer; sourceTree = "<group>"; };
@@ -901,6 +903,7 @@
 				0A3C2D221EA7E1EE00EFB7D4 /* NetworkTestCase.swift */,
 				0A3C2D231EA7E1EE00EFB7D4 /* ParseTestCase.swift */,
 				0A85F0E320B314E10095AFFB /* Pinning */,
+				0A3CC4932221FEB1006C7FB4 /* SerializeTestCase.swift */,
 				0A3C2D241EA7E1EE00EFB7D4 /* URLSessionNetworkStackTestCase.swift */,
 			);
 			path = Network;
@@ -1701,6 +1704,7 @@
 				F19A442D20384DD400AD6448 /* UIViewConstraintTestCase.swift in Sources */,
 				0A266F9E1ED59FB6009CD0D7 /* DefaultLoggerTestCase.swift in Sources */,
 				0A266FA01ED59FB6009CD0D7 /* StringLogItemFormatterTestCase.swift in Sources */,
+				0A3CC4942221FEB1006C7FB4 /* SerializeTestCase.swift in Sources */,
 				0A02BDDD220D08BA00CF14C9 /* HTTPResourceEndpointTestCase.swift in Sources */,
 				0A266FA11ED59FB6009CD0D7 /* JSONTests.swift in Sources */,
 				0A9AF8C21FC33B070076458E /* ReusableViewCollectionViewTestCase.swift in Sources */,

--- a/Sources/Network/Network.swift
+++ b/Sources/Network/Network.swift
@@ -16,6 +16,7 @@ public enum Network {
         public let response: URLResponse
 
         public init(value: R, response: URLResponse) {
+
             self.value = value
             self.response = response
         }
@@ -25,15 +26,15 @@ public enum Network {
 
     public enum Error: Swift.Error {
 
+        public typealias APIError = Swift.Error
+        public typealias TotalRetriedDelay = ResourceRetry.Delay
+
         case noRequest(Swift.Error)
-        case http(code: HTTP.StatusCode, apiError: Swift.Error?, response: URLResponse)
-        case noData(response: URLResponse)
-        case url(Swift.Error, response: URLResponse?)
-        case badResponse(response: URLResponse?)
-        case retry(errors: [Swift.Error],
-                   totalDelay: ResourceRetry.Delay,
-                   retryError: ResourceRetry.Error,
-                   response: URLResponse?)
+        case http(HTTP.StatusCode, APIError?, URLResponse)
+        case noData(URLResponse)
+        case url(Swift.Error, URLResponse?)
+        case badResponse(URLResponse?)
+        case retry([Swift.Error], TotalRetriedDelay, ResourceRetry.Error, URLResponse?)
     }
 
     // MARK: - Network Configuration
@@ -58,7 +59,9 @@ public enum Network {
 }
 
 extension Network.Error {
+
     var response: URLResponse? {
+
         switch self {
         case .noRequest:
             return nil

--- a/Sources/Network/Pinning/PublicKeyAlgorithm.swift
+++ b/Sources/Network/Pinning/PublicKeyAlgorithm.swift
@@ -1,17 +1,11 @@
 import Security
 
-public enum PublicKeyAlgorithm {
+public enum PublicKeyAlgorithm: CaseIterable {
     case rsa2048
     case rsa4096
     case ecDsaSecp256r1
     case ecDsaSecp384r1
     case ecDsaSecp521r1
-
-    public static let allCases: [PublicKeyAlgorithm] = [.rsa2048,
-                                                        .rsa4096,
-                                                        .ecDsaSecp384r1,
-                                                        .ecDsaSecp384r1,
-                                                        .ecDsaSecp521r1]
 
     public var asn1HeaderData: Data {
         switch self {

--- a/Sources/Network/Pinning/ServerTrustEvaluator.swift
+++ b/Sources/Network/Pinning/ServerTrustEvaluator.swift
@@ -129,13 +129,13 @@ public final class ServerTrustEvaluator {
                     keychainLock.unlock()
 
                     let isPublicKeyHashPinned: (PublicKeyAlgorithm) -> Bool = {
-                        guard pinnedHashes.contains(publicKeyData.spkiHash(for: $0)) else { return false }
-
-                        // TODO: perhaps add some `spkiHash` caching?
-                        return true
+                        pinnedHashes.contains(publicKeyData.spkiHash(for: $0))
                     }
 
-                    if let _ = PublicKeyAlgorithm.allCases.first(where: isPublicKeyHashPinned) { return }
+                    guard PublicKeyAlgorithm.allCases.contains(where: isPublicKeyHashPinned) else { continue }
+
+                    // TODO: perhaps add some `spkiHash` caching?
+                    return
                 }
             } catch let error as SecCertificate.PublicKeyExtractionError {
                 throw PublicKeyPinVerificationError.extractPublicKey(error)

--- a/Sources/Network/Serialize.swift
+++ b/Sources/Network/Serialize.swift
@@ -4,6 +4,7 @@ public enum Serialize {
 
     enum Error: Swift.Error {
         case json(Swift.Error)
+        case invalidJSON(Any)
         case invalidImage(UIImage)
     }
 
@@ -17,6 +18,10 @@ public enum Serialize {
     public static func json<T: Mappable>(object: T) throws -> Data {
 
         let json = object.json()
+
+        guard JSONSerialization.isValidJSONObject(json) else {
+            throw Error.invalidJSON(json)
+        }
 
         do {
             return try JSONSerialization.data(withJSONObject: json, options: [])
@@ -33,6 +38,7 @@ public enum Serialize {
     /// A Serialize.Error that can be of type:
     ///   - `invalidImage` if the image isn't a PNG
     public static func imageAsPNGData(_ image: UIImage) throws-> Data {
+
         guard let imageData = image.pngData() else {
             throw Error.invalidImage(image)
         }

--- a/Sources/Persistence/CoreData/NSPersistentStoreCoordinator+CoreDataStack.swift
+++ b/Sources/Persistence/CoreData/NSPersistentStoreCoordinator+CoreDataStack.swift
@@ -3,7 +3,7 @@ import CoreData
 public extension NSPersistentStoreCoordinator {
 
     var firstStoreType: CoreDataStackStoreType {
-        
+
         guard let firstStore = persistentStores.first else {
             fatalError("💥: Persistent Store Coordinator must have at least one store!")
         }

--- a/Tests/AlicerceTests/Network/NetworkTestCase.swift
+++ b/Tests/AlicerceTests/Network/NetworkTestCase.swift
@@ -4,6 +4,8 @@ import XCTest
 
 final class NetworkTestCase: XCTestCase {
 
+    // MARK: Configuration
+
     func testConfiguration_WhenCreateWithFullInit_ItShouldPopulateAllTheValues() {
 
         let networkConfiguration = Network.Configuration(retryQueue: DispatchQueue(label: "configuration-retry-queue"))
@@ -28,6 +30,45 @@ final class NetworkTestCase: XCTestCase {
         else { return XCTFail("💥") }
         
         XCTAssertEqual(configurationDummyRequestInterceptor, dummyRequestInterceptor)
+    }
+
+    // MARK: Error
+
+    func testErrorResponse_WhenCaseContainsResponse_ShouldReturnIt() {
+
+        enum DummyError: Error { case 🕳 }
+
+        let testResponse = URLResponse(url: URL(string: "https://mindera.com")!,
+                                       mimeType: nil,
+                                       expectedContentLength: 1337,
+                                       textEncodingName: nil)
+
+        let httpError = Network.Error.http(.unknownError(1337), nil, testResponse)
+        let noDataError = Network.Error.noData(testResponse)
+        let urlError = Network.Error.url(DummyError.🕳, testResponse)
+        let badResponseError = Network.Error.badResponse(testResponse)
+        let retryError = Network.Error.retry([], 0, .cancelled, testResponse)
+
+        XCTAssertEqual(httpError.response, testResponse)
+        XCTAssertEqual(noDataError.response, testResponse)
+        XCTAssertEqual(urlError.response, testResponse)
+        XCTAssertEqual(badResponseError.response, testResponse)
+        XCTAssertEqual(retryError.response, testResponse)
+    }
+
+    func testErrorResponse_WhenCaseDoesNotContainsResponse_ShouldReturnNil() {
+
+        enum DummyError: Error { case 🕳 }
+
+        let noRequestError = Network.Error.noRequest(DummyError.🕳)
+        let urlError = Network.Error.url(DummyError.🕳, nil)
+        let badResponseError = Network.Error.badResponse(nil)
+        let retryError = Network.Error.retry([], 0, .cancelled, nil)
+
+        XCTAssertNil(noRequestError.response)
+        XCTAssertNil(urlError.response)
+        XCTAssertNil(badResponseError.response)
+        XCTAssertNil(retryError.response)
     }
 }
 
@@ -57,3 +98,4 @@ extension DummyRequestInterceptor: Equatable {
         return true
     }
 }
+

--- a/Tests/AlicerceTests/Network/SerializeTestCase.swift
+++ b/Tests/AlicerceTests/Network/SerializeTestCase.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import Alicerce
+
+struct MockMappableModel: Mappable {
+
+    static var mockModel: (Any) throws -> MockMappableModel = {
+         throw JSON.Error.unexpectedType(expected: MockMappableModel.self, found: type(of: $0))
+    }
+
+    var mockJSON: Any = ""
+}
+
+extension MockMappableModel {
+
+    static func model(from object: Any) throws -> MockMappableModel { return try mockModel(object) }
+
+    func json() -> Any { return mockJSON }
+}
+
+
+final class SerializeTestCase: XCTestCase {
+
+    // MARK: - Success tests
+
+    func testJSON_WithSuccessfulSerialization_ShouldReturnData() {
+
+        let model = MappableModel(data: "👍")
+        let modelData = try! JSONSerialization.data(withJSONObject: model.json(), options: [])
+
+        do {
+            let data = try Serialize.json(object: model)
+            XCTAssertEqual(data, modelData)
+        } catch {
+            XCTFail("🔥 received unexpected error 👉 \(error) 😱")
+        }
+    }
+
+    func testImageAsPNGData_WithSuccessfulSerialization_ShouldReturnImage() {
+
+        let image = imageFromFile(withName: "mr-minder", type: "png")
+
+        do {
+            let data = try Serialize.imageAsPNGData(image)
+            XCTAssertEqual(data, image.pngData())
+        } catch {
+            XCTFail("🔥 received unexpected error 👉 \(error) 😱")
+        }
+    }
+
+    // MARK: - Error tests
+
+    func testJSON_WithInvalidJSON_ShouldThrowAnInvalidJSONError() {
+
+        var model = MockMappableModel()
+        model.mockJSON = "💥"
+
+        do {
+            let _ = try Serialize.json(object: model)
+            XCTFail("🔥 unexpected success 😱")
+        } catch Serialize.Error.invalidJSON(let errorJSON) {
+            XCTAssertDumpsEqual(errorJSON, model.json())
+        } catch {
+            XCTFail("🔥 received unexpected error 👉 \(error) 😱")
+        }
+    }
+
+    // TODO: JSON failing serialization
+
+    func testImage_WithNonPNGImage_ShouldThrowAnInvalidImageError() {
+
+        let image = UIImage()
+
+        do {
+            let _ = try Serialize.imageAsPNGData(image)
+            XCTFail("🔥 unexpected success 😱")
+        } catch Serialize.Error.invalidImage(let errorImage) {
+            XCTAssertEqual(errorImage, image)
+        } catch {
+            XCTFail("🔥 received unexpected error 👉 \(error) 😱")
+        }
+    }
+}

--- a/Tests/AlicerceTests/Network/URLSessionNetworkStackTestCase.swift
+++ b/Tests/AlicerceTests/Network/URLSessionNetworkStackTestCase.swift
@@ -388,7 +388,7 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
             switch result {
             case .success:
                 XCTFail("🔥 should throw an error 🤔")
-            case let .failure(.http(code: receiveStatusCode, apiError: nil, response: receivedResponse)):
+            case let .failure(.http(receiveStatusCode, nil, receivedResponse)):
                 XCTAssertEqual(receiveStatusCode.statusCode, mockResponse.statusCode)
                 XCTAssertEqual(receivedResponse, mockResponse)
             case let .failure(error):
@@ -419,9 +419,7 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
             switch result {
             case .success:
                 XCTFail("🔥 should throw an error 🤔")
-            case let .failure(.http(code: receiveStatusCode,
-                                    apiError: Resource.MockAPIError.💩?,
-                                    response: receivedResponse)):
+            case let .failure(.http(receiveStatusCode, Resource.MockAPIError.💩?, receivedResponse)):
                 XCTAssertEqual(receiveStatusCode.statusCode, mockResponse.statusCode)
                 XCTAssertEqual(receivedResponse, mockResponse)
             case let .failure(error):

--- a/Tests/AlicerceTests/Stores/NetworkPersistableStoreTestCase.swift
+++ b/Tests/AlicerceTests/Stores/NetworkPersistableStoreTestCase.swift
@@ -75,7 +75,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
         // Given
         let mockResponse = successResponse
 
-        networkStack.mockError = .noData(response: mockResponse)
+        networkStack.mockError = .noData(mockResponse)
         persistenceStack.mockObjectResult = .success(nil)
 
         resource.mockStrategy = .persistenceThenNetwork
@@ -89,7 +89,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                 return XCTFail("🔥: unexpected success!")
             }
 
-            guard case .network(.noData(response: mockResponse)) = error else {
+            guard case .network(.noData(mockResponse)) = error else {
                 return XCTFail("🔥: unexpected error \(error)!")
             }
         }
@@ -109,7 +109,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
         // Given
         let mockResponse = successResponse
 
-        networkStack.mockError = .noData(response: mockResponse)
+        networkStack.mockError = .noData(mockResponse)
         persistenceStack.mockObjectResult = .success(nil)
 
         resource.mockStrategy = .networkThenPersistence
@@ -123,7 +123,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                 return XCTFail("🔥: unexpected success!")
             }
 
-            guard case .network(.noData(response: mockResponse)) = error else {
+            guard case .network(.noData(mockResponse)) = error else {
                 return XCTFail("🔥: unexpected error \(error)!")
             }
         }
@@ -241,7 +241,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
         // Given
         let mockResponse = successResponse
 
-        networkStack.mockError = .noData(response: mockResponse)
+        networkStack.mockError = .noData(mockResponse)
         persistenceStack.mockObjectResult = .failure(.💥)
 
         resource.mockStrategy = .networkThenPersistence
@@ -259,7 +259,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                 return XCTFail("🔥: unexpected error \(error)!")
             }
 
-            XCTAssertDumpsEqual(errors, [Network.Error.noData(response: mockResponse), MockPersistenceStack.Error.💥])
+            XCTAssertDumpsEqual(errors, [Network.Error.noData(mockResponse), MockPersistenceStack.Error.💥])
         }
 
         networkStack.runMockFetch()
@@ -277,7 +277,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
         // Given
         let mockResponse = successResponse
 
-        networkStack.mockError = .noData(response: mockResponse)
+        networkStack.mockError = .noData(mockResponse)
         persistenceStack.mockObjectResult = .failure(.💥)
 
         resource.mockStrategy = .persistenceThenNetwork
@@ -295,7 +295,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                 return XCTFail("🔥: unexpected error \(error)!")
             }
 
-            XCTAssertDumpsEqual(errors, [MockPersistenceStack.Error.💥, Network.Error.noData(response: mockResponse)])
+            XCTAssertDumpsEqual(errors, [MockPersistenceStack.Error.💥, Network.Error.noData(mockResponse)])
         }
 
         networkStack.runMockFetch()
@@ -312,7 +312,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
 
         // Given
         let cancelable = CancelableBag()
-        networkStack.mockError = .url(URLError(.cancelled), response: nil)
+        networkStack.mockError = .url(URLError(.cancelled), nil)
         networkStack.beforeFetchCompletionClosure = {
             cancelable.cancel()
         }
@@ -329,7 +329,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                 return XCTFail("🔥: unexpected success!")
             }
 
-            guard case .cancelled(Network.Error.url(URLError.cancelled, response: nil)?) = error else {
+            guard case .cancelled(Network.Error.url(URLError.cancelled, nil)?) = error else {
                 return XCTFail("🔥: unexpected error \(error)!")
             }
         }
@@ -348,7 +348,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
 
         // Given
         let cancelable = CancelableBag()
-        networkStack.mockError = .badResponse(response: nil)
+        networkStack.mockError = .badResponse(nil)
         networkStack.beforeFetchCompletionClosure = {
             cancelable.cancel()
         }
@@ -474,7 +474,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                                            httpVersion: nil,
                                            headerFields: nil)!
 
-        networkStack.mockError = .noData(response: mockResponse)
+        networkStack.mockError = .noData(mockResponse)
         networkStack.mockCancelable.mockCancelClosure = {
             cancelExpectation.fulfill()
         }
@@ -738,7 +738,7 @@ class NetworkPersistableStoreTestCase: XCTestCase {
                                            httpVersion: nil,
                                            headerFields: nil)!
 
-        networkStack.mockError = .noData(response: mockResponse)
+        networkStack.mockError = .noData(mockResponse)
         persistenceStack.mockObjectResult = .success(persistenceData)
 
         resource.mockStrategy = .networkThenPersistence

--- a/Tests/AlicerceTests/Stores/NetworkStoreTestCase.swift
+++ b/Tests/AlicerceTests/Stores/NetworkStoreTestCase.swift
@@ -73,7 +73,7 @@ class NetworkStoreTestCase: XCTestCase {
         let statusCode = 500
         let mockError = NSError(domain: "☠️", code: statusCode, userInfo: nil)
 
-        networkStack.mockError = .url(mockError, response: nil)
+        networkStack.mockError = .url(mockError, nil)
 
         networkStack.fetch(resource: testResource) { (result: NetworkStoreResult) in
 
@@ -123,7 +123,7 @@ class NetworkStoreTestCase: XCTestCase {
 
         let cancelable = CancelableBag()
 
-        networkStack.mockError = .url(MockOtherError.💥, response: nil)
+        networkStack.mockError = .url(MockOtherError.💥, nil)
         networkStack.beforeFetchCompletionClosure = {
             cancelable.cancel()
         }

--- a/Tests/AlicerceTests/UIKit/UIViewConstraintTestCase.swift
+++ b/Tests/AlicerceTests/UIKit/UIViewConstraintTestCase.swift
@@ -22,11 +22,11 @@ class UIViewConstraintTestCase: XCTestCase {
     }
 
     override func tearDown() {
-        super.tearDown()
-
         superview = nil
         view1 = nil
         view2 = nil
+
+        super.tearDown()
     }
 
     func test_translatesAutoresizingMaskIntoConstraints_is_false() {

--- a/Tests/AlicerceTests/View/ReusableViewCollectionViewTestCase.swift
+++ b/Tests/AlicerceTests/View/ReusableViewCollectionViewTestCase.swift
@@ -19,7 +19,6 @@ class ReusableViewCollectionViewTestCase: XCTestCase {
     override func tearDown() {
         collectionViewController = nil
 
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
 

--- a/Tests/AlicerceTests/View/ReusableViewTableViewTestCase.swift
+++ b/Tests/AlicerceTests/View/ReusableViewTableViewTestCase.swift
@@ -16,7 +16,6 @@ class ReusableViewTableViewTestCase: XCTestCase {
     override func tearDown() {
         tableViewController = nil
 
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
 


### PR DESCRIPTION
Found some more quick wins to add a bit of extra code coverage (since I'm on a spree 😝).

The last bits of _possible_ coverage (i.e. excluding `assertionFailure`s, `fatalError`s and unreachable code) will probably require creating an iOS 9 targeted suite as well as maybe some UI Tests (for `KeyboardObserver`). There're also some filesystem related errors that are testable (e.g. on `DiskMemoryPersistenceStack`).

All in all, I would say we're pretty good now above 90% ☺️

## Changes

- Added missing tests on `Network`, `Serialize` and `DiskMemoryPersistenceStack`.

- Did minor improvements on `Network.Error`'s, by creating some typealiases and removing the inconsistent associated value labels.

- Made `PublicKeyAlgorithm` `CaseIterable`.

- Did small clean up in legacy (iOS 9) pinning check on `ServerTrustEvaluator`.