### PR TITLE
Make `APIError`'s great again ✊

### DIFF
--- a/Sources/Network/Network.swift
+++ b/Sources/Network/Network.swift
@@ -30,7 +30,8 @@ public enum Network {
         public typealias TotalRetriedDelay = ResourceRetry.Delay
 
         case noRequest(Swift.Error)
-        case http(HTTP.StatusCode, APIError?, URLResponse)
+        case http(HTTP.StatusCode, URLResponse)
+        case api(APIError, HTTP.StatusCode, URLResponse)
         case noData(URLResponse)
         case url(Swift.Error, URLResponse?)
         case badResponse(URLResponse?)
@@ -65,15 +66,15 @@ extension Network.Error {
         switch self {
         case .noRequest:
             return nil
-        case let .http(_, _, response):
+
+        case .http(_, let response),
+            .api(_, _, let response),
+            .noData(let response):
             return response
-        case let .noData(response):
-            return response
-        case let .url(_, response):
-            return response
-        case let .badResponse(response):
-            return response
-        case let .retry(_, _, _, response):
+
+        case .url(_, let response),
+             .badResponse(let response),
+             .retry(_, _, _, let response):
             return response
         }
     }

--- a/Sources/Resource/NetworkResource.swift
+++ b/Sources/Resource/NetworkResource.swift
@@ -7,8 +7,22 @@ public protocol NetworkResource: Resource {
     /// A type representing the network request.
     associatedtype Request
 
-    /// The resource's make request handler closure, invoked when the request generation finishes.
+    /// A type representing the network response.
+    associatedtype Response
+
+    /// A type representing an API error.
+    associatedtype APIError: Swift.Error
+
+    /// A resource's parse API error closure, invoked when a request fails with a protocol error in an attempt to
+    /// extract a custom API error.
+    typealias ParseAPIErrorClosure = (Remote?, Response) -> APIError?
+
+    /// A resource's make request handler closure, invoked when the request generation finishes.
     typealias MakeRequestHandler = (Result<Request, AnyError>) -> Cancelable
+
+    /// The resource's parse API error closure, invoked when a request fails with a protocol error in an attempt to
+    /// extract a custom API error.
+    var parseAPIError: ParseAPIErrorClosure { get }
 
     /// Generates a new request to fetch the resource (to be scheduled by the network client).
     ///

--- a/Sources/Resource/Resource.swift
+++ b/Sources/Resource/Resource.swift
@@ -1,14 +1,26 @@
 import Foundation
 
-public typealias ResourceMapClosure<U, V> = (U) throws -> V
-public typealias ResourceErrorParseClosure<R, E: Swift.Error> = (R) -> E?
-
+/// A type representing a resource.
 public protocol Resource {
-    associatedtype Remote
-    associatedtype Local
-    associatedtype Error: Swift.Error
 
-    var parse: ResourceMapClosure<Remote, Local> { get }
-    var serialize: ResourceMapClosure<Local, Remote> { get }
-    var errorParser: ResourceErrorParseClosure<Remote, Error> { get }
+    /// A resource's remote value type.
+    associatedtype Remote
+
+    /// A resource's local value type.
+    associatedtype Local
+
+    /// A resource's mapping closure, invoked to convert one type to another.
+    typealias MapClosure<U, V> = (U) throws -> V
+
+    /// A resource's parse closure, invoked to convert a remote value into a local one.
+    typealias ParseClosure = MapClosure<Remote, Local>
+
+    /// A resource's serialize closure, invoked to convert a local value into a remote one.
+    typealias SerializeClosure = MapClosure<Local, Remote>
+
+    /// A resource's parse closure, invoked to convert a remote value into a local one.
+    var parse: ParseClosure { get }
+
+    /// The resource's serialize closure, invoked to convert a local value into a remote one.
+    var serialize: SerializeClosure { get }
 }

--- a/Tests/AlicerceTests/Network/NetworkTestCase.swift
+++ b/Tests/AlicerceTests/Network/NetworkTestCase.swift
@@ -43,13 +43,15 @@ final class NetworkTestCase: XCTestCase {
                                        expectedContentLength: 1337,
                                        textEncodingName: nil)
 
-        let httpError = Network.Error.http(.unknownError(1337), nil, testResponse)
+        let httpError = Network.Error.http(.unknownError(1337), testResponse)
+        let apiError = Network.Error.api(DummyError.🕳, .unknownError(1337), testResponse)
         let noDataError = Network.Error.noData(testResponse)
         let urlError = Network.Error.url(DummyError.🕳, testResponse)
         let badResponseError = Network.Error.badResponse(testResponse)
         let retryError = Network.Error.retry([], 0, .cancelled, testResponse)
 
         XCTAssertEqual(httpError.response, testResponse)
+        XCTAssertEqual(apiError.response, testResponse)
         XCTAssertEqual(noDataError.response, testResponse)
         XCTAssertEqual(urlError.response, testResponse)
         XCTAssertEqual(badResponseError.response, testResponse)

--- a/Tests/AlicerceTests/PerformanceMetrics/NetworkStorePerformanceMetricsTrackerTestCase.swift
+++ b/Tests/AlicerceTests/PerformanceMetrics/NetworkStorePerformanceMetricsTrackerTestCase.swift
@@ -5,17 +5,15 @@ class NetworkStorePerformanceMetricsTrackerTestCase: XCTestCase {
 
     private struct MockResource: Resource {
 
-        var mockParse: (Remote) throws -> Local = { _ in throw MockError.💥 }
-
         enum MockError: Swift.Error { case 💥 }
+
+        var mockParse: ParseClosure = { _ in throw MockError.💥 }
 
         typealias Remote = String
         typealias Local = Int
-        typealias Error = MockError
 
-        var parse: ResourceMapClosure<Remote, Local> { return mockParse }
-        var serialize: ResourceMapClosure<Local, Remote> { fatalError() }
-        var errorParser: ResourceErrorParseClosure<Remote, Error> { fatalError() }
+        var parse: ParseClosure { return mockParse }
+        var serialize: SerializeClosure { fatalError() }
     }
 
     private var tracker: MockNetworkStorePerformanceMetricsTracker!

--- a/Tests/AlicerceTests/Resource/HTTPNetworkResourceTestCase.swift
+++ b/Tests/AlicerceTests/Resource/HTTPNetworkResourceTestCase.swift
@@ -36,8 +36,11 @@ class MockHTTPNetworkResource<T>: HTTPNetworkResource {
 
     typealias Remote = Data
     typealias Local = T
-    typealias Error = MockAPIError
+
     typealias Request = URLRequest
+    typealias Response = URLResponse
+    typealias APIError = MockAPIError
+
     typealias Endpoint = MockHTTPResourceEndpoint
 
     enum MockError: Swift.Error { case 😱, 😭 }
@@ -45,20 +48,20 @@ class MockHTTPNetworkResource<T>: HTTPNetworkResource {
 
     // Mocks
 
-    var mockParse: (Remote) throws -> Local = { _ in throw MockError.😱 }
-    var mockSerialize: (Local) throws -> Remote = { _ in throw MockError.😭 }
-    var mockErrorParser: (Remote) -> Error? = { _ in return MockAPIError.🤬 }
+    var mockParse: ParseClosure = { _ in throw MockError.😱 }
+    var mockSerialize: SerializeClosure = { _ in throw MockError.😭 }
+    var mockParseAPIError: ParseAPIErrorClosure = { _, _ in return MockAPIError.🤬 }
 
     var mockEndpoint: Endpoint = MockHTTPResourceEndpoint(baseURL: URL(string: "https://mindera.com")!)
 
     // Resource
 
-    var parse: (Remote) throws -> Local { return mockParse }
-    var serialize: (Local) throws -> Remote { return mockSerialize }
-    var errorParser: (Remote) -> Error? { return mockErrorParser }
+    var parse: ParseClosure { return mockParse }
+    var serialize: SerializeClosure { return mockSerialize }
 
     // NetworkResource
 
+    var parseAPIError: ParseAPIErrorClosure { return mockParseAPIError }
     static var empty: Remote { return Data() }
 
     // HTTPNetworkResource

--- a/Tests/AlicerceTests/Resource/MockResource.swift
+++ b/Tests/AlicerceTests/Resource/MockResource.swift
@@ -6,19 +6,19 @@ struct MockResource<T>: NetworkResource & RetryableResource & PersistableResourc
 
     typealias Remote = Data
     typealias Local = T
-    typealias Error = MockAPIError
 
     typealias Request = URLRequest
     typealias Response = URLResponse
+    typealias APIError = MockAPIError
 
     enum MockError: Swift.Error { case 💣, 🧨 }
     enum MockAPIError: Swift.Error { case 💩 }
 
     // Mocks
 
-    var mockParse: (Remote) throws -> Local = { _ in throw MockError.💣 }
-    var mockSerialize: (Local) throws -> Remote = { _ in throw MockError.🧨 }
-    var mockErrorParser: (Remote) -> Error? = { _ in return MockAPIError.💩 }
+    var mockParse: ParseClosure = { _ in throw MockError.💣 }
+    var mockSerialize: SerializeClosure = { _ in throw MockError.🧨 }
+    var mockParseAPIError: ParseAPIErrorClosure = { _, _ in return MockAPIError.💩 }
 
     var didInvokeMakeRequest: (() -> Void)?
     var didInvokeMakeRequestHandler: ((Cancelable) -> Void)?
@@ -32,12 +32,12 @@ struct MockResource<T>: NetworkResource & RetryableResource & PersistableResourc
 
     // Resource
 
-    var parse: (Remote) throws -> Local { return mockParse }
-    var serialize: (Local) throws -> Remote { return mockSerialize }
-    var errorParser: (Remote) -> Error? { return mockErrorParser }
+    var parse: ParseClosure { return mockParse }
+    var serialize: SerializeClosure { return mockSerialize }
 
     // NetworkResource
-    
+
+    var parseAPIError: ParseAPIErrorClosure { return mockParseAPIError }
     static var empty: Remote { return Data() }
 
     @discardableResult


### PR DESCRIPTION
Until now, custom API Error's resulting from `Resource`'s `errorParser` closure were returned inside a `Network.Error.http` error as an optional value. Even though they were available (and filterable) upstream, they were sort of a "second class citizen" in the overall network error picture.

Additionally, the API error parsing closure only received the remote payload, which greatly limited the amount of available information to be able to handle more complex scenarios where response information (such as HTTP status code and headers) is required.

To address the above issues, a new `Network.Error.api` error was created, and the resources' API error parsing closure was also updated to also receive the response.

## Changes:

- Create new `Network.Error.api` error.

- Remove `APIError?` from `Network.Error.http` error.

- Update `Network.URLSessionNetworkStack` to attempt extracting an
`APIError` whenever the status code isn't successful, even if no data
was returned.

- Move API Error parsing to `NetworkResource`:

  + Rename `errorParser` closure to `parseAPIError`.

  + Add `Response` and `APIError` `associatedType`'s.

- Reorganized `Resource`:

  + Move `typealias`'es inside protocol.

  + Create new `ParseClosure` and `SerializeClosure` `typealias`'es.

- Fix relevant UT's.