### PR TITLE
Add `_modify` accessor to `Atomic.value`

### DIFF
--- a/Sources/Utils/Atomic.swift
+++ b/Sources/Utils/Atomic.swift
@@ -28,10 +28,16 @@ public final class Atomic<Value> {
     private let lock: Lock
     private var _value: Value
 
-    /// Atomically get or set the value of the variable.
+    /// Atomically get, set or modify the value of the variable.
     public var value: Value {
         get { return withValue { $0 } }
         set(newValue) { swap(newValue) }
+        _modify {
+            lock.lock()
+            defer { lock.unlock() }
+
+            yield &_value
+        }
     }
 
     /// Initialize the variable with the given initial value.

--- a/Sources/Utils/Atomic.swift
+++ b/Sources/Utils/Atomic.swift
@@ -31,7 +31,7 @@ public final class Atomic<Value> {
     /// Atomically get, set or modify the value of the variable.
     public var value: Value {
         get { return withValue { $0 } }
-        set(newValue) { swap(newValue) }
+        set(newValue) { modify { $0 = newValue } }
         _modify {
             lock.lock()
             defer { lock.unlock() }

--- a/Tests/AlicerceTests/Utils/AtomicTestCase.swift
+++ b/Tests/AlicerceTests/Utils/AtomicTestCase.swift
@@ -26,6 +26,11 @@ class AtomicTestCase: XCTestCase {
         XCTAssertEqual(atomic.value, 1337)
     }
 
+    func testMutateInPlace_ShouldUpdateValue() {
+        atomic.value += 1337
+        XCTAssertEqual(atomic.value, 1337)
+    }
+
     func testSwap_ShouldSwapValue() {
         XCTAssertEqual(atomic.swap(1337), 0)
         XCTAssertEqual(atomic.value, 1337)


### PR DESCRIPTION
With Swift 5.0 the new `_modify` accessor became available, which allows a more efficient access to underlying storage when an in place mutation is made (i.e. via `inout`, like `value += 1`), by `yield`ing
a reference to the storage itself, instead of performing a copy (`get`) followed by a write (`set`).

This is particularly useful in containers where memory operations can become expensive (like collections), but also in containers wrapping expensive operations (like locking/unlocking locks).

Such is the case of `Atomic`, where besides optimizing memory access to the underlying storage, it can save a lock/unlock when the `.value` is modified in place (i.e. via `inout`). In this particular case, one can even claim that it’s more correct, because the whole mutation is truly made in a single atomic operation instead of two (as is already the case in the `modify(_:)` API).