### PR TITLE
Fix ReusableView unit tests on iOS 13 /  Xcode 11

### DIFF
--- a/Tests/AlicerceTests/View/ReusableViewCollectionViewTestCase.swift
+++ b/Tests/AlicerceTests/View/ReusableViewCollectionViewTestCase.swift
@@ -4,6 +4,7 @@ import UIKit
 
 class ReusableViewCollectionViewTestCase: XCTestCase {
 
+    private var window: UIWindow!
     private var collectionViewController: TestCollectionViewController!
     private var collectionView: UICollectionView! { return collectionViewController.collectionView }
     private var collectionViewLayout: UICollectionViewFlowLayout! {
@@ -13,10 +14,15 @@ class ReusableViewCollectionViewTestCase: XCTestCase {
     override func setUp() {
         super.setUp()
 
+        window = UIWindow()
         collectionViewController = TestCollectionViewController(collectionViewLayout: UICollectionViewFlowLayout())
+
+        window.rootViewController = collectionViewController
+        window.makeKeyAndVisible()
     }
 
     override func tearDown() {
+        window = nil
         collectionViewController = nil
 
         super.tearDown()

--- a/Tests/AlicerceTests/View/ReusableViewTableViewTestCase.swift
+++ b/Tests/AlicerceTests/View/ReusableViewTableViewTestCase.swift
@@ -4,16 +4,23 @@ import UIKit
 
 class ReusableViewTableViewTestCase: XCTestCase {
 
+    private var window: UIWindow!
     private var tableViewController: TestTableViewController!
     private var tableView: UITableView! { return tableViewController.tableView }
 
     override func setUp() {
         super.setUp()
 
+        window = UIWindow()
+
         tableViewController = TestTableViewController()
+
+        window.rootViewController = tableViewController
+        window.makeKeyAndVisible()
     }
 
     override func tearDown() {
+        window = nil
         tableViewController = nil
 
         super.tearDown()


### PR DESCRIPTION
<!-- Thanks for contributing to _Alicerce 🏗_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've rebased my changes on top of `master`
- [x] I've built and run the project to see all new and existing tests pass
- [x] I've followed the [Mindera swift style guide](https://github.com/Mindera/swift-style-guide)
- [x] I've read the [Contribution Guidelines](https://github.com/Mindera/Alicerce/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Probably due to some underlying changes in UIKit for iOS 13 (Xcode 11), our tests for `ReusableViewCollectionView` and `ReusableViewTableView` stopped working because the cells weren't being "drawn" on their respective container views despite we forcing the `layoutIfNeeded`.

To address this, the respective container VCs were added to a `UIWindow` as its `rootViewController`, which solved the issue.

### Description

- Make `ReusableViewCollectionViewTestCase` and `ReusableViewTableViewTestCase`'s container VC's be added as `rootViewController` of a dummy `UIWindow`, which is made key and visible.