### PR TITLE
Clear `viewModel` on base cells and reusable views

### DIFF
--- a/Sources/View/ViewModelCollectionReusableView.swift
+++ b/Sources/View/ViewModelCollectionReusableView.swift
@@ -9,4 +9,11 @@ open class ViewModelCollectionReusableView<ViewModel>: CollectionReusableView, R
     }
 
     open func setUpBindings() {}
+
+    open override func prepareForReuse() {
+
+        viewModel = nil
+
+        super.prepareForReuse()
+    }
 }

--- a/Sources/View/ViewModelCollectionReusableView.swift
+++ b/Sources/View/ViewModelCollectionReusableView.swift
@@ -12,8 +12,8 @@ open class ViewModelCollectionReusableView<ViewModel>: CollectionReusableView, R
 
     open override func prepareForReuse() {
 
-        viewModel = nil
-
         super.prepareForReuse()
+
+        viewModel = nil
     }
 }

--- a/Sources/View/ViewModelCollectionViewCell.swift
+++ b/Sources/View/ViewModelCollectionViewCell.swift
@@ -9,4 +9,11 @@ open class ViewModelCollectionViewCell<ViewModel>: CollectionViewCell, ReusableV
     }
 
     open func setUpBindings() {}
+
+    open override func prepareForReuse() {
+
+        viewModel = nil
+
+        super.prepareForReuse()
+    }
 }

--- a/Sources/View/ViewModelCollectionViewCell.swift
+++ b/Sources/View/ViewModelCollectionViewCell.swift
@@ -12,8 +12,8 @@ open class ViewModelCollectionViewCell<ViewModel>: CollectionViewCell, ReusableV
 
     open override func prepareForReuse() {
 
-        viewModel = nil
-
         super.prepareForReuse()
+
+        viewModel = nil
     }
 }

--- a/Sources/View/ViewModelTableViewCell.swift
+++ b/Sources/View/ViewModelTableViewCell.swift
@@ -9,4 +9,11 @@ open class ViewModelTableViewCell<ViewModel>: TableViewCell, ReusableViewModelVi
     }
 
     open func setUpBindings() {}
+
+    open override func prepareForReuse() {
+
+        viewModel = nil
+
+        super.prepareForReuse()
+    }
 }

--- a/Sources/View/ViewModelTableViewCell.swift
+++ b/Sources/View/ViewModelTableViewCell.swift
@@ -12,8 +12,8 @@ open class ViewModelTableViewCell<ViewModel>: TableViewCell, ReusableViewModelVi
 
     open override func prepareForReuse() {
 
-        viewModel = nil
-
         super.prepareForReuse()
+
+        viewModel = nil
     }
 }

--- a/Sources/View/ViewModelTableViewHeaderFooterView.swift
+++ b/Sources/View/ViewModelTableViewHeaderFooterView.swift
@@ -12,8 +12,8 @@ open class ViewModelTableViewHeaderFooterView<ViewModel>: TableViewHeaderFooterV
 
     open override func prepareForReuse() {
 
-        viewModel = nil
-
         super.prepareForReuse()
+
+        viewModel = nil
     }
 }

--- a/Sources/View/ViewModelTableViewHeaderFooterView.swift
+++ b/Sources/View/ViewModelTableViewHeaderFooterView.swift
@@ -9,4 +9,11 @@ open class ViewModelTableViewHeaderFooterView<ViewModel>: TableViewHeaderFooterV
     }
 
     open func setUpBindings() {}
+
+    open override func prepareForReuse() {
+
+        viewModel = nil
+
+        super.prepareForReuse()
+    }
 }

--- a/Tests/AlicerceTests/View/ViewModelCollectionReusableViewTestCase.swift
+++ b/Tests/AlicerceTests/View/ViewModelCollectionReusableViewTestCase.swift
@@ -7,6 +7,7 @@ final class MockViewModelCollectionReusableView: ViewModelCollectionReusableView
     private(set) var setUpSubviewsCallCount = 0
     private(set) var setUpConstraintsCallCount = 0
     private(set) var setUpBindingsCallCount = 0
+    private(set) var prepareForReuseCallCount = 0
 
     override func setUpSubviews() {
         super.setUpSubviews()
@@ -21,6 +22,11 @@ final class MockViewModelCollectionReusableView: ViewModelCollectionReusableView
     override func setUpBindings() {
         super.setUpBindings()
         setUpBindingsCallCount += 1
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        prepareForReuseCallCount += 1
     }
 }
 
@@ -59,5 +65,34 @@ final class ViewModelCollectionReusableViewTestCase: XCTestCase {
         XCTAssertNotNil(cell.viewModel)
         XCTAssertEqual(cell.viewModel, viewModel)
         XCTAssertEqual(cell.setUpBindingsCallCount, 1)
+    }
+
+    func testReuse_WithoutViewModel_ShouldEndWithoutViewModel() {
+
+        let cell = MockViewModelCollectionReusableView()
+
+        XCTAssertNil(cell.viewModel)
+
+        cell.prepareForReuse()
+
+        XCTAssertNil(cell.viewModel)
+        XCTAssertEqual(cell.setUpBindingsCallCount, 1)
+        XCTAssertEqual(cell.prepareForReuseCallCount, 1)
+    }
+
+    func testReuse_WithViewModel_ShouldEndWithoutViewModel() {
+
+        let cell = MockViewModelCollectionReusableView()
+
+        cell.viewModel = MockReusableViewModelView()
+
+        XCTAssertNotNil(cell.viewModel)
+        XCTAssertEqual(cell.setUpBindingsCallCount, 1)
+
+        cell.prepareForReuse()
+
+        XCTAssertNil(cell.viewModel)
+        XCTAssertEqual(cell.setUpBindingsCallCount, 2)
+        XCTAssertEqual(cell.prepareForReuseCallCount, 1)
     }
 }

--- a/Tests/AlicerceTests/View/ViewModelCollectionViewCellTestCase.swift
+++ b/Tests/AlicerceTests/View/ViewModelCollectionViewCellTestCase.swift
@@ -7,6 +7,7 @@ final class MockViewModelCollectionViewCell: ViewModelCollectionViewCell<MockReu
     private(set) var setUpSubviewsCallCount = 0
     private(set) var setUpConstraintsCallCount = 0
     private(set) var setUpBindingsCallCount = 0
+    private(set) var prepareForReuseCallCount = 0
 
     override func setUpSubviews() {
         super.setUpSubviews()
@@ -21,6 +22,11 @@ final class MockViewModelCollectionViewCell: ViewModelCollectionViewCell<MockReu
     override func setUpBindings() {
         super.setUpBindings()
         setUpBindingsCallCount += 1
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        prepareForReuseCallCount += 1
     }
 }
 
@@ -60,5 +66,34 @@ final class ViewModelCollectionViewCellTestCase: XCTestCase {
         XCTAssertNotNil(cell.viewModel)
         XCTAssertEqual(cell.viewModel, viewModel)
         XCTAssertEqual(cell.setUpBindingsCallCount, 1)
+    }
+
+    func testReuse_WithoutViewModel_ShouldEndWithoutViewModel() {
+
+        let cell = MockViewModelCollectionViewCell()
+
+        XCTAssertNil(cell.viewModel)
+
+        cell.prepareForReuse()
+
+        XCTAssertNil(cell.viewModel)
+        XCTAssertEqual(cell.setUpBindingsCallCount, 1)
+        XCTAssertEqual(cell.prepareForReuseCallCount, 1)
+    }
+
+    func testReuse_WithViewModel_ShouldEndWithoutViewModel() {
+
+        let cell = MockViewModelCollectionViewCell()
+
+        cell.viewModel = MockReusableViewModelView()
+
+        XCTAssertNotNil(cell.viewModel)
+        XCTAssertEqual(cell.setUpBindingsCallCount, 1)
+
+        cell.prepareForReuse()
+
+        XCTAssertNil(cell.viewModel)
+        XCTAssertEqual(cell.setUpBindingsCallCount, 2)
+        XCTAssertEqual(cell.prepareForReuseCallCount, 1)
     }
 }

--- a/Tests/AlicerceTests/View/ViewModelTableViewCellTestCase.swift
+++ b/Tests/AlicerceTests/View/ViewModelTableViewCellTestCase.swift
@@ -7,6 +7,7 @@ final class MockViewModelTableViewCell: ViewModelTableViewCell<MockReusableViewM
     private(set) var setUpSubviewsCallCount = 0
     private(set) var setUpConstraintsCallCount = 0
     private(set) var setUpBindingsCallCount = 0
+    private(set) var prepareForReuseCallCount = 0
 
     override func setUpSubviews() {
         super.setUpSubviews()
@@ -21,6 +22,11 @@ final class MockViewModelTableViewCell: ViewModelTableViewCell<MockReusableViewM
     override func setUpBindings() {
         super.setUpBindings()
         setUpBindingsCallCount += 1
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        prepareForReuseCallCount += 1
     }
 }
 
@@ -59,5 +65,34 @@ final class ViewModelTableViewCellTestCase: XCTestCase {
         XCTAssertNotNil(cell.viewModel)
         XCTAssertEqual(cell.viewModel, viewModel)
         XCTAssertEqual(cell.setUpBindingsCallCount, 1)
+    }
+
+    func testReuse_WithoutViewModel_ShouldEndWithoutViewModel() {
+
+        let cell = MockViewModelTableViewCell()
+
+        XCTAssertNil(cell.viewModel)
+
+        cell.prepareForReuse()
+
+        XCTAssertNil(cell.viewModel)
+        XCTAssertEqual(cell.setUpBindingsCallCount, 1)
+        XCTAssertEqual(cell.prepareForReuseCallCount, 1)
+    }
+
+    func testReuse_WithViewModel_ShouldEndWithoutViewModel() {
+
+        let cell = MockViewModelTableViewCell()
+
+        cell.viewModel = MockReusableViewModelView()
+
+        XCTAssertNotNil(cell.viewModel)
+        XCTAssertEqual(cell.setUpBindingsCallCount, 1)
+
+        cell.prepareForReuse()
+
+        XCTAssertNil(cell.viewModel)
+        XCTAssertEqual(cell.setUpBindingsCallCount, 2)
+        XCTAssertEqual(cell.prepareForReuseCallCount, 1)
     }
 }

--- a/Tests/AlicerceTests/View/ViewModelTableViewHeaderFooterViewTestCase.swift
+++ b/Tests/AlicerceTests/View/ViewModelTableViewHeaderFooterViewTestCase.swift
@@ -7,6 +7,7 @@ final class MockViewModelTableViewHeaderFooterView: ViewModelTableViewHeaderFoot
     private(set) var setUpSubviewsCallCount = 0
     private(set) var setUpConstraintsCallCount = 0
     private(set) var setUpBindingsCallCount = 0
+    private(set) var prepareForReuseCallCount = 0
 
     override func setUpSubviews() {
         super.setUpSubviews()
@@ -21,6 +22,11 @@ final class MockViewModelTableViewHeaderFooterView: ViewModelTableViewHeaderFoot
     override func setUpBindings() {
         super.setUpBindings()
         setUpBindingsCallCount += 1
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        prepareForReuseCallCount += 1
     }
 }
 
@@ -59,5 +65,34 @@ final class ViewModelTableViewHeaderFooterViewTestCase: XCTestCase {
         XCTAssertNotNil(cell.viewModel)
         XCTAssertEqual(cell.viewModel, viewModel)
         XCTAssertEqual(cell.setUpBindingsCallCount, 1)
+    }
+
+    func testReuse_WithoutViewModel_ShouldEndWithoutViewModel() {
+
+        let cell = MockViewModelTableViewHeaderFooterView()
+
+        XCTAssertNil(cell.viewModel)
+
+        cell.prepareForReuse()
+
+        XCTAssertNil(cell.viewModel)
+        XCTAssertEqual(cell.setUpBindingsCallCount, 1)
+        XCTAssertEqual(cell.prepareForReuseCallCount, 1)
+    }
+
+    func testReuse_WithViewModel_ShouldEndWithoutViewModel() {
+
+        let cell = MockViewModelTableViewHeaderFooterView()
+
+        cell.viewModel = MockReusableViewModelView()
+
+        XCTAssertNotNil(cell.viewModel)
+        XCTAssertEqual(cell.setUpBindingsCallCount, 1)
+
+        cell.prepareForReuse()
+
+        XCTAssertNil(cell.viewModel)
+        XCTAssertEqual(cell.setUpBindingsCallCount, 2)
+        XCTAssertEqual(cell.prepareForReuseCallCount, 1)
     }
 }


### PR DESCRIPTION
### Checklist
- [x] I've rebased my changes on top of `master`
- [x] I've built and run the project to see all new and existing tests pass
- [x] I've followed the [Mindera swift style guide](https://github.com/Mindera/swift-style-guide)
- [x] I've read the [Contribution Guidelines](https://github.com/Mindera/Alicerce/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
To ensure the view/cell is on a pristine state when reused, the view model should be cleared on `prepareForReuse`. This default implementation also leads to the view model being set and unset in the same place. This PR closes issue [203](https://github.com/Mindera/Alicerce/issues/203).
