### PR TITLE
Add `finishFetchesAndInvalidateSession` in `URLSessionNetworkStack`

### DIFF
--- a/Sources/Network/URLSessionNetworkStack.swift
+++ b/Sources/Network/URLSessionNetworkStack.swift
@@ -48,6 +48,21 @@ public extension Network {
                       retryQueue: configuration.retryQueue)
         }
 
+        /// Invalidates the stack's session, allowing any outstanding fetches to finish and breaking the session's
+        /// reference to the stack (its delegate) as well as any callback objects.
+        ///
+        /// The session objects keep a strong reference to the delegate until the session is explicitly invalidated.
+        /// If the stack's session isn't invalidated, the retain cycle is never broken and the app leaks (until it
+        /// exits).
+        ///
+        /// - Important: This method should **always** be invoked before deinit'ing the stack, to avoid a retain cycle.
+        ///
+        /// - SeeAlso: `URLSession.finishTasksAndInvalidate`.
+        public func finishFetchesAndInvalidateSession() {
+
+            session?.finishTasksAndInvalidate()
+        }
+
         @discardableResult
         public func fetch<R>(resource: R, completion: @escaping Network.CompletionClosure<R.Remote>) -> Cancelable
         where R: NetworkResource & RetryableResource, R.Remote == Remote, R.Request == Request, R.Response == Response {

--- a/Tests/AlicerceTests/Network/Mocks/MockURLSession.swift
+++ b/Tests/AlicerceTests/Network/Mocks/MockURLSession.swift
@@ -13,6 +13,8 @@ final class MockURLSession: URLSession {
     var mockAuthenticationChallenge: URLAuthenticationChallenge = URLAuthenticationChallenge()
     var mockAuthenticationCompletionHandler: Network.AuthenticationCompletionClosure = { _, _  in }
 
+    var didInvokeFinishTasksAndInvalidate: (() -> Void)?
+
     private let _configuration: URLSessionConfiguration
     private let _delegate: URLSessionDelegate?
     private let _delegateQueue: OperationQueue
@@ -64,5 +66,10 @@ final class MockURLSession: URLSession {
         self.mockDataTask = dataTask
 
         return dataTask
+    }
+
+    override func finishTasksAndInvalidate() {
+
+        didInvokeFinishTasksAndInvalidate?()
     }
 }

--- a/Tests/AlicerceTests/Network/URLSessionNetworkStackTestCase.swift
+++ b/Tests/AlicerceTests/Network/URLSessionNetworkStackTestCase.swift
@@ -55,7 +55,7 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: - Success tests
+    // MARK: - init
 
     func testConvenienceInit_WithValidProperties_ShouldPopulateAllProperties() {
         let expectation = self.expectation(description: "testConvenienceInit")
@@ -82,6 +82,26 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
             expectation.fulfill()
         }
     }
+
+    // MARK: - finishFetchesAndInvalidateSession
+
+    func testFetchesTasksAndInvalidateSession_WithSetSession_ShouldCallFinishTasksAndInvalidateOnTheSession() {
+        let expectation = self.expectation(description: "testFinishTasksAndInvalidateSession")
+        defer { waitForExpectations(timeout: expectationTimeout) }
+
+        let networkConfiguration = Network.Configuration(retryQueue: networkStackRetryQueue)
+
+        networkStack = Network.URLSessionNetworkStack(configuration: networkConfiguration)
+        mockSession = MockURLSession(delegate: networkStack)
+
+        networkStack.session = mockSession
+
+        mockSession.didInvokeFinishTasksAndInvalidate = { expectation.fulfill() }
+
+        networkStack.finishFetchesAndInvalidateSession()
+    }
+
+    // MARK: - fetch (success)
 
     func testFetch_WhenResponseIsSuccessful_ShouldCallCompletionClosureWithData() {
         let expectation = self.expectation(description: "testFetch")
@@ -326,7 +346,7 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
         networkStack.fetch(resource: resource) { _ in }
     }
 
-    // MARK: - Error tests
+    // MARK: - fetch (failure)
 
     func testFetch_WithNetworkFailureError_ShouldThrowAnURLError() {
         let expectation = self.expectation(description: "testFetch")


### PR DESCRIPTION
`URLSession` objects keep a strong reference to their delegate until the session is explicitly invalidated.

As such, if the `URLSessionNetworkStack`'s `session` isn't invalidated, the retain cycle is never broken and the app leaks (until it exits).

This means that this should **always** be made before deinit'ing the `URLSessionNetworkStack`, to avoid a retain cycle.

Since the stack is effectively the owner of the session, a new `finishFetchesAndInvalidateSession()` API was added to the stack to allow performing this operation while serving as documentation.