### PR TITLE
Add configurable internal logger 📝

### DIFF
--- a/Alicerce.xcodeproj/project.pbxproj
+++ b/Alicerce.xcodeproj/project.pbxproj
@@ -162,6 +162,8 @@
 		0A708F6620E97B6E001784DA /* AnyAnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A708F6520E97B6E001784DA /* AnyAnalyticsTracker.swift */; };
 		0A708F6A20E9810B001784DA /* AnalyticsParameterKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A708F6920E9810B001784DA /* AnalyticsParameterKey.swift */; };
 		0A708F6E20E99D9F001784DA /* MockAnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A708F6C20E99D9A001784DA /* MockAnalyticsTracker.swift */; };
+		0A72EB44225158EE00540C67 /* MetadataLoggerTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A72EB43225158EE00540C67 /* MetadataLoggerTestCase.swift */; };
+		0A72EB4622515E7A00540C67 /* DummyLoggerTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A72EB4522515E7A00540C67 /* DummyLoggerTestCase.swift */; };
 		0A7476C81ECB3F88003024D1 /* ReusableViewModelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A7476C71ECB3F88003024D1 /* ReusableViewModelView.swift */; };
 		0A76A006209F868C00D46B63 /* Route+Tree_DescriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A76A004209F854C00D46B63 /* Route+Tree_DescriptionTests.swift */; };
 		0A77982920FCCD24008E269A /* ResourceRetryTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A77982820FCCD24008E269A /* ResourceRetryTestCase.swift */; };
@@ -196,6 +198,7 @@
 		0A85F0E720B3177E0095AFFB /* PublicKeyAlgorithmTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A85F0E620B3177E0095AFFB /* PublicKeyAlgorithmTestCase.swift */; };
 		0A85F0E920B31A810095AFFB /* Data+SPKIHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A85F0E820B31A810095AFFB /* Data+SPKIHash.swift */; };
 		0A85F0EB20B31AE30095AFFB /* Data+SPKIHashTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A85F0EA20B31AE30095AFFB /* Data+SPKIHashTestCase.swift */; };
+		0A8BFBE9222C7D2B009CF72E /* Log+DummyLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8BFBE8222C7D2B009CF72E /* Log+DummyLogger.swift */; };
 		0A8E68A520BB41CF003EF5E3 /* LogModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A8E68A420BB41CF003EF5E3 /* LogModule.swift */; };
 		0A9084391EBCBFB200616076 /* NibView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9084361EBCBFB200616076 /* NibView.swift */; };
 		0A90843A1EBCBFB200616076 /* ReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9084371EBCBFB200616076 /* ReusableView.swift */; };
@@ -452,6 +455,8 @@
 		0A708F6520E97B6E001784DA /* AnyAnalyticsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyAnalyticsTracker.swift; sourceTree = "<group>"; };
 		0A708F6920E9810B001784DA /* AnalyticsParameterKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsParameterKey.swift; sourceTree = "<group>"; };
 		0A708F6C20E99D9A001784DA /* MockAnalyticsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAnalyticsTracker.swift; sourceTree = "<group>"; };
+		0A72EB43225158EE00540C67 /* MetadataLoggerTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataLoggerTestCase.swift; sourceTree = "<group>"; };
+		0A72EB4522515E7A00540C67 /* DummyLoggerTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DummyLoggerTestCase.swift; sourceTree = "<group>"; };
 		0A7476C71ECB3F88003024D1 /* ReusableViewModelView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReusableViewModelView.swift; sourceTree = "<group>"; };
 		0A7476CB1ECB48B2003024D1 /* TableViewHeaderFooterViewTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewHeaderFooterViewTestCase.swift; sourceTree = "<group>"; };
 		0A7476CD1ECB4C48003024D1 /* CollectionReusableViewTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionReusableViewTestCase.swift; sourceTree = "<group>"; };
@@ -506,6 +511,7 @@
 		0A85F0E820B31A810095AFFB /* Data+SPKIHash.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+SPKIHash.swift"; sourceTree = "<group>"; };
 		0A85F0EA20B31AE30095AFFB /* Data+SPKIHashTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+SPKIHashTestCase.swift"; sourceTree = "<group>"; };
 		0A85F0EC20B31B210095AFFB /* CertificateUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertificateUtils.swift; sourceTree = "<group>"; };
+		0A8BFBE8222C7D2B009CF72E /* Log+DummyLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Log+DummyLogger.swift"; sourceTree = "<group>"; };
 		0A8E68A420BB41CF003EF5E3 /* LogModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogModule.swift; sourceTree = "<group>"; };
 		0A9084361EBCBFB200616076 /* NibView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NibView.swift; sourceTree = "<group>"; };
 		0A9084371EBCBFB200616076 /* ReusableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReusableView.swift; sourceTree = "<group>"; };
@@ -981,6 +987,7 @@
 			isa = PBXGroup;
 			children = (
 				0A98158520E2E33B00F4680B /* Log+DefaultLogger.swift */,
+				0A8BFBE8222C7D2B009CF72E /* Log+DummyLogger.swift */,
 				0A3C2C9D1EA7E18500EFB7D4 /* Logger.swift */,
 				0A708F5820E9360A001784DA /* MetadataLogger.swift */,
 				0A708F5320E932EB001784DA /* ModuleLogger.swift */,
@@ -993,7 +1000,9 @@
 			children = (
 				0A3C2D1B1EA7E1EE00EFB7D4 /* DefaultLoggerTestCase.swift */,
 				0A3236E620D88ED400D225CB /* LoggerTestCase.swift */,
+				0A72EB43225158EE00540C67 /* MetadataLoggerTestCase.swift */,
 				0A708F5E20E94DF8001784DA /* ModuleLoggerTestCase.swift */,
+				0A72EB4522515E7A00540C67 /* DummyLoggerTestCase.swift */,
 			);
 			path = Loggers;
 			sourceTree = "<group>";
@@ -1664,6 +1673,7 @@
 				0A266FBD1ED59FCD009CD0D7 /* MockErrorManagedObjectContext.m in Sources */,
 				0A266FBE1ED59FCD009CD0D7 /* CoreDataStackModel.xcdatamodeld in Sources */,
 				0A79686120812130005738AF /* LockTestCase.swift in Sources */,
+				0A72EB4622515E7A00540C67 /* DummyLoggerTestCase.swift in Sources */,
 				0A266FBF1ED59FCD009CD0D7 /* EmptyCoreDataStackModel.xcdatamodeld in Sources */,
 				0A708F6E20E99D9F001784DA /* MockAnalyticsTracker.swift in Sources */,
 				0A266F8C1ED59FB6009CD0D7 /* MultiTrackerTestCase.swift in Sources */,
@@ -1689,6 +1699,7 @@
 				0A266F9A1ED59FB6009CD0D7 /* ConsoleLogDestinationTestCase.swift in Sources */,
 				0AB34A062085385A001F2979 /* UnfairLockTestCase.swift in Sources */,
 				0A266F9B1ED59FB6009CD0D7 /* MockMetadataLogDestination.swift in Sources */,
+				0A72EB44225158EE00540C67 /* MetadataLoggerTestCase.swift in Sources */,
 				0AFB0DCE20F8E81700A58515 /* MockAuthenticationChallengeHandler.swift in Sources */,
 				0AFB0DC720F8E77700A58515 /* MockURLSession.swift in Sources */,
 				0AB34A0820853873001F2979 /* PthreadLockTestCase.swift in Sources */,
@@ -1819,6 +1830,7 @@
 				0A3C2DC11EA7E5DD00EFB7D4 /* ServiceLocator.swift in Sources */,
 				0A3C2DB81EA7E5DD00EFB7D4 /* CollectionViewCell.swift in Sources */,
 				65D46CB5203C90E5008E847B /* PersistencePerformanceMetricsTracker.swift in Sources */,
+				0A8BFBE9222C7D2B009CF72E /* Log+DummyLogger.swift in Sources */,
 				0A708F5920E9360A001784DA /* MetadataLogger.swift in Sources */,
 				0A3C2D8D1EA7E5DD00EFB7D4 /* Data.swift in Sources */,
 				0A3C2DB61EA7E5DD00EFB7D4 /* Resource.swift in Sources */,

--- a/Sources/Logging/Destinations/Log+ConsoleLogDestination.swift
+++ b/Sources/Logging/Destinations/Log+ConsoleLogDestination.swift
@@ -106,3 +106,7 @@ public extension Log {
         public func removeMetadata(forKeys keys: [MetadataKey], onFailure: @escaping (Error) -> Void) {}
     }
 }
+
+extension Log.ConsoleLogDestination: Logger {}
+
+extension Log.ConsoleLogDestination: MetadataLogger {}

--- a/Sources/Logging/Destinations/LogDestination.swift
+++ b/Sources/Logging/Destinations/LogDestination.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A type representing a logging destination (or provider).
-public protocol LogDestination: class {
+public protocol LogDestination: AnyObject {
 
     /// A type representing a destination's identifier.
     typealias ID = String

--- a/Sources/Logging/Destinations/MetadataLogDestination.swift
+++ b/Sources/Logging/Destinations/MetadataLogDestination.swift
@@ -1,5 +1,3 @@
-// Copyright © 2018 Mindera. All rights reserved.
-
 import Foundation
 
 /// A type representing a logging destination (or provider) that can set/unset custom logging metadata.

--- a/Sources/Logging/Log.swift
+++ b/Sources/Logging/Log.swift
@@ -73,3 +73,27 @@ public enum Log {
         }
     }
 }
+
+extension Log {
+
+    /// The framework's (configurable) internal logger, mostly used as a default error logger, or to log errors which
+    /// don't impact normal functioning and are not exposed/propagated via the current API's.
+    ///
+    /// The default value is set to a `Log.ConsoleLogDestination` instance configured with a `StringLogItemFormatter`
+    /// with the format string: `"$DHH:mm:ss.SSS$d $C$L$c $N.$F:$l - [Alicerce 🏗] $M"`.
+    ///
+    /// Set to a `Log.DummyLogger` instance to disable logging from the framework, or to the `Logger` of your choice to
+    /// easily include Alicerce's logs into to your own logs.
+    ///
+    /// - Warning: This variable is **not** thread safe (for performance reasons). If you wish to customize its value
+    /// please do so just once on app launch, or before using any of Alicerce's components.
+    public static var internalLogger: Logger = {
+
+        let format = "$DHH:mm:ss.SSS$d $C$L$c $N.$F:$l - [Alicerce 🏗] $M"
+
+        let formatter = Log.StringLogItemFormatter()
+        let destination = Log.ConsoleLogDestination<StringLogItemFormatter, NoMetadataKey>(formatter: formatter)
+
+        return destination
+    }()
+}

--- a/Sources/Logging/Loggers/Log+DummyLogger.swift
+++ b/Sources/Logging/Loggers/Log+DummyLogger.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+extension Log {
+
+    /// A dummy implementation of a `Logger`, to use when you don't want to log anything but need to have a logger set.
+    public final class DummyLogger: Logger {
+
+        public func log(level: Log.Level,
+                        message: @autoclosure () -> String,
+                        file: StaticString,
+                        line: UInt,
+                        function: StaticString) {}
+    }
+}

--- a/Sources/Logging/Loggers/MetadataLogger.swift
+++ b/Sources/Logging/Loggers/MetadataLogger.swift
@@ -1,5 +1,3 @@
-// Copyright © 2018 Mindera. All rights reserved.
-
 import Foundation
 
 /// A type that logs messages with multiple possible severity log levels, and sets/unsets custom logging metadata.
@@ -22,4 +20,28 @@ public protocol MetadataLogger: Logger {
     ///
     /// - Parameter keys: The custom metadata keys to remove.
     func removeMetadata(forKeys keys: [MetadataKey])
+}
+
+public extension MetadataLogger where Self: MetadataLogDestination {
+
+    public func setMetadata(_ metadata: [MetadataKey : Any]) {
+
+        setMetadata(metadata) { error in
+
+            guard self !== Log.internalLogger else { return }
+
+            Log.internalLogger.error("💥 '\(type(of: self))' failed to log metadata: \(metadata) with error: \(error)")
+        }
+    }
+
+    public func removeMetadata(forKeys keys: [MetadataKey]) {
+
+        removeMetadata(forKeys: keys) { error in
+
+            guard self !== Log.internalLogger else { return }
+
+            Log.internalLogger.error("💥 '\(type(of: self))' failed to remove metadata for keys: \(keys) with " +
+                                     "error: \(error)")
+        }
+    }
 }

--- a/Sources/Persistence/CoreData/NSManagedObjectContext+CoreDataStack.swift
+++ b/Sources/Persistence/CoreData/NSManagedObjectContext+CoreDataStack.swift
@@ -53,9 +53,8 @@ public extension NSManagedObjectContext {
         do {
             try save()
         } catch let error {
-            // FIXME: use proper logging function when available
-            print("💥[Alicerce.NSManagedObjectContext]: Error saving context \(self) (\(description)): \(error). " +
-                  "Rolling back all changes...")
+            Log.internalLogger.error("💥 Failed to save context \(self) (\(description)) with error: \(error)! " +
+                                     "Rolling back all changes...")
 
             rollback()
             throw error
@@ -71,9 +70,9 @@ public extension NSManagedObjectContext {
             do {
                 try parent.save()
             } catch let error {
-                // FIXME: use proper logging function when available
-                print("💥[Alicerce.NSManagedObjectContext]: Error saving parent context \(self) (\(description)): " +
-                      "\(error). Rolling back all changes...")
+                Log.internalLogger.error("💥 Failed to save parent context \(parent) (\(description)) with " +
+                                         "error: \(error)! Rolling back changes in parent...")
+
                 parent.rollback()
                 parentError = error
             }

--- a/Sources/Persistence/DiskMemoryPersistenceStack.swift
+++ b/Sources/Persistence/DiskMemoryPersistenceStack.swift
@@ -412,8 +412,7 @@ public extension Persistence {
 
                 guard let urls = try? self.directoryContents(with: [.contentAccessDateKey, .fileSizeKey]) else {
                     assertionFailure("💥 Failed to get directory contents on evict!")
-                    print("💥[Alicerce.Persistence.DiskMemoryPersistenceStack]: Failed to get directory contents on " +
-                        "evict!")
+                    Log.internalLogger.error("💥 Failed to get directory contents on evict!")
                     return
                 }
 
@@ -445,8 +444,7 @@ public extension Persistence {
                         try self.remove(fileAtURL: $0.url, size: $0.fileAttr.size)
                     } catch {
                         assertionFailure("💥 Failed to remove file with at: \($0) with error: \(error)")
-                        print("💥[Alicerce.Persistence.DiskMemoryPersistenceStack]: Failed to remove file at: \($0) " +
-                            "with error: \(error)")
+                        Log.internalLogger.error("💥 Failed to remove file at: \($0) with error: \(error)")
                     }
                 }
             }

--- a/Sources/Stores/NetworkPersistableStore.swift
+++ b/Sources/Stores/NetworkPersistableStore.swift
@@ -121,7 +121,7 @@ Persistence.Remote == Data {
                     },
                     cancelled: { _ in },
                     failure: { error in
-                        print("⚠️ [Alicerce.NetworkPersistableStore]: Failed to fetch value for '\(resource)': \(error)")
+                        Log.internalLogger.warning("⚠️ Failed to fetch value for '\(resource)' with error: \(error)")
                     })
             },
             cacheMiss: { [weak self] in
@@ -186,7 +186,7 @@ Persistence.Remote == Data {
                 switch $0 {
                 case .success: break
                 case .failure(let error):
-                    print("⚠️ [Alicerce.NetworkPersistableStore]: Failed to persist value for '\(resource)': \(error)")
+                    Log.internalLogger.warning("⚠️ Failed to persist value for '\(resource)' with error: \(error)")
                 }
             }
 
@@ -230,7 +230,7 @@ Persistence.Remote == Data {
                 switch $0 {
                 case .success: break
                 case .failure(let error):
-                    print("⚠️ [Alicerce.NetworkPersistableStore]: Failed to remove value for '\(resource)': \(error)")
+                    Log.internalLogger.warning("⚠️ Failed to remove value for '\(resource)' with error: \(error)")
                 }
             }
         } catch {

--- a/Tests/AlicerceTests/Logging/Destinations/MockMetadataLogDestination.swift
+++ b/Tests/AlicerceTests/Logging/Destinations/MockMetadataLogDestination.swift
@@ -1,12 +1,18 @@
 import Alicerce
 
-class MockMetadataLogDestination<MetadataKey: Hashable>: MetadataLogDestination {
+typealias MockLogDestination = MockMetadataLogDestination<Log.NoModule, Log.NoMetadataKey>
+
+class MockMetadataLogDestination<Module: LogModule, MetadataKey: Hashable>: MetadataLogDestination {
 
     typealias ErrorClosure = (Error) -> Void
 
     var writeInvokedClosure: ((Log.Item, @escaping ErrorClosure) -> Void)?
+
     var setMetadataInvokedClosure: (([MetadataKey : Any], @escaping ErrorClosure) -> Void)?
     var removeMetadataInvokedClosure: (([MetadataKey], @escaping ErrorClosure) -> Void)?
+
+    var registerModuleInvokedClosure: ((Module, Log.Level) -> Void)?
+    var unregisterModuleInvokedClosure: ((Module) -> Void)?
 
     var mockID: ID?
     var mockMinLevel: Log.Level?
@@ -38,5 +44,18 @@ class MockMetadataLogDestination<MetadataKey: Hashable>: MetadataLogDestination 
 
     func removeMetadata(forKeys keys: [MetadataKey], onFailure: @escaping (Error) -> Void) {
         removeMetadataInvokedClosure?(keys, onFailure)
+    }
+}
+
+extension MockMetadataLogDestination: MetadataLogger {}
+
+extension MockMetadataLogDestination: ModuleLogger {
+
+    func registerModule(_ module: Module, minLevel: Log.Level) throws {
+        registerModuleInvokedClosure?(module, minLevel)
+    }
+
+    func unregisterModule(_ module: Module) throws {
+        unregisterModuleInvokedClosure?(module)
     }
 }

--- a/Tests/AlicerceTests/Logging/Loggers/DefaultLoggerTestCase.swift
+++ b/Tests/AlicerceTests/Logging/Loggers/DefaultLoggerTestCase.swift
@@ -4,20 +4,10 @@ import XCTest
 class DefaultLoggerTestCase: XCTestCase {
 
     enum MockError: Error { case 😱 }
+    enum MockLogModule: String, LogModule { case 🏗, 🚧 }
+    enum MockMetadataKey { case 👤, 📱, 📊 }
 
-    enum MockLogModule: String, LogModule {
-        case 🏗
-        case 🚧
-    }
-
-    enum MockMetadataKey {
-        case 👤
-        case 📱
-        case 📊
-    }
-
-    typealias MockLogDestination = MockMetadataLogDestination<MockMetadataKey>
-    
+    typealias MockLogDestination = MockMetadataLogDestination<MockLogModule, MockMetadataKey>
     typealias DefaultLogger = Log.DefaultLogger<MockLogModule, MockMetadataKey>
 
     private var log: DefaultLogger!
@@ -326,6 +316,14 @@ class DefaultLoggerTestCase: XCTestCase {
 
         let destination = MockLogDestination(id: "1", minLevel: .verbose)
 
+        let onError: DefaultLogger.LogDestinationErrorClosure = { errorDestination, error in
+            defer { errorExpectation.fulfill() }
+            XCTAssertEqual(errorDestination.id, destination.id)
+            guard case MockError.😱 = error else { return XCTFail("unexpected error \(error)") }
+        }
+
+        log = DefaultLogger(onError: onError)
+
         do {
             try log.registerDestination(destination)
             try log.registerModule(.🏗, minLevel: .verbose)
@@ -346,12 +344,6 @@ class DefaultLoggerTestCase: XCTestCase {
             failure(MockError.😱)
 
             writeExpectation.fulfill()
-        }
-
-        log.onError = { errorDestination, error in
-            defer { errorExpectation.fulfill() }
-            XCTAssertEqual(errorDestination.id, destination.id)
-            guard case MockError.😱 = error else { return XCTFail("unexpected error \(error)") }
         }
 
         log.log(module: .🏗,
@@ -401,6 +393,14 @@ class DefaultLoggerTestCase: XCTestCase {
 
         let destination = MockLogDestination(id: "1")
 
+        let onError: DefaultLogger.LogDestinationErrorClosure = { errorDestination, error in
+            defer { errorExpectation.fulfill() }
+            XCTAssertEqual(errorDestination.id, destination.id)
+            guard case MockError.😱 = error else { return XCTFail("unexpected error \(error)") }
+        }
+
+        log = DefaultLogger(onError: onError)
+
         do {
             try log.registerDestination(destination)
         } catch {
@@ -413,12 +413,6 @@ class DefaultLoggerTestCase: XCTestCase {
             XCTAssertDumpsEqual(metadata, testMetadata)
             failure(MockError.😱)
             metadataExpectation.fulfill()
-        }
-
-        log.onError = { errorDestination, error in
-            defer { errorExpectation.fulfill() }
-            XCTAssertEqual(errorDestination.id, destination.id)
-            guard case MockError.😱 = error else { return XCTFail("unexpected error \(error)") }
         }
 
         log.setMetadata(testMetadata)
@@ -463,6 +457,14 @@ class DefaultLoggerTestCase: XCTestCase {
 
         let destination = MockLogDestination(id: "1")
 
+        let onError: DefaultLogger.LogDestinationErrorClosure = { errorDestination, error in
+            defer { errorExpectation.fulfill() }
+            XCTAssertEqual(errorDestination.id, destination.id)
+            guard case MockError.😱 = error else { return XCTFail("unexpected error \(error)") }
+        }
+
+        log = DefaultLogger(onError: onError)
+
         do {
             try log.registerDestination(destination)
         } catch {
@@ -475,12 +477,6 @@ class DefaultLoggerTestCase: XCTestCase {
             XCTAssertDumpsEqual(keys, testMetadataKeys)
             failure(MockError.😱)
             metadataExpectation.fulfill()
-        }
-
-        log.onError = { errorDestination, error in
-            defer { errorExpectation.fulfill() }
-            XCTAssertEqual(errorDestination.id, destination.id)
-            guard case MockError.😱 = error else { return XCTFail("unexpected error \(error)") }
         }
 
         log.removeMetadata(forKeys: testMetadataKeys)

--- a/Tests/AlicerceTests/Logging/Loggers/DummyLoggerTestCase.swift
+++ b/Tests/AlicerceTests/Logging/Loggers/DummyLoggerTestCase.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import Alicerce
+
+class DummyLoggerTestCase: XCTestCase {
+
+    func testLog() {
+        let log = Log.DummyLogger()
+
+        log.log(level: .verbose, message: "message", file: "filename.ext", line: 1337, function: "function")
+    }
+}

--- a/Tests/AlicerceTests/Logging/Loggers/LoggerTestCase.swift
+++ b/Tests/AlicerceTests/Logging/Loggers/LoggerTestCase.swift
@@ -76,6 +76,25 @@ class LoggerTestCase: XCTestCase {
 
         log.error("message", file: "filename.ext", line: 1337, function: "function")
     }
+
+    func testLog_WithLogDestination_ShouldInvokeWriteWithDefaultErrorClosure() {
+
+        enum MockError: Error { case 💣 }
+
+        let log = MockLogDestination()
+
+        log.writeInvokedClosure = { item, errorClosure in
+            XCTAssertEqual(item.level, .verbose)
+            XCTAssertEqual(item.message, "message")
+            XCTAssertEqual(item.file.description, "filename.ext")
+            XCTAssertEqual(item.line, 1337)
+            XCTAssertEqual(item.function.description, "function")
+
+            errorClosure(MockError.💣)
+        }
+
+        log.log(level: .verbose, message: "message", file: "filename.ext", line: 1337, function: "function")
+    }
 }
 
 private enum MockModule: String, LogModule {

--- a/Tests/AlicerceTests/Logging/Loggers/MetadataLoggerTestCase.swift
+++ b/Tests/AlicerceTests/Logging/Loggers/MetadataLoggerTestCase.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import Alicerce
+
+class MetadataLoggerTestCase: XCTestCase {
+
+    enum MockError: Error { case 💣 }
+    enum MockMetadataKey { case 👤, 📱, 📊 }
+
+    typealias MockLogDestination = MockMetadataLogDestination<Log.NoModule, MockMetadataKey>
+
+    func testSetMetadata_WithMetadataLogDestination_ShouldInvokeSetMetadataWithDefaultErrorClosure() {
+
+        let log = MockLogDestination()
+
+        let testMetadata: [MockMetadataKey : Any] = [.👤 : "Minder", .📱 : "iPhone 1337", .📊 : Double.pi]
+
+        log.setMetadataInvokedClosure = { metadata, errorClosure in
+            XCTAssertDumpsEqual(metadata, testMetadata)
+            errorClosure(MockError.💣)
+        }
+
+        log.setMetadata(testMetadata)
+    }
+
+    func testRemoveMetadata_WithMetadataLogDestination_ShouldInvokeRemoveMetadataWithDefaultErrorClosure() {
+
+        let log = MockLogDestination()
+
+        let testMetadataKeys: [MockMetadataKey] = [.👤, .📱, .📊]
+
+        log.removeMetadataInvokedClosure = { keys, errorClosure in
+            XCTAssertEqual(keys, testMetadataKeys)
+            errorClosure(MockError.💣)
+        }
+
+        log.removeMetadata(forKeys: testMetadataKeys)
+    }
+
+}

--- a/Tests/AlicerceTests/Logging/Loggers/ModuleLoggerTestCase.swift
+++ b/Tests/AlicerceTests/Logging/Loggers/ModuleLoggerTestCase.swift
@@ -84,6 +84,26 @@ class ModuleLoggerTestCase: XCTestCase {
         log.error(.🤖, "message", file: "filename.ext", line: 1337, function: "function")
     }
 
+    func testLog_WithLogDestination_ShouldInvokeWriteWithDefaultErrorClosure() {
+
+        enum MockError: Error { case 💣 }
+
+        let log = MockMetadataLogDestination<MockModule, Log.NoMetadataKey>()
+
+        log.writeInvokedClosure = { item, errorClosure in
+            XCTAssertEqual(item.module, MockModule.🤖.rawValue)
+            XCTAssertEqual(item.level, .info)
+            XCTAssertEqual(item.message, "message")
+            XCTAssertEqual(item.file.description, "filename.ext")
+            XCTAssertEqual(item.line, 1337)
+            XCTAssertEqual(item.function.description, "function")
+
+            errorClosure(MockError.💣)
+        }
+
+        log.log(module: .🤖, level: .info, message: "message", file: "filename.ext", line: 1337, function: "function")
+    }
+
     // no module
 
     func testVerbose_WithNilModule_ShouldInvokeLogWithCorrectLogLevel() {

--- a/Tests/AlicerceTests/Persistence/DiskMemoryPersistenceTestCase.swift
+++ b/Tests/AlicerceTests/Persistence/DiskMemoryPersistenceTestCase.swift
@@ -596,7 +596,7 @@ fileprivate func deleteItem(_ item: String) {
     do {
         try FileManager.default.removeItem(atPath: finalPath)
     } catch {
-        print("⚠️ Failed to remove file with error 👉 \(error)")
+        XCTFail("Failed to remove file with error: \(error)")
     }
 }
 


### PR DESCRIPTION
Until now, we were logging some errors and warnings via `print` calls, which couldn't be disabled or forwarded to any existing logger controlled by framework consumers.

To address this, a new internal logger was created, and all `print` calls were converted to log calls on this `Logger` instance (at `Log.internalLogger`). This logger is configurable from outside (`static var`) to enable framework consumers to change it.

This way, framework consumers can either disable Alicerce logging completely (by setting this property to a `Log.DummyLogger`), or pipe Alicerce logs to their own logging infrastructure by setting it to another `Logger` instance.

## Changes:

- Create `Log.internalLogger` property, which logs to the console by default.

- Update all `print` calls to use the new `Log.internalLogger`.

- Make `Logger` and `LogDestination` extend `AnyObject`.

- Create `Log.DummyLogger`, which is a logger that doesn't log anything.

- Create `Log.NoModule`, which is a `LogModule` that can't be created,
e.g. to allow using a `Log.DefaultLogger` without any module.

- Create `Log.NoMetadataKey`, which is a type that can't be created, e.g. to allow using a `Log.DefaultLogger` without any metadata.

- Create protocol extension to make `LogDestination` conform to `Logger.

- Create protocol extension to make `MetadataLogDestination` conform to
`MetadataLogger.

- Create protocol extension to make `LogDestination` partially conform to `ModuleLogger (i.e. only `log` is implemented).

- Added conformance to `Logger` and `MetadataLogger` to `Log.ConsoleLogDestination`.

- Add relevant UT's.