### PR TITLE
Auto layout DSL

### DIFF
--- a/Alicerce.podspec
+++ b/Alicerce.podspec
@@ -30,6 +30,11 @@ Pod::Spec.new do |s|
         ss.dependency 'Alicerce/Core'
     end
 
+    s.subspec 'AutoLayout' do |ss|
+        ss.source_files = 'Sources/AutoLayout/*.swift'
+        ss.frameworks   = 'UIKit'
+    end
+
     s.subspec 'DeepLinking' do |ss|
         ss.source_files = 'Sources/DeepLinking/**/*.swift'
         ss.dependency 'Alicerce/Core'

--- a/Alicerce.xcodeproj/project.pbxproj
+++ b/Alicerce.xcodeproj/project.pbxproj
@@ -309,6 +309,7 @@
 		1B7166BC216BE424008A8A46 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 1B7166B9216BE402008A8A46 /* Localizable.strings */; };
 		1BBEB6091F333E5600D06526 /* UIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BBEB6081F333E5600D06526 /* UIImage.swift */; };
 		1BBEB60C1F333E6E00D06526 /* UIImageTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BBEB60A1F333E6600D06526 /* UIImageTestCase.swift */; };
+		4833D5B423D0D2CE00EBD925 /* WidthConstrainableProxyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4833D5B223D0D28C00EBD925 /* WidthConstrainableProxyTestCase.swift */; };
 		4838FE3023A94CE0007311F0 /* ConstrainableProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4838FE2823A94CE0007311F0 /* ConstrainableProxy.swift */; };
 		4838FE3123A94CE0007311F0 /* Array+ConstrainableProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4838FE2923A94CE0007311F0 /* Array+ConstrainableProxy.swift */; };
 		4838FE3223A94CE0007311F0 /* ConstraintRelation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4838FE2A23A94CE0007311F0 /* ConstraintRelation.swift */; };
@@ -328,6 +329,11 @@
 		4838FE5723A951E6007311F0 /* TopConstrainableProxyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4838FE4023A950CA007311F0 /* TopConstrainableProxyTestCase.swift */; };
 		4838FE5823A951E9007311F0 /* TrailingConstrainableProxyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4838FE3B23A950CA007311F0 /* TrailingConstrainableProxyTestCase.swift */; };
 		4838FE5923A951ED007311F0 /* XCTAssertConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4838FE3C23A950CA007311F0 /* XCTAssertConstraint.swift */; };
+		48BF456523D1CFCA00DFBB28 /* HeightConstrainableProxyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BF456323D1CFB300DFBB28 /* HeightConstrainableProxyTestCase.swift */; };
+		48BF456823D1D2C200DFBB28 /* CenterXConstrainableProxyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BF456623D1D26F00DFBB28 /* CenterXConstrainableProxyTestCase.swift */; };
+		48BF456B23D1D4AA00DFBB28 /* CenterYConstrainableProxyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BF456923D1D4A300DFBB28 /* CenterYConstrainableProxyTestCase.swift */; };
+		48BF457123D1FD1D00DFBB28 /* CenterConstrainableProxyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BF456F23D1FD0C00DFBB28 /* CenterConstrainableProxyTestCase.swift */; };
+		48BF457423D204E600DFBB28 /* SizeConstrainableProxyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BF457223D204DC00DFBB28 /* SizeConstrainableProxyTestCase.swift */; };
 		65D46CB5203C90E5008E847B /* PersistencePerformanceMetricsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D46CB4203C90E5008E847B /* PersistencePerformanceMetricsTracker.swift */; };
 		68DCF2391F7D0C1400D6BB88 /* StrategyFetchResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68DCF2381F7D0C1400D6BB88 /* StrategyFetchResource.swift */; };
 		73C6051B20F3BBA300D0B643 /* Token.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73C6051A20F3BBA300D0B643 /* Token.swift */; };
@@ -648,6 +654,7 @@
 		1B7166CD216C231E008A8A46 /* StringTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringTestCase.swift; sourceTree = "<group>"; };
 		1BBEB6081F333E5600D06526 /* UIImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImage.swift; sourceTree = "<group>"; };
 		1BBEB60A1F333E6600D06526 /* UIImageTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImageTestCase.swift; sourceTree = "<group>"; };
+		4833D5B223D0D28C00EBD925 /* WidthConstrainableProxyTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidthConstrainableProxyTestCase.swift; sourceTree = "<group>"; };
 		4838FE2823A94CE0007311F0 /* ConstrainableProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConstrainableProxy.swift; sourceTree = "<group>"; };
 		4838FE2923A94CE0007311F0 /* Array+ConstrainableProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+ConstrainableProxy.swift"; sourceTree = "<group>"; };
 		4838FE2A23A94CE0007311F0 /* ConstraintRelation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConstraintRelation.swift; sourceTree = "<group>"; };
@@ -667,6 +674,11 @@
 		4838FE4123A950CB007311F0 /* BaseConstrainableProxyTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseConstrainableProxyTestCase.swift; sourceTree = "<group>"; };
 		4838FE4223A950CB007311F0 /* LeftConstrainableProxyTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LeftConstrainableProxyTestCase.swift; sourceTree = "<group>"; };
 		4838FE4323A950CB007311F0 /* EdgesConstrainableProxyTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EdgesConstrainableProxyTestCase.swift; sourceTree = "<group>"; };
+		48BF456323D1CFB300DFBB28 /* HeightConstrainableProxyTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeightConstrainableProxyTestCase.swift; sourceTree = "<group>"; };
+		48BF456623D1D26F00DFBB28 /* CenterXConstrainableProxyTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterXConstrainableProxyTestCase.swift; sourceTree = "<group>"; };
+		48BF456923D1D4A300DFBB28 /* CenterYConstrainableProxyTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterYConstrainableProxyTestCase.swift; sourceTree = "<group>"; };
+		48BF456F23D1FD0C00DFBB28 /* CenterConstrainableProxyTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterConstrainableProxyTestCase.swift; sourceTree = "<group>"; };
+		48BF457223D204DC00DFBB28 /* SizeConstrainableProxyTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SizeConstrainableProxyTestCase.swift; sourceTree = "<group>"; };
 		65D46CB4203C90E5008E847B /* PersistencePerformanceMetricsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistencePerformanceMetricsTracker.swift; sourceTree = "<group>"; };
 		68DCF2381F7D0C1400D6BB88 /* StrategyFetchResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StrategyFetchResource.swift; sourceTree = "<group>"; };
 		73C6051A20F3BBA300D0B643 /* Token.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Token.swift; sourceTree = "<group>"; };
@@ -1495,14 +1507,20 @@
 			children = (
 				4838FE4123A950CB007311F0 /* BaseConstrainableProxyTestCase.swift */,
 				4838FE3923A950CA007311F0 /* BottomConstrainableProxyTestCase.swift */,
+				48BF456F23D1FD0C00DFBB28 /* CenterConstrainableProxyTestCase.swift */,
+				48BF456623D1D26F00DFBB28 /* CenterXConstrainableProxyTestCase.swift */,
+				48BF456923D1D4A300DFBB28 /* CenterYConstrainableProxyTestCase.swift */,
 				4838FE4323A950CB007311F0 /* EdgesConstrainableProxyTestCase.swift */,
+				48BF456323D1CFB300DFBB28 /* HeightConstrainableProxyTestCase.swift */,
 				4838FE3F23A950CA007311F0 /* LeadingConstrainableProxyTestCase.swift */,
 				4838FE4223A950CB007311F0 /* LeftConstrainableProxyTestCase.swift */,
 				4838FE3D23A950CA007311F0 /* NSLayoutConstraint+TestHelpers.swift */,
 				4838FE3E23A950CA007311F0 /* NSLayoutConstraintTestCase.swift */,
 				4838FE3A23A950CA007311F0 /* RightConstrainableProxyTestCase.swift */,
+				48BF457223D204DC00DFBB28 /* SizeConstrainableProxyTestCase.swift */,
 				4838FE4023A950CA007311F0 /* TopConstrainableProxyTestCase.swift */,
 				4838FE3B23A950CA007311F0 /* TrailingConstrainableProxyTestCase.swift */,
+				4833D5B223D0D28C00EBD925 /* WidthConstrainableProxyTestCase.swift */,
 				4838FE3C23A950CA007311F0 /* XCTAssertConstraint.swift */,
 			);
 			path = AutoLayout;
@@ -1843,6 +1861,7 @@
 				0A266F921ED59FB6009CD0D7 /* Route+TrieNode_InitTests.swift in Sources */,
 				0A266F931ED59FB6009CD0D7 /* Route+TrieNode_MatchTests.swift in Sources */,
 				0A77982920FCCD24008E269A /* RetryTestCase.swift in Sources */,
+				48BF456B23D1D4AA00DFBB28 /* CenterYConstrainableProxyTestCase.swift in Sources */,
 				0A3236E120D87E4C00D225CB /* LogDestinationTestCase.swift in Sources */,
 				0AD6ACBF20B58896001426B8 /* ServerTrustEvaluator+ConfigurationTestCase.swift in Sources */,
 				0A266F941ED59FB6009CD0D7 /* Route+TrieNode_RemoveTests.swift in Sources */,
@@ -1894,6 +1913,7 @@
 				0A166EDE2210905B00EC6686 /* NestedContextCoreDataStackTestCase.swift in Sources */,
 				4838FE5423A951DB007311F0 /* LeftConstrainableProxyTestCase.swift in Sources */,
 				0A266FA41ED59FB6009CD0D7 /* MockNetworkStack.swift in Sources */,
+				48BF456523D1CFCA00DFBB28 /* HeightConstrainableProxyTestCase.swift in Sources */,
 				0A266FA51ED59FB6009CD0D7 /* URLSessionNetworkStack+ErrorTestCase.swift in Sources */,
 				0A3236E520D88C9800D225CB /* DispatchQueueTestCase.swift in Sources */,
 				0A266FA61ED59FB6009CD0D7 /* ParseTestCase.swift in Sources */,
@@ -1908,6 +1928,7 @@
 				0A266FAA1ED59FB6009CD0D7 /* MockCoreDataStack.swift in Sources */,
 				0AFB0DC620F8E77300A58515 /* MockURLSessionDataTask.swift in Sources */,
 				0A76A006209F868C00D46B63 /* Route+TrieNode_IsEmptyAndDescriptionTests.swift in Sources */,
+				4833D5B423D0D2CE00EBD925 /* WidthConstrainableProxyTestCase.swift in Sources */,
 				0A5836E820CF41C10090E987 /* Log+Item.swift in Sources */,
 				0A11894820F3BAB800AF8229 /* MockPerformanceMetricsTracker.swift in Sources */,
 				0A265E1D20EAEA8A00A55ED9 /* BoxTestCase.swift in Sources */,
@@ -1926,6 +1947,7 @@
 				0AFB0DCA20F8E7AE00A58515 /* MockRequestAuthenticator.swift in Sources */,
 				1BBEB60C1F333E6E00D06526 /* UIImageTestCase.swift in Sources */,
 				0AECE6812177741A003A2509 /* MockCancelable.swift in Sources */,
+				48BF457123D1FD1D00DFBB28 /* CenterConstrainableProxyTestCase.swift in Sources */,
 				9DEC00AE209A052300F94353 /* BuilderCacheTestCase.swift in Sources */,
 				0A266FB11ED59FB6009CD0D7 /* NetworkPersistableStoreTestCase.swift in Sources */,
 				0AFB0DD220F8FD1C00A58515 /* RetryableResourceTestCase.swift in Sources */,
@@ -1955,7 +1977,9 @@
 				0AECE68521777A86003A2509 /* CancelableBagTestCase.swift in Sources */,
 				0A266FB81ED59FB6009CD0D7 /* ServiceLocatorTests.swift in Sources */,
 				1B4033651ED8CA5F00B4B03D /* ViewModelCollectionViewCellTestCase.swift in Sources */,
+				48BF457423D204E600DFBB28 /* SizeConstrainableProxyTestCase.swift in Sources */,
 				0A266FB91ED59FB6009CD0D7 /* AssertDumpsEqualTestCase.swift in Sources */,
+				48BF456823D1D2C200DFBB28 /* CenterXConstrainableProxyTestCase.swift in Sources */,
 				0AECE67E21776E22003A2509 /* WeakCancelableTestCase.swift in Sources */,
 				0AA061022273B4F80052B4A1 /* TestNIBCollectionReusableView.swift in Sources */,
 				0A266FBA1ED59FB6009CD0D7 /* TestUtils.swift in Sources */,

--- a/Alicerce.xcodeproj/project.pbxproj
+++ b/Alicerce.xcodeproj/project.pbxproj
@@ -309,6 +309,25 @@
 		1B7166BC216BE424008A8A46 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 1B7166B9216BE402008A8A46 /* Localizable.strings */; };
 		1BBEB6091F333E5600D06526 /* UIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BBEB6081F333E5600D06526 /* UIImage.swift */; };
 		1BBEB60C1F333E6E00D06526 /* UIImageTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BBEB60A1F333E6600D06526 /* UIImageTestCase.swift */; };
+		4838FE3023A94CE0007311F0 /* ConstrainableProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4838FE2823A94CE0007311F0 /* ConstrainableProxy.swift */; };
+		4838FE3123A94CE0007311F0 /* Array+ConstrainableProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4838FE2923A94CE0007311F0 /* Array+ConstrainableProxy.swift */; };
+		4838FE3223A94CE0007311F0 /* ConstraintRelation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4838FE2A23A94CE0007311F0 /* ConstraintRelation.swift */; };
+		4838FE3323A94CE0007311F0 /* ViewProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4838FE2B23A94CE0007311F0 /* ViewProxy.swift */; };
+		4838FE3423A94CE0007311F0 /* NSLayoutConstraint+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4838FE2C23A94CE0007311F0 /* NSLayoutConstraint+Helpers.swift */; };
+		4838FE3523A94CE0007311F0 /* Constrain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4838FE2D23A94CE0007311F0 /* Constrain.swift */; };
+		4838FE3623A94CE0007311F0 /* LayoutGuideProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4838FE2E23A94CE0007311F0 /* LayoutGuideProxy.swift */; };
+		4838FE3723A94CE0007311F0 /* LayoutItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4838FE2F23A94CE0007311F0 /* LayoutItem.swift */; };
+		4838FE4F23A951C8007311F0 /* NSLayoutConstraint+TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4838FE3D23A950CA007311F0 /* NSLayoutConstraint+TestHelpers.swift */; };
+		4838FE5023A951CF007311F0 /* BaseConstrainableProxyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4838FE4123A950CB007311F0 /* BaseConstrainableProxyTestCase.swift */; };
+		4838FE5123A951D2007311F0 /* BottomConstrainableProxyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4838FE3923A950CA007311F0 /* BottomConstrainableProxyTestCase.swift */; };
+		4838FE5223A951D5007311F0 /* EdgesConstrainableProxyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4838FE4323A950CB007311F0 /* EdgesConstrainableProxyTestCase.swift */; };
+		4838FE5323A951D8007311F0 /* LeadingConstrainableProxyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4838FE3F23A950CA007311F0 /* LeadingConstrainableProxyTestCase.swift */; };
+		4838FE5423A951DB007311F0 /* LeftConstrainableProxyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4838FE4223A950CB007311F0 /* LeftConstrainableProxyTestCase.swift */; };
+		4838FE5523A951DF007311F0 /* NSLayoutConstraintTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4838FE3E23A950CA007311F0 /* NSLayoutConstraintTestCase.swift */; };
+		4838FE5623A951E3007311F0 /* RightConstrainableProxyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4838FE3A23A950CA007311F0 /* RightConstrainableProxyTestCase.swift */; };
+		4838FE5723A951E6007311F0 /* TopConstrainableProxyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4838FE4023A950CA007311F0 /* TopConstrainableProxyTestCase.swift */; };
+		4838FE5823A951E9007311F0 /* TrailingConstrainableProxyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4838FE3B23A950CA007311F0 /* TrailingConstrainableProxyTestCase.swift */; };
+		4838FE5923A951ED007311F0 /* XCTAssertConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4838FE3C23A950CA007311F0 /* XCTAssertConstraint.swift */; };
 		65D46CB5203C90E5008E847B /* PersistencePerformanceMetricsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D46CB4203C90E5008E847B /* PersistencePerformanceMetricsTracker.swift */; };
 		68DCF2391F7D0C1400D6BB88 /* StrategyFetchResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68DCF2381F7D0C1400D6BB88 /* StrategyFetchResource.swift */; };
 		73C6051B20F3BBA300D0B643 /* Token.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73C6051A20F3BBA300D0B643 /* Token.swift */; };
@@ -629,6 +648,25 @@
 		1B7166CD216C231E008A8A46 /* StringTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringTestCase.swift; sourceTree = "<group>"; };
 		1BBEB6081F333E5600D06526 /* UIImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImage.swift; sourceTree = "<group>"; };
 		1BBEB60A1F333E6600D06526 /* UIImageTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImageTestCase.swift; sourceTree = "<group>"; };
+		4838FE2823A94CE0007311F0 /* ConstrainableProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConstrainableProxy.swift; sourceTree = "<group>"; };
+		4838FE2923A94CE0007311F0 /* Array+ConstrainableProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+ConstrainableProxy.swift"; sourceTree = "<group>"; };
+		4838FE2A23A94CE0007311F0 /* ConstraintRelation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConstraintRelation.swift; sourceTree = "<group>"; };
+		4838FE2B23A94CE0007311F0 /* ViewProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewProxy.swift; sourceTree = "<group>"; };
+		4838FE2C23A94CE0007311F0 /* NSLayoutConstraint+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSLayoutConstraint+Helpers.swift"; sourceTree = "<group>"; };
+		4838FE2D23A94CE0007311F0 /* Constrain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constrain.swift; sourceTree = "<group>"; };
+		4838FE2E23A94CE0007311F0 /* LayoutGuideProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LayoutGuideProxy.swift; sourceTree = "<group>"; };
+		4838FE2F23A94CE0007311F0 /* LayoutItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LayoutItem.swift; sourceTree = "<group>"; };
+		4838FE3923A950CA007311F0 /* BottomConstrainableProxyTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BottomConstrainableProxyTestCase.swift; sourceTree = "<group>"; };
+		4838FE3A23A950CA007311F0 /* RightConstrainableProxyTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RightConstrainableProxyTestCase.swift; sourceTree = "<group>"; };
+		4838FE3B23A950CA007311F0 /* TrailingConstrainableProxyTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrailingConstrainableProxyTestCase.swift; sourceTree = "<group>"; };
+		4838FE3C23A950CA007311F0 /* XCTAssertConstraint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = XCTAssertConstraint.swift; sourceTree = "<group>"; };
+		4838FE3D23A950CA007311F0 /* NSLayoutConstraint+TestHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSLayoutConstraint+TestHelpers.swift"; sourceTree = "<group>"; };
+		4838FE3E23A950CA007311F0 /* NSLayoutConstraintTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSLayoutConstraintTestCase.swift; sourceTree = "<group>"; };
+		4838FE3F23A950CA007311F0 /* LeadingConstrainableProxyTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LeadingConstrainableProxyTestCase.swift; sourceTree = "<group>"; };
+		4838FE4023A950CA007311F0 /* TopConstrainableProxyTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TopConstrainableProxyTestCase.swift; sourceTree = "<group>"; };
+		4838FE4123A950CB007311F0 /* BaseConstrainableProxyTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseConstrainableProxyTestCase.swift; sourceTree = "<group>"; };
+		4838FE4223A950CB007311F0 /* LeftConstrainableProxyTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LeftConstrainableProxyTestCase.swift; sourceTree = "<group>"; };
+		4838FE4323A950CB007311F0 /* EdgesConstrainableProxyTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EdgesConstrainableProxyTestCase.swift; sourceTree = "<group>"; };
 		65D46CB4203C90E5008E847B /* PersistencePerformanceMetricsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistencePerformanceMetricsTracker.swift; sourceTree = "<group>"; };
 		68DCF2381F7D0C1400D6BB88 /* StrategyFetchResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StrategyFetchResource.swift; sourceTree = "<group>"; };
 		73C6051A20F3BBA300D0B643 /* Token.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Token.swift; sourceTree = "<group>"; };
@@ -1437,10 +1475,44 @@
 			path = PerformanceMetrics;
 			sourceTree = "<group>";
 		};
+		4838FE2723A94CAB007311F0 /* AutoLayout */ = {
+			isa = PBXGroup;
+			children = (
+				4838FE2923A94CE0007311F0 /* Array+ConstrainableProxy.swift */,
+				4838FE2D23A94CE0007311F0 /* Constrain.swift */,
+				4838FE2823A94CE0007311F0 /* ConstrainableProxy.swift */,
+				4838FE2A23A94CE0007311F0 /* ConstraintRelation.swift */,
+				4838FE2E23A94CE0007311F0 /* LayoutGuideProxy.swift */,
+				4838FE2F23A94CE0007311F0 /* LayoutItem.swift */,
+				4838FE2C23A94CE0007311F0 /* NSLayoutConstraint+Helpers.swift */,
+				4838FE2B23A94CE0007311F0 /* ViewProxy.swift */,
+			);
+			path = AutoLayout;
+			sourceTree = "<group>";
+		};
+		4838FE3823A9508E007311F0 /* AutoLayout */ = {
+			isa = PBXGroup;
+			children = (
+				4838FE4123A950CB007311F0 /* BaseConstrainableProxyTestCase.swift */,
+				4838FE3923A950CA007311F0 /* BottomConstrainableProxyTestCase.swift */,
+				4838FE4323A950CB007311F0 /* EdgesConstrainableProxyTestCase.swift */,
+				4838FE3F23A950CA007311F0 /* LeadingConstrainableProxyTestCase.swift */,
+				4838FE4223A950CB007311F0 /* LeftConstrainableProxyTestCase.swift */,
+				4838FE3D23A950CA007311F0 /* NSLayoutConstraint+TestHelpers.swift */,
+				4838FE3E23A950CA007311F0 /* NSLayoutConstraintTestCase.swift */,
+				4838FE3A23A950CA007311F0 /* RightConstrainableProxyTestCase.swift */,
+				4838FE4023A950CA007311F0 /* TopConstrainableProxyTestCase.swift */,
+				4838FE3B23A950CA007311F0 /* TrailingConstrainableProxyTestCase.swift */,
+				4838FE3C23A950CA007311F0 /* XCTAssertConstraint.swift */,
+			);
+			path = AutoLayout;
+			sourceTree = "<group>";
+		};
 		OBJ_10 /* AlicerceTests */ = {
 			isa = PBXGroup;
 			children = (
 				0A3C2D071EA7E1EE00EFB7D4 /* AlicerceTests-Bridging-Header.h */,
+				4838FE3823A9508E007311F0 /* AutoLayout */,
 				1B57E9861EB15F3C0027AB30 /* Analytics */,
 				0A3C2D091EA7E1EE00EFB7D4 /* DeepLinking */,
 				0A7CC0ED208FF76B009F3A6E /* Extensions */,
@@ -1485,6 +1557,7 @@
 		OBJ_7 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				4838FE2723A94CAB007311F0 /* AutoLayout */,
 				1B57E97B1EB150AB0027AB30 /* Analytics */,
 				0A3C2C821EA7E18500EFB7D4 /* DeepLinking */,
 				0A3C2C881EA7E18500EFB7D4 /* Extensions */,
@@ -1759,6 +1832,7 @@
 				0A439C5D232E899D004813BD /* Route+TrieNode_TestUtils.swift in Sources */,
 				0AA061012273B4F80052B4A1 /* TestNIBTableHeaderFooterView.swift in Sources */,
 				0A266FBF1ED59FCD009CD0D7 /* EmptyCoreDataStackModel.xcdatamodeld in Sources */,
+				4838FE5723A951E6007311F0 /* TopConstrainableProxyTestCase.swift in Sources */,
 				0A708F6E20E99D9F001784DA /* MockAnalyticsTracker.swift in Sources */,
 				0A266F8C1ED59FB6009CD0D7 /* MultiTrackerTestCase.swift in Sources */,
 				0A85F0E720B3177E0095AFFB /* PublicKeyAlgorithmTestCase.swift in Sources */,
@@ -1775,6 +1849,7 @@
 				0A266F951ED59FB6009CD0D7 /* Route+TrieRouter_RegisterTests.swift in Sources */,
 				0A266F961ED59FB6009CD0D7 /* DataTestCase.swift in Sources */,
 				0A266F971ED59FB6009CD0D7 /* OptionalTests.swift in Sources */,
+				4838FE5323A951D8007311F0 /* LeadingConstrainableProxyTestCase.swift in Sources */,
 				0AFB0DCC20F8E7F400A58515 /* MockRequestInterceptor.swift in Sources */,
 				0A166EE92210C59200EC6686 /* TestEntity+Utils.swift in Sources */,
 				0AA061032273B4F80052B4A1 /* TestNIBTableViewCell.swift in Sources */,
@@ -1785,11 +1860,14 @@
 				0AB34A062085385A001F2979 /* UnfairLockTestCase.swift in Sources */,
 				0A266F9B1ED59FB6009CD0D7 /* MockMetadataLogDestination.swift in Sources */,
 				9D4E3AA3239A6841007F3050 /* CollectionReusableViewSizerTestCase.swift in Sources */,
+				4838FE5623A951E3007311F0 /* RightConstrainableProxyTestCase.swift in Sources */,
 				0A72EB44225158EE00540C67 /* MetadataLoggerTestCase.swift in Sources */,
+				4838FE5823A951E9007311F0 /* TrailingConstrainableProxyTestCase.swift in Sources */,
 				0AFB0DCE20F8E81700A58515 /* MockAuthenticationChallengeHandler.swift in Sources */,
 				0AFB0DC720F8E77700A58515 /* MockURLSession.swift in Sources */,
 				0AB34A0820853873001F2979 /* PthreadLockTestCase.swift in Sources */,
 				0A166EE22210B83100EC6686 /* CoreDataStack+ManagedObjectReflectableTestCase.swift in Sources */,
+				4838FE4F23A951C8007311F0 /* NSLayoutConstraint+TestHelpers.swift in Sources */,
 				0A3236E720D88ED400D225CB /* LoggerTestCase.swift in Sources */,
 				0A266F9C1ED59FB6009CD0D7 /* FileLogDestinationTestCase.swift in Sources */,
 				73C6051D20F3BD0E00D0B643 /* TokenTests.swift in Sources */,
@@ -1799,9 +1877,11 @@
 				0A3907F91FC366BC0050714A /* ViewModelCollectionReusableViewTestCase.swift in Sources */,
 				0AECE68721777E7F003A2509 /* URLSessionTask+CancelableTestCase.swift in Sources */,
 				F19A442D20384DD400AD6448 /* UIViewConstraintTestCase.swift in Sources */,
+				4838FE5123A951D2007311F0 /* BottomConstrainableProxyTestCase.swift in Sources */,
 				0A266F9E1ED59FB6009CD0D7 /* MultiLoggerTestCase.swift in Sources */,
 				0A266FA01ED59FB6009CD0D7 /* StringLogItemFormatterTestCase.swift in Sources */,
 				0A3CC4942221FEB1006C7FB4 /* SerializeTestCase.swift in Sources */,
+				4838FE5923A951ED007311F0 /* XCTAssertConstraint.swift in Sources */,
 				0A02BDDD220D08BA00CF14C9 /* HTTPResourceEndpointTestCase.swift in Sources */,
 				0A266FA11ED59FB6009CD0D7 /* JSONTests.swift in Sources */,
 				0A9AF8C21FC33B070076458E /* ReusableViewCollectionViewTestCase.swift in Sources */,
@@ -1812,6 +1892,7 @@
 				0A01F88020B337BA00BA7C4D /* CertificateUtils.swift in Sources */,
 				0A999A06238A075200A315B5 /* Route+TrieRouter_RouteTests.swift in Sources */,
 				0A166EDE2210905B00EC6686 /* NestedContextCoreDataStackTestCase.swift in Sources */,
+				4838FE5423A951DB007311F0 /* LeftConstrainableProxyTestCase.swift in Sources */,
 				0A266FA41ED59FB6009CD0D7 /* MockNetworkStack.swift in Sources */,
 				0A266FA51ED59FB6009CD0D7 /* URLSessionNetworkStack+ErrorTestCase.swift in Sources */,
 				0A3236E520D88C9800D225CB /* DispatchQueueTestCase.swift in Sources */,
@@ -1831,9 +1912,11 @@
 				0A11894820F3BAB800AF8229 /* MockPerformanceMetricsTracker.swift in Sources */,
 				0A265E1D20EAEA8A00A55ED9 /* BoxTestCase.swift in Sources */,
 				0A7B505220B6D769005A08E7 /* SecCertificate+PublicKeyTestCase.swift in Sources */,
+				4838FE5223A951D5007311F0 /* EdgesConstrainableProxyTestCase.swift in Sources */,
 				0AA061002273B4F80052B4A1 /* TestNIBCollectionViewCell.swift in Sources */,
 				0AECE6832177799C003A2509 /* DummyCancelableTestCase.swift in Sources */,
 				0A02BDE3220D92DD00CF14C9 /* MockHTTPResourceEndpoint.swift in Sources */,
+				4838FE5523A951DF007311F0 /* NSLayoutConstraintTestCase.swift in Sources */,
 				0A266FAB1ED59FB6009CD0D7 /* DiskMemoryPersistenceTestCase.swift in Sources */,
 				0A9AF8C01FC336F60076458E /* ReusableViewTestCase.swift in Sources */,
 				0A266FAC1ED59FB6009CD0D7 /* MockPersistenceStack.swift in Sources */,
@@ -1846,6 +1929,7 @@
 				9DEC00AE209A052300F94353 /* BuilderCacheTestCase.swift in Sources */,
 				0A266FB11ED59FB6009CD0D7 /* NetworkPersistableStoreTestCase.swift in Sources */,
 				0AFB0DD220F8FD1C00A58515 /* RetryableResourceTestCase.swift in Sources */,
+				4838FE5023A951CF007311F0 /* BaseConstrainableProxyTestCase.swift in Sources */,
 				0A266FB21ED59FB6009CD0D7 /* CollectionReusableViewTestCase.swift in Sources */,
 				0A3907F71FC35E760050714A /* ReusableViewTableViewTestCase.swift in Sources */,
 				0A266FB31ED59FB6009CD0D7 /* CollectionViewCellTestCase.swift in Sources */,
@@ -1911,6 +1995,7 @@
 				0A848DE6220B4D3F00B690E8 /* HTTPNetworkResource.swift in Sources */,
 				0A8388601EB1F6B000C1E835 /* SiblingContextCoreDataStack.swift in Sources */,
 				0A1083E220CD8322003969AB /* DispatchQueue.swift in Sources */,
+				4838FE3423A94CE0007311F0 /* NSLayoutConstraint+Helpers.swift in Sources */,
 				0A708F6A20E9810B001784DA /* AnalyticsParameterKey.swift in Sources */,
 				0A6BD638228876A10063CEAB /* URLSessionNetworkStack+Error.swift in Sources */,
 				0A708F6620E97B6E001784DA /* AnyAnalyticsTracker.swift in Sources */,
@@ -1919,6 +2004,7 @@
 				0A708F6220E96CD1001784DA /* Analytics.swift in Sources */,
 				0AD7F24820A9D1D000CC927E /* ServerTrustEvaluator.swift in Sources */,
 				0A3C2DBA1EA7E5DD00EFB7D4 /* TableViewHeaderFooterView.swift in Sources */,
+				4838FE3323A94CE0007311F0 /* ViewProxy.swift in Sources */,
 				1B14CDC11ECCC84D00CFAC15 /* KeyboardObserver.swift in Sources */,
 				0A3C2D9F1EA7E5DD00EFB7D4 /* Logger.swift in Sources */,
 				0A3C2DC11EA7E5DD00EFB7D4 /* ServiceLocator.swift in Sources */,
@@ -1960,6 +2046,7 @@
 				68DCF2391F7D0C1400D6BB88 /* StrategyFetchResource.swift in Sources */,
 				0ACFA72F20AEC92700D2E280 /* AuthenticationChallengeHandler.swift in Sources */,
 				0A83884D1EB1F60000C1E835 /* Persistence.swift in Sources */,
+				4838FE3523A94CE0007311F0 /* Constrain.swift in Sources */,
 				0A3C2DA61EA7E5DD00EFB7D4 /* URLSessionNetworkStack.swift in Sources */,
 				0A3C2DA41EA7E5DD00EFB7D4 /* NetworkStack.swift in Sources */,
 				0ACEB2982080EF88000D95AD /* Lock.swift in Sources */,
@@ -1968,6 +2055,7 @@
 				0A83885A1EB1F6B000C1E835 /* CoreDataStack.swift in Sources */,
 				0A3C2DB71EA7E5DD00EFB7D4 /* CollectionReusableView.swift in Sources */,
 				9D4E3AA1239A6557007F3050 /* CollectionReusableViewSizer.swift in Sources */,
+				4838FE3123A94CE0007311F0 /* Array+ConstrainableProxy.swift in Sources */,
 				0A39A730225961000009E9F0 /* ExternalErrorDecoderResource.swift in Sources */,
 				0A266F201ED374F5009CD0D7 /* AssertDumpsEqual.swift in Sources */,
 				0ACEB2922080E6D4000D95AD /* Atomic.swift in Sources */,
@@ -1991,6 +2079,7 @@
 				0A90843D1EBCBFC400616076 /* ViewModelView.swift in Sources */,
 				1B57E97D1EB150C80027AB30 /* Analytics+MultiTracker.swift in Sources */,
 				1B4D4CB51F04F67E00FA4260 /* RequestInterceptor.swift in Sources */,
+				4838FE3223A94CE0007311F0 /* ConstraintRelation.swift in Sources */,
 				0A3C2DBE1EA7E5DD00EFB7D4 /* Box.swift in Sources */,
 				0A3C2DB91EA7E5DD00EFB7D4 /* TableViewCell.swift in Sources */,
 				1B40335C1ED8A62900B4B03D /* ViewModelTableViewHeaderFooterView.swift in Sources */,
@@ -2001,9 +2090,12 @@
 				0ACFA73120AEC95C00D2E280 /* PublicKeyAlgorithm.swift in Sources */,
 				0A3C2D9E1EA7E5DD00EFB7D4 /* LogDestination.swift in Sources */,
 				0A9084391EBCBFB200616076 /* NibView.swift in Sources */,
+				4838FE3723A94CE0007311F0 /* LayoutItem.swift in Sources */,
 				0ABFFAC41EA8D08B00CFC8BD /* JSON.swift in Sources */,
 				0A3C2DA31EA7E5DD00EFB7D4 /* Network.swift in Sources */,
+				4838FE3023A94CE0007311F0 /* ConstrainableProxy.swift in Sources */,
 				0A848DE4220B4C0100B690E8 /* HTTPResourceEndpoint.swift in Sources */,
+				4838FE3623A94CE0007311F0 /* LayoutGuideProxy.swift in Sources */,
 				0A166EE42210B8BB00EC6686 /* CoreDataStack+CRUD.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Alicerce.xcodeproj/project.pbxproj
+++ b/Alicerce.xcodeproj/project.pbxproj
@@ -329,6 +329,10 @@
 		4838FE5723A951E6007311F0 /* TopConstrainableProxyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4838FE4023A950CA007311F0 /* TopConstrainableProxyTestCase.swift */; };
 		4838FE5823A951E9007311F0 /* TrailingConstrainableProxyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4838FE3B23A950CA007311F0 /* TrailingConstrainableProxyTestCase.swift */; };
 		4838FE5923A951ED007311F0 /* XCTAssertConstraint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4838FE3C23A950CA007311F0 /* XCTAssertConstraint.swift */; };
+		48A5ECC823D5AC620014B2B7 /* FirstBaselineConstrainableProxyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48A5ECC623D5AC3A0014B2B7 /* FirstBaselineConstrainableProxyTestCase.swift */; };
+		48A5ECCB23D5B0020014B2B7 /* LastBaselineConstrainableProxyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48A5ECC923D5AFF80014B2B7 /* LastBaselineConstrainableProxyTestCase.swift */; };
+		48A5ECCE23D5B84B0014B2B7 /* LeadingTrailingConstrainableProxyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48A5ECCC23D5B8470014B2B7 /* LeadingTrailingConstrainableProxyTestCase.swift */; };
+		48A5ECD123D5B9FC0014B2B7 /* TopBottomConstrainableProxyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48A5ECCF23D5B9F70014B2B7 /* TopBottomConstrainableProxyTestCase.swift */; };
 		48BF456523D1CFCA00DFBB28 /* HeightConstrainableProxyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BF456323D1CFB300DFBB28 /* HeightConstrainableProxyTestCase.swift */; };
 		48BF456823D1D2C200DFBB28 /* CenterXConstrainableProxyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BF456623D1D26F00DFBB28 /* CenterXConstrainableProxyTestCase.swift */; };
 		48BF456B23D1D4AA00DFBB28 /* CenterYConstrainableProxyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BF456923D1D4A300DFBB28 /* CenterYConstrainableProxyTestCase.swift */; };
@@ -674,6 +678,10 @@
 		4838FE4123A950CB007311F0 /* BaseConstrainableProxyTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseConstrainableProxyTestCase.swift; sourceTree = "<group>"; };
 		4838FE4223A950CB007311F0 /* LeftConstrainableProxyTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LeftConstrainableProxyTestCase.swift; sourceTree = "<group>"; };
 		4838FE4323A950CB007311F0 /* EdgesConstrainableProxyTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EdgesConstrainableProxyTestCase.swift; sourceTree = "<group>"; };
+		48A5ECC623D5AC3A0014B2B7 /* FirstBaselineConstrainableProxyTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstBaselineConstrainableProxyTestCase.swift; sourceTree = "<group>"; };
+		48A5ECC923D5AFF80014B2B7 /* LastBaselineConstrainableProxyTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastBaselineConstrainableProxyTestCase.swift; sourceTree = "<group>"; };
+		48A5ECCC23D5B8470014B2B7 /* LeadingTrailingConstrainableProxyTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeadingTrailingConstrainableProxyTestCase.swift; sourceTree = "<group>"; };
+		48A5ECCF23D5B9F70014B2B7 /* TopBottomConstrainableProxyTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBottomConstrainableProxyTestCase.swift; sourceTree = "<group>"; };
 		48BF456323D1CFB300DFBB28 /* HeightConstrainableProxyTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeightConstrainableProxyTestCase.swift; sourceTree = "<group>"; };
 		48BF456623D1D26F00DFBB28 /* CenterXConstrainableProxyTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterXConstrainableProxyTestCase.swift; sourceTree = "<group>"; };
 		48BF456923D1D4A300DFBB28 /* CenterYConstrainableProxyTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CenterYConstrainableProxyTestCase.swift; sourceTree = "<group>"; };
@@ -1511,8 +1519,11 @@
 				48BF456623D1D26F00DFBB28 /* CenterXConstrainableProxyTestCase.swift */,
 				48BF456923D1D4A300DFBB28 /* CenterYConstrainableProxyTestCase.swift */,
 				4838FE4323A950CB007311F0 /* EdgesConstrainableProxyTestCase.swift */,
+				48A5ECC623D5AC3A0014B2B7 /* FirstBaselineConstrainableProxyTestCase.swift */,
 				48BF456323D1CFB300DFBB28 /* HeightConstrainableProxyTestCase.swift */,
+				48A5ECC923D5AFF80014B2B7 /* LastBaselineConstrainableProxyTestCase.swift */,
 				4838FE3F23A950CA007311F0 /* LeadingConstrainableProxyTestCase.swift */,
+				48A5ECCC23D5B8470014B2B7 /* LeadingTrailingConstrainableProxyTestCase.swift */,
 				4838FE4223A950CB007311F0 /* LeftConstrainableProxyTestCase.swift */,
 				4838FE3D23A950CA007311F0 /* NSLayoutConstraint+TestHelpers.swift */,
 				4838FE3E23A950CA007311F0 /* NSLayoutConstraintTestCase.swift */,
@@ -1522,6 +1533,7 @@
 				4838FE3B23A950CA007311F0 /* TrailingConstrainableProxyTestCase.swift */,
 				4833D5B223D0D28C00EBD925 /* WidthConstrainableProxyTestCase.swift */,
 				4838FE3C23A950CA007311F0 /* XCTAssertConstraint.swift */,
+				48A5ECCF23D5B9F70014B2B7 /* TopBottomConstrainableProxyTestCase.swift */,
 			);
 			path = AutoLayout;
 			sourceTree = "<group>";
@@ -1843,7 +1855,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				0AEEE10E20CF1C6300B47687 /* DefaultLogLevelFormatterTestCase.swift in Sources */,
+				48A5ECCB23D5B0020014B2B7 /* LastBaselineConstrainableProxyTestCase.swift in Sources */,
 				0A266FBD1ED59FCD009CD0D7 /* MockErrorManagedObjectContext.m in Sources */,
+				48A5ECC823D5AC620014B2B7 /* FirstBaselineConstrainableProxyTestCase.swift in Sources */,
 				0A266FBE1ED59FCD009CD0D7 /* CoreDataStackModel.xcdatamodeld in Sources */,
 				0A79686120812130005738AF /* LockTestCase.swift in Sources */,
 				0A72EB4622515E7A00540C67 /* DummyLoggerTestCase.swift in Sources */,
@@ -1863,6 +1877,7 @@
 				0A77982920FCCD24008E269A /* RetryTestCase.swift in Sources */,
 				48BF456B23D1D4AA00DFBB28 /* CenterYConstrainableProxyTestCase.swift in Sources */,
 				0A3236E120D87E4C00D225CB /* LogDestinationTestCase.swift in Sources */,
+				48A5ECCE23D5B84B0014B2B7 /* LeadingTrailingConstrainableProxyTestCase.swift in Sources */,
 				0AD6ACBF20B58896001426B8 /* ServerTrustEvaluator+ConfigurationTestCase.swift in Sources */,
 				0A266F941ED59FB6009CD0D7 /* Route+TrieNode_RemoveTests.swift in Sources */,
 				0A266F951ED59FB6009CD0D7 /* Route+TrieRouter_RegisterTests.swift in Sources */,
@@ -1920,6 +1935,7 @@
 				0AD91CDE221A003E006652F6 /* NSManagedObjectContext+CoreDataStackTestCase.swift in Sources */,
 				0A266FA71ED59FB6009CD0D7 /* URLSessionNetworkStackTestCase.swift in Sources */,
 				0AD91CD82219AF82006652F6 /* NSPredicate+Utils.swift in Sources */,
+				48A5ECD123D5B9FC0014B2B7 /* TopBottomConstrainableProxyTestCase.swift in Sources */,
 				0AD91CDA2219B2A2006652F6 /* TestEntityValue.swift in Sources */,
 				0A266FA81ED59FB6009CD0D7 /* CoreDataStack+CRUDTestCase.swift in Sources */,
 				0A266FA91ED59FB6009CD0D7 /* CoreDataStack+FactoriesTests.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ It is designed with an MVVM architecture in mind, but you'll find most component
 ## Main features ✨
 
 1. **[Analytics][] 🔍**
+1. **[Auto Layout][AutoLayout] 📐**
 1. **[Deep Linking][DeepLinking] 🔗**
 1. **[Logging][] 📝**
 1. **[Network][] 🌍**
@@ -142,6 +143,7 @@ Alicerce is Copyright (c) 2016 - present Mindera and is available under the MIT 
 With ❤️ from [Mindera](https://www.mindera.com) 🤓
 
 [Analytics]: https://github.com/Mindera/Alicerce/tree/master/Sources/Analytics
+[AutoLayout]: https://github.com/Mindera/Alicerce/tree/master/Sources/AutoLayout
 [DeepLinking]: https://github.com/Mindera/Alicerce/tree/master/Sources/DeepLinking
 [Logging]: https://github.com/Mindera/Alicerce/tree/master/Sources/Logging
 [Network]: https://github.com/Mindera/Alicerce/tree/master/Sources/Network

--- a/Sources/AutoLayout/Array+ConstrainableProxy.swift
+++ b/Sources/AutoLayout/Array+ConstrainableProxy.swift
@@ -1,0 +1,136 @@
+import UIKit
+
+extension Array where Element: LeadingConstrainableProxy {
+
+    @discardableResult
+    func alignLeading() -> [NSLayoutConstraint] {
+
+        guard let first = first else { return [] }
+        return self[1...].map {
+            $0.prepare()
+            return first.leading(to: $0)
+        }
+    }
+}
+
+extension Array where Element: TrailingConstrainableProxy {
+
+    @discardableResult
+    func alignTrailing() -> [NSLayoutConstraint] {
+
+        guard let first = first else { return [] }
+        return self[1...].map {
+            $0.prepare()
+            return first.trailing(to: $0)
+        }
+    }
+}
+
+extension Array where Element: TopConstrainableProxy {
+
+    @discardableResult
+    func alignTop() -> [NSLayoutConstraint] {
+
+        guard let first = first else { return [] }
+        return self[1...].map {
+            $0.prepare()
+            return first.top(to: $0)
+        }
+    }
+}
+
+extension Array where Element: BottomConstrainableProxy {
+
+    @discardableResult
+    func alignBottom() -> [NSLayoutConstraint] {
+
+        guard let first = first else { return [] }
+        return self[1...].map {
+            $0.prepare()
+            return first.bottom(to: $0)
+        }
+    }
+}
+
+extension Array where Element: PositionConstrainableProxy {
+
+    @discardableResult
+    func alignCenterX() -> [NSLayoutConstraint] {
+
+        guard let first = first else { return [] }
+        return self[1...].map {
+            $0.prepare()
+            return first.centerX(to: $0)
+        }
+    }
+
+    @discardableResult
+    func alignCenterY() -> [NSLayoutConstraint] {
+
+        guard let first = first else { return [] }
+        return self[1...].map {
+            $0.prepare()
+            return first.centerY(to: $0)
+        }
+    }
+}
+
+extension Array where Element: WidthConstrainableProxy {
+
+    @discardableResult
+    func equalWidth() -> [NSLayoutConstraint] {
+
+        guard let first = first else { return [] }
+        return self[1...].map {
+            $0.prepare()
+            return first.width(to: $0)
+        }
+    }
+
+    @discardableResult
+    func equal(width: CGFloat) -> [NSLayoutConstraint] {
+
+        guard isEmpty == false else { return [] }
+        return map {
+            $0.prepare()
+            return $0.width(width, relation: .equal)
+        }
+    }
+}
+
+extension Array where Element: HeightConstrainableProxy {
+
+    @discardableResult
+    func equalHeight() -> [NSLayoutConstraint] {
+
+        guard let first = first else { return [] }
+        return self[1...].map {
+            $0.prepare()
+            return first.height(to: $0)
+        }
+    }
+}
+
+extension Array where Element: LeadingConstrainableProxy & TrailingConstrainableProxy {
+
+    @discardableResult
+    func distributeHorizontally(margin: CGFloat = 0.0) -> [NSLayoutConstraint] {
+
+        last?.prepare()
+        return zip(self, self[1...]).map { first, second in
+            second.leadingToTrailing(of: first, offset: margin)
+        }
+    }
+}
+
+extension Array where Element: TopConstrainableProxy & BottomConstrainableProxy {
+
+    @discardableResult
+    func distributeVertically(margin: CGFloat = 0.0) -> [NSLayoutConstraint] {
+
+        last?.prepare()
+        return zip(self, self[1...]).map { first, second in
+            second.topToBottom(of: first, offset: margin)
+        }
+    }
+}

--- a/Sources/AutoLayout/Array+ConstrainableProxy.swift
+++ b/Sources/AutoLayout/Array+ConstrainableProxy.swift
@@ -6,10 +6,7 @@ extension Array where Element: LeadingConstrainableProxy {
     func alignLeading() -> [NSLayoutConstraint] {
 
         guard let first = first else { return [] }
-        return self[1...].map {
-            $0.prepare()
-            return first.leading(to: $0)
-        }
+        return self[1...].map { first.leading(to: $0) }
     }
 }
 
@@ -19,10 +16,7 @@ extension Array where Element: TrailingConstrainableProxy {
     func alignTrailing() -> [NSLayoutConstraint] {
 
         guard let first = first else { return [] }
-        return self[1...].map {
-            $0.prepare()
-            return first.trailing(to: $0)
-        }
+        return self[1...].map { first.trailing(to: $0) }
     }
 }
 
@@ -32,10 +26,7 @@ extension Array where Element: TopConstrainableProxy {
     func alignTop() -> [NSLayoutConstraint] {
 
         guard let first = first else { return [] }
-        return self[1...].map {
-            $0.prepare()
-            return first.top(to: $0)
-        }
+        return self[1...].map { first.top(to: $0) }
     }
 }
 
@@ -45,10 +36,7 @@ extension Array where Element: BottomConstrainableProxy {
     func alignBottom() -> [NSLayoutConstraint] {
 
         guard let first = first else { return [] }
-        return self[1...].map {
-            $0.prepare()
-            return first.bottom(to: $0)
-        }
+        return self[1...].map { first.bottom(to: $0) }
     }
 }
 
@@ -58,20 +46,14 @@ extension Array where Element: PositionConstrainableProxy {
     func alignCenterX() -> [NSLayoutConstraint] {
 
         guard let first = first else { return [] }
-        return self[1...].map {
-            $0.prepare()
-            return first.centerX(to: $0)
-        }
+        return self[1...].map { first.centerX(to: $0) }
     }
 
     @discardableResult
     func alignCenterY() -> [NSLayoutConstraint] {
 
         guard let first = first else { return [] }
-        return self[1...].map {
-            $0.prepare()
-            return first.centerY(to: $0)
-        }
+        return self[1...].map { first.centerY(to: $0) }
     }
 }
 
@@ -81,20 +63,13 @@ extension Array where Element: WidthConstrainableProxy {
     func equalWidth() -> [NSLayoutConstraint] {
 
         guard let first = first else { return [] }
-        return self[1...].map {
-            $0.prepare()
-            return first.width(to: $0)
-        }
+        return self[1...].map { first.width(to: $0) }
     }
 
     @discardableResult
     func equal(width: CGFloat) -> [NSLayoutConstraint] {
 
-        guard isEmpty == false else { return [] }
-        return map {
-            $0.prepare()
-            return $0.width(width, relation: .equal)
-        }
+        map { $0.width(width, relation: .equal) }
     }
 }
 
@@ -104,10 +79,7 @@ extension Array where Element: HeightConstrainableProxy {
     func equalHeight() -> [NSLayoutConstraint] {
 
         guard let first = first else { return [] }
-        return self[1...].map {
-            $0.prepare()
-            return first.height(to: $0)
-        }
+        return self[1...].map { first.height(to: $0) }
     }
 }
 
@@ -116,7 +88,7 @@ extension Array where Element: LeadingConstrainableProxy & TrailingConstrainable
     @discardableResult
     func distributeHorizontally(margin: CGFloat = 0.0) -> [NSLayoutConstraint] {
 
-        last?.prepare()
+        guard isEmpty == false else { return [] }
         return zip(self, self[1...]).map { first, second in
             second.leadingToTrailing(of: first, offset: margin)
         }
@@ -128,7 +100,7 @@ extension Array where Element: TopConstrainableProxy & BottomConstrainableProxy 
     @discardableResult
     func distributeVertically(margin: CGFloat = 0.0) -> [NSLayoutConstraint] {
 
-        last?.prepare()
+        guard isEmpty == false else { return [] }
         return zip(self, self[1...]).map { first, second in
             second.topToBottom(of: first, offset: margin)
         }

--- a/Sources/AutoLayout/Constrain.swift
+++ b/Sources/AutoLayout/Constrain.swift
@@ -20,12 +20,8 @@ final class ConstraintGroup {
     }
 
     var isActive: Bool {
-        get {
-            return constraints.allSatisfy { $0.isActive }
-        }
-        set {
-             newValue ? install(constraints) : uninstall(constraints)
-        }
+        get { constraints.allSatisfy { $0.isActive } }
+        set { newValue ? install(constraints) : uninstall(constraints) }
     }
 
     private func install(_ constraints: [NSLayoutConstraint]) {

--- a/Sources/AutoLayout/Constrain.swift
+++ b/Sources/AutoLayout/Constrain.swift
@@ -1,0 +1,206 @@
+// swiftlint:disable function_parameter_count
+
+import UIKit
+
+final class LayoutContext {
+
+    fileprivate var constraints: [NSLayoutConstraint] = []
+
+    func add(_ constraint: NSLayoutConstraint) {
+
+        constraints.append(constraint)
+    }
+}
+
+final class ConstraintGroup {
+
+    fileprivate var constraints: [NSLayoutConstraint] = [] {
+        willSet { uninstall(constraints) }
+        didSet { install(constraints) }
+    }
+
+    var isActive: Bool {
+        get {
+            return constraints.allSatisfy { $0.isActive }
+        }
+        set {
+             newValue ? install(constraints) : uninstall(constraints)
+        }
+    }
+
+    private func install(_ constraints: [NSLayoutConstraint]) {
+
+        NSLayoutConstraint.activate(constraints)
+    }
+
+    private func uninstall(_ constraints: [NSLayoutConstraint]) {
+
+        NSLayoutConstraint.deactivate(constraints)
+    }
+}
+
+@discardableResult
+func constrain<A: LayoutItem>(
+    _ a: A,
+    replacing group: ConstraintGroup = .init(),
+    constraints: (A.ProxyType) -> Void
+) -> ConstraintGroup {
+
+    let context = LayoutContext()
+
+    let a = a.proxy(with: context)
+
+    constraints(a)
+
+    group.constraints = context.constraints
+
+    return group
+}
+
+@discardableResult
+func constrain<A: LayoutItem, B: LayoutItem>(
+    _ a: A,
+    _ b: B,
+    replacing group: ConstraintGroup = .init(),
+    constraints: (A.ProxyType, B.ProxyType) -> Void
+) -> ConstraintGroup {
+
+    let context = LayoutContext()
+
+    let a = a.proxy(with: context)
+    let b = b.proxy(with: context)
+
+    constraints(a, b)
+
+    group.constraints = context.constraints
+
+    return group
+}
+
+@discardableResult
+func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem>(
+    _ a: A,
+    _ b: B,
+    _ c: C,
+    replacing group: ConstraintGroup = .init(),
+    constraints: (A.ProxyType, B.ProxyType, C.ProxyType) -> Void
+) -> ConstraintGroup {
+
+    let context = LayoutContext()
+
+    let a = a.proxy(with: context)
+    let b = b.proxy(with: context)
+    let c = c.proxy(with: context)
+
+    constraints(a, b, c)
+
+    group.constraints = context.constraints
+
+    return group
+}
+
+@discardableResult
+func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem>(
+    _ a: A,
+    _ b: B,
+    _ c: C,
+    _ d: D,
+    replacing group: ConstraintGroup = .init(),
+    constraints: (A.ProxyType, B.ProxyType, C.ProxyType, D.ProxyType) -> Void
+) -> ConstraintGroup {
+
+    let context = LayoutContext()
+
+    let a = a.proxy(with: context)
+    let b = b.proxy(with: context)
+    let c = c.proxy(with: context)
+    let d = d.proxy(with: context)
+
+    constraints(a, b, c, d)
+
+    group.constraints = context.constraints
+
+    return group
+}
+
+@discardableResult
+func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem, E: LayoutItem>(
+    _ a: A,
+    _ b: B,
+    _ c: C,
+    _ d: D,
+    _ e: E,
+    replacing group: ConstraintGroup = .init(),
+    constraints: (A.ProxyType, B.ProxyType, C.ProxyType, D.ProxyType, E.ProxyType) -> Void
+) -> ConstraintGroup {
+
+    let context = LayoutContext()
+
+    let a = a.proxy(with: context)
+    let b = b.proxy(with: context)
+    let c = c.proxy(with: context)
+    let d = d.proxy(with: context)
+    let e = e.proxy(with: context)
+
+    constraints(a, b, c, d, e)
+
+    group.constraints = context.constraints
+
+    return group
+}
+
+@discardableResult
+func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem, E: LayoutItem, F: LayoutItem>(
+    _ a: A,
+    _ b: B,
+    _ c: C,
+    _ d: D,
+    _ e: E,
+    _ f: F,
+    replacing group: ConstraintGroup = .init(),
+    constraints: (A.ProxyType, B.ProxyType, C.ProxyType, D.ProxyType, E.ProxyType, F.ProxyType) -> Void
+) -> ConstraintGroup {
+
+    let context = LayoutContext()
+
+    let a = a.proxy(with: context)
+    let b = b.proxy(with: context)
+    let c = c.proxy(with: context)
+    let d = d.proxy(with: context)
+    let e = e.proxy(with: context)
+    let f = f.proxy(with: context)
+
+    constraints(a, b, c, d, e, f)
+
+    group.constraints = context.constraints
+
+    return group
+}
+
+@discardableResult
+func constrain<T: LayoutItem>(
+    _ items: [T],
+    replacing group: ConstraintGroup = .init(),
+    constraints: ([T.ProxyType]) -> Void
+) -> ConstraintGroup {
+
+    let context = LayoutContext()
+
+    let proxies = items.map { $0.proxy(with: context) }
+
+    constraints(proxies)
+
+    group.constraints = context.constraints
+
+    return group
+}
+
+@discardableResult
+func constrain(
+    clearing group: ConstraintGroup = .init()
+) -> ConstraintGroup {
+
+    group.constraints = []
+
+    return group
+}

--- a/Sources/AutoLayout/ConstrainableProxy.swift
+++ b/Sources/AutoLayout/ConstrainableProxy.swift
@@ -1,0 +1,870 @@
+// swiftlint:disable file_length function_parameter_count
+
+import UIKit
+
+protocol ConstrainableProxy: AnyObject {
+
+    var context: LayoutContext { get }
+    var item: AnyObject { get }
+
+    func prepare()
+}
+
+protocol TopConstrainableProxy: ConstrainableProxy {
+
+    var top: NSLayoutYAxisAnchor { get }
+}
+
+extension TopConstrainableProxy {
+
+    @discardableResult
+    func top(
+        to anotherProxy: TopConstrainableProxy,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        return constrain(
+            from: top,
+            to: anotherProxy.top,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+
+    @discardableResult
+    func topToBottom(
+        of anotherProxy: BottomConstrainableProxy,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        return constrain(
+            from: top,
+            to: anotherProxy.bottom,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+}
+
+protocol BottomConstrainableProxy: ConstrainableProxy {
+
+    var bottom: NSLayoutYAxisAnchor { get }
+}
+
+extension BottomConstrainableProxy {
+
+    @discardableResult
+    func bottom(
+        to anotherProxy: BottomConstrainableProxy,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        return constrain(
+            from: bottom,
+            to: anotherProxy.bottom,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+
+    @discardableResult
+    func bottomToTop(
+        of anotherProxy: TopConstrainableProxy,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        return constrain(
+            from: bottom,
+            to: anotherProxy.top,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+}
+
+protocol LeadingConstrainableProxy: ConstrainableProxy {
+
+    var leading: NSLayoutXAxisAnchor { get }
+}
+
+extension LeadingConstrainableProxy {
+
+    @discardableResult
+    func leading(
+        to anotherProxy: LeadingConstrainableProxy,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        return constrain(
+            from: leading,
+            to: anotherProxy.leading,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+
+    @discardableResult
+    func leadingToTrailing(
+        of anotherProxy: TrailingConstrainableProxy,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        return constrain(
+            from: leading,
+            to: anotherProxy.trailing,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+
+    @discardableResult
+    func leadingToCenterX(
+        of anotherProxy: CenterXConstrainableProxy,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        return constrain(
+            from: leading,
+            to: anotherProxy.centerX,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+}
+
+protocol LeftConstrainableProxy: ConstrainableProxy {
+
+    var left: NSLayoutXAxisAnchor { get }
+}
+
+extension LeftConstrainableProxy {
+
+    @discardableResult
+    func left(
+        to anotherProxy: LeftConstrainableProxy,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        return constrain(
+            from: left,
+            to: anotherProxy.left,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+
+    @discardableResult
+    func leftToRight(
+        of anotherProxy: RightConstrainableProxy,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        return constrain(
+            from: left,
+            to: anotherProxy.right,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+}
+
+protocol RightConstrainableProxy: ConstrainableProxy {
+
+    var right: NSLayoutXAxisAnchor { get }
+}
+
+extension RightConstrainableProxy {
+
+    @discardableResult
+    func right(
+        to anotherProxy: RightConstrainableProxy,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        return constrain(
+            from: right,
+            to: anotherProxy.right,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+
+    @discardableResult
+    func rightToLeft(
+        of anotherProxy: LeftConstrainableProxy,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        return constrain(
+            from: right,
+            to: anotherProxy.left,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+}
+
+protocol TrailingConstrainableProxy: ConstrainableProxy {
+
+    var trailing: NSLayoutXAxisAnchor { get }
+}
+
+extension TrailingConstrainableProxy {
+
+    @discardableResult
+    func trailing(
+        to anotherProxy: TrailingConstrainableProxy,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        return constrain(
+            from: trailing,
+            to: anotherProxy.trailing,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+
+    @discardableResult
+    func trailingToLeading(
+        of anotherProxy: LeadingConstrainableProxy,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        return constrain(
+            from: trailing,
+            to: anotherProxy.leading,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+
+    @discardableResult
+    func trailingToCenterX(
+        of anotherProxy: CenterXConstrainableProxy,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        return constrain(
+            from: trailing,
+            to: anotherProxy.centerX,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+}
+
+protocol EdgesConstrainableProxy: TopConstrainableProxy,
+    BottomConstrainableProxy,
+    LeadingConstrainableProxy,
+    TrailingConstrainableProxy,
+    LeftConstrainableProxy,
+    RightConstrainableProxy {}
+
+extension EdgesConstrainableProxy {
+
+    @discardableResult
+    func edges(
+        to anotherProxy: EdgesConstrainableProxy,
+        insets: UIEdgeInsets = .zero,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> [NSLayoutConstraint] {
+
+        let constraints: [NSLayoutConstraint] = [
+            top(to: anotherProxy, offset: insets.top, relation: relation, priority: priority),
+            leading(to: anotherProxy, offset: insets.left, relation: relation, priority: priority),
+            bottom(to: anotherProxy, offset: -insets.bottom, relation: relation, priority: priority),
+            trailing(to: anotherProxy, offset: -insets.right, relation: relation, priority: priority)
+        ]
+
+        return constraints
+    }
+}
+
+protocol CenterYConstrainableProxy: ConstrainableProxy {
+
+    var centerY: NSLayoutYAxisAnchor { get }
+}
+
+extension CenterYConstrainableProxy {
+
+    @discardableResult
+    func centerY(
+        to view: PositionConstrainableProxy,
+        multiplier: CGFloat = 1,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        return center(
+            axis: .vertical,
+            to: view,
+            multiplier: multiplier,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+
+    @discardableResult
+    func centerYToTop(
+        of view: PositionConstrainableProxy,
+        multiplier: CGFloat = 1,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        return center(
+            axis: .vertical,
+            to: view,
+            toAttribute: .top,
+            multiplier: multiplier,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+
+    @discardableResult
+    func centerYToBottom(
+        of view: PositionConstrainableProxy,
+        multiplier: CGFloat = 1,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        return center(
+            axis: .vertical,
+            to: view,
+            toAttribute: .bottom,
+            multiplier: multiplier,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+}
+
+protocol CenterXConstrainableProxy: ConstrainableProxy {
+
+    var centerX: NSLayoutXAxisAnchor { get }
+}
+
+extension CenterXConstrainableProxy {
+
+    @discardableResult
+    func centerX(
+        to view: PositionConstrainableProxy,
+        multiplier: CGFloat = 1,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        return center(
+            axis: .horizontal,
+            to: view,
+            multiplier: multiplier,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+
+    @discardableResult
+    func centerXToLeading(
+        of anotherProxy: LeadingConstrainableProxy,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        return constrain(
+            from: centerX,
+            to: anotherProxy.leading,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+
+    @discardableResult
+    func centerXToTrailing(
+        of anotherProxy: TrailingConstrainableProxy,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        return constrain(
+            from: centerX,
+            to: anotherProxy.trailing,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+}
+
+protocol CenterConstrainableProxy: CenterXConstrainableProxy, CenterYConstrainableProxy {}
+
+extension CenterConstrainableProxy {
+
+    @discardableResult
+    func center(
+        in view: PositionConstrainableProxy,
+        offset: CGPoint = .zero,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> [NSLayoutConstraint] {
+
+        let constraints: [NSLayoutConstraint] = [
+            centerX(to: view, offset: offset.x, relation: relation, priority: priority),
+            centerY(to: view, offset: offset.y, relation: relation, priority: priority)
+        ]
+
+        return constraints
+    }
+}
+
+protocol WidthConstrainableProxy: ConstrainableProxy {
+
+    var width: NSLayoutDimension { get }
+}
+
+extension WidthConstrainableProxy {
+
+    @discardableResult
+    func width(
+        _ width: CGFloat,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        return constrain(
+            dimension: self.width,
+            constant: width,
+            relation: relation,
+            priority: priority
+        )
+    }
+
+    @discardableResult
+    func width(
+        to view: WidthConstrainableProxy,
+        multiplier: CGFloat = 1,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        return constrain(
+            from: width,
+            to: view.width,
+            multiplier: multiplier,
+            constant: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+}
+
+protocol HeightConstrainableProxy: ConstrainableProxy {
+
+    var height: NSLayoutDimension { get }
+}
+
+extension HeightConstrainableProxy {
+
+    @discardableResult
+    func height(
+        _ height: CGFloat,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        return constrain(
+            dimension: self.height,
+            constant: height,
+            relation: relation,
+            priority: priority
+        )
+    }
+
+    @discardableResult
+    func height(
+        to view: HeightConstrainableProxy,
+        multiplier: CGFloat = 1,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        return constrain(
+            from: height,
+            to: view.height,
+            multiplier: multiplier,
+            constant: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+}
+
+protocol SizeConstrainableProxy: WidthConstrainableProxy, HeightConstrainableProxy {}
+
+extension SizeConstrainableProxy {
+
+    @discardableResult
+    func size(
+        _ size: CGSize,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> [NSLayoutConstraint] {
+
+        let constraints: [NSLayoutConstraint] = [
+            width(size.width, relation: relation, priority: priority),
+            height(size.height, relation: relation, priority: priority)
+        ]
+
+        return constraints
+    }
+
+    @discardableResult
+    func size(
+        to view: SizeConstrainableProxy,
+        multiplier: CGFloat = 1,
+        insets: CGSize = .zero,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> [NSLayoutConstraint] {
+
+        let constraints: [NSLayoutConstraint] = [
+            width(to: view, multiplier: multiplier, offset: insets.width, relation: relation, priority: priority),
+            height(to: view, multiplier: multiplier, offset: insets.height, relation: relation, priority: priority)
+        ]
+
+        return constraints
+    }
+}
+
+protocol BaselineConstrainableProxy: ConstrainableProxy {
+
+    var firstBaseline: NSLayoutYAxisAnchor { get }
+    var lastBaseline: NSLayoutYAxisAnchor { get }
+}
+
+extension BaselineConstrainableProxy {
+
+    @discardableResult
+    func firstBaseline(
+        to view: BaselineConstrainableProxy,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        return constrain(
+            from: firstBaseline,
+            to: view.firstBaseline,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+
+    @discardableResult
+    func firstBaselineToTop(
+        of view: TopConstrainableProxy,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        return constrain(
+            from: firstBaseline,
+            to: view.top,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+
+    @discardableResult
+    func firstBaselineToBottom(
+        of view: BottomConstrainableProxy,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        return constrain(
+            from: firstBaseline,
+            to: view.bottom,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+
+    @discardableResult
+    func lastBaseline(
+        to view: BaselineConstrainableProxy,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        return constrain(
+            from: lastBaseline,
+            to: view.lastBaseline,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+
+    @discardableResult
+    func lastBaselineToTop(
+        of view: TopConstrainableProxy,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        return constrain(
+            from: lastBaseline,
+            to: view.top,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+
+    @discardableResult
+    func lastBaselineToBottom(
+        of view: BottomConstrainableProxy,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        return constrain(
+            from: lastBaseline,
+            to: view.bottom,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+}
+
+protocol PositionConstrainableProxy: EdgesConstrainableProxy, SizeConstrainableProxy, CenterConstrainableProxy {}
+
+// MARK: - Helpers
+
+private extension ConstrainableProxy {
+
+    // MARK: - NSLayoutYAxisAnchor
+
+    func constrain(
+        from: NSLayoutYAxisAnchor,
+        to: NSLayoutYAxisAnchor,
+        offset: CGFloat,
+        relation: ConstraintRelation,
+        priority: UILayoutPriority
+    ) -> NSLayoutConstraint {
+
+        let constraint: NSLayoutConstraint
+        switch relation {
+        case .equal:
+            constraint = from.constraint(equalTo: to, constant: offset)
+        case .equalOrLess:
+            constraint = from.constraint(lessThanOrEqualTo: to, constant: offset)
+        case .equalOrGreater:
+            constraint = from.constraint(greaterThanOrEqualTo: to, constant: offset)
+        }
+
+        let result = constraint.with(priority: priority)
+
+        prepare()
+        context.add(result)
+
+        return result
+    }
+
+    // MARK: - NSLayoutXAxisAnchor
+
+    func constrain(
+        from: NSLayoutXAxisAnchor,
+        to: NSLayoutXAxisAnchor,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        let constraint: NSLayoutConstraint
+        switch relation {
+        case .equal:
+            constraint = from.constraint(equalTo: to, constant: offset)
+        case .equalOrLess:
+            constraint = from.constraint(lessThanOrEqualTo: to, constant: offset)
+        case .equalOrGreater:
+            constraint = from.constraint(greaterThanOrEqualTo: to, constant: offset)
+        }
+
+        let result = constraint.with(priority: priority)
+
+        prepare()
+        context.add(result)
+
+        return result
+    }
+
+    // MARK: - NSLayoutDimension
+
+    func constrain(
+        from: NSLayoutDimension,
+        to: NSLayoutDimension,
+        multiplier: CGFloat,
+        constant: CGFloat,
+        relation: ConstraintRelation,
+        priority: UILayoutPriority
+    ) -> NSLayoutConstraint {
+
+        let constraint: NSLayoutConstraint
+        switch relation {
+        case .equal:
+            constraint = from.constraint(equalTo: to, multiplier: multiplier, constant: constant)
+        case .equalOrLess:
+            constraint = from.constraint(lessThanOrEqualTo: to, multiplier: multiplier, constant: constant)
+        case .equalOrGreater:
+            constraint = from.constraint(greaterThanOrEqualTo: to, multiplier: multiplier, constant: constant)
+        }
+
+        let result = constraint.with(priority: priority)
+
+        prepare()
+        context.add(result)
+
+        return result
+    }
+
+    func constrain(
+        dimension: NSLayoutDimension,
+        constant: CGFloat,
+        relation: ConstraintRelation,
+        priority: UILayoutPriority
+    ) -> NSLayoutConstraint {
+
+        let constraint: NSLayoutConstraint
+        switch relation {
+        case .equal:
+            constraint = dimension.constraint(equalToConstant: constant)
+        case .equalOrLess:
+            constraint = dimension.constraint(lessThanOrEqualToConstant: constant)
+        case .equalOrGreater:
+            constraint = dimension.constraint(greaterThanOrEqualToConstant: constant)
+        }
+
+        let result = constraint.with(priority: priority)
+
+        prepare()
+        context.add(result)
+
+        return result
+    }
+
+    func center(
+        axis: NSLayoutConstraint.Axis,
+        to: PositionConstrainableProxy,
+        toAttribute: NSLayoutConstraint.Attribute? = nil,
+        multiplier: CGFloat,
+        offset: CGFloat,
+        relation: ConstraintRelation,
+        priority: UILayoutPriority
+    ) -> NSLayoutConstraint {
+
+        let attribute: NSLayoutConstraint.Attribute
+        switch axis {
+        case .horizontal:
+            attribute = .centerX
+        case .vertical:
+            attribute = .centerY
+        @unknown default:
+            assertionFailure("🔥 Unexpected axis \(axis) to be centered! Assuming horizontal")
+            attribute = .centerX
+        }
+
+        let _relation: NSLayoutConstraint.Relation
+        switch relation {
+        case .equal:
+            _relation = .equal
+        case .equalOrLess:
+            _relation = .lessThanOrEqual
+        case .equalOrGreater:
+            _relation = .greaterThanOrEqual
+        }
+
+        let constraint = NSLayoutConstraint(
+            item: item,
+            attribute: attribute,
+            relatedBy: _relation,
+            toItem: to.item,
+            attribute: toAttribute ?? attribute,
+            multiplier: multiplier,
+            constant: offset
+        ).with(priority: priority)
+
+        prepare()
+        context.add(constraint)
+
+        return constraint
+    }
+}

--- a/Sources/AutoLayout/ConstrainableProxy.swift
+++ b/Sources/AutoLayout/ConstrainableProxy.swift
@@ -333,7 +333,7 @@ extension CenterYConstrainableProxy {
 
     @discardableResult
     func centerY(
-        to view: PositionConstrainableProxy,
+        to view0: PositionConstrainableProxy,
         multiplier: CGFloat = 1,
         offset: CGFloat = 0,
         relation: ConstraintRelation = .equal,
@@ -342,7 +342,7 @@ extension CenterYConstrainableProxy {
 
         center(
             axis: .vertical,
-            to: view,
+            to: view0,
             multiplier: multiplier,
             offset: offset,
             relation: relation,
@@ -352,7 +352,7 @@ extension CenterYConstrainableProxy {
 
     @discardableResult
     func centerYToTop(
-        of view: PositionConstrainableProxy,
+        of view0: PositionConstrainableProxy,
         multiplier: CGFloat = 1,
         offset: CGFloat = 0,
         relation: ConstraintRelation = .equal,
@@ -361,7 +361,7 @@ extension CenterYConstrainableProxy {
 
         center(
             axis: .vertical,
-            to: view,
+            to: view0,
             toAttribute: .top,
             multiplier: multiplier,
             offset: offset,
@@ -372,7 +372,7 @@ extension CenterYConstrainableProxy {
 
     @discardableResult
     func centerYToBottom(
-        of view: PositionConstrainableProxy,
+        of view0: PositionConstrainableProxy,
         multiplier: CGFloat = 1,
         offset: CGFloat = 0,
         relation: ConstraintRelation = .equal,
@@ -381,7 +381,7 @@ extension CenterYConstrainableProxy {
 
         center(
             axis: .vertical,
-            to: view,
+            to: view0,
             toAttribute: .bottom,
             multiplier: multiplier,
             offset: offset,
@@ -400,7 +400,7 @@ extension CenterXConstrainableProxy {
 
     @discardableResult
     func centerX(
-        to view: PositionConstrainableProxy,
+        to view0: PositionConstrainableProxy,
         multiplier: CGFloat = 1,
         offset: CGFloat = 0,
         relation: ConstraintRelation = .equal,
@@ -409,7 +409,7 @@ extension CenterXConstrainableProxy {
 
         center(
             axis: .horizontal,
-            to: view,
+            to: view0,
             multiplier: multiplier,
             offset: offset,
             relation: relation,
@@ -458,15 +458,15 @@ extension CenterConstrainableProxy {
 
     @discardableResult
     func center(
-        in view: PositionConstrainableProxy,
+        in view0: PositionConstrainableProxy,
         offset: CGPoint = .zero,
         relation: ConstraintRelation = .equal,
         priority: UILayoutPriority = .required
     ) -> [NSLayoutConstraint] {
 
         let constraints: [NSLayoutConstraint] = [
-            centerX(to: view, offset: offset.x, relation: relation, priority: priority),
-            centerY(to: view, offset: offset.y, relation: relation, priority: priority)
+            centerX(to: view0, offset: offset.x, relation: relation, priority: priority),
+            centerY(to: view0, offset: offset.y, relation: relation, priority: priority)
         ]
 
         return constraints
@@ -497,7 +497,7 @@ extension WidthConstrainableProxy {
 
     @discardableResult
     func width(
-        to view: WidthConstrainableProxy,
+        to view0: WidthConstrainableProxy,
         multiplier: CGFloat = 1,
         offset: CGFloat = 0,
         relation: ConstraintRelation = .equal,
@@ -506,7 +506,7 @@ extension WidthConstrainableProxy {
 
         constrain(
             from: width,
-            to: view.width,
+            to: view0.width,
             multiplier: multiplier,
             constant: offset,
             relation: relation,
@@ -539,7 +539,7 @@ extension HeightConstrainableProxy {
 
     @discardableResult
     func height(
-        to view: HeightConstrainableProxy,
+        to view0: HeightConstrainableProxy,
         multiplier: CGFloat = 1,
         offset: CGFloat = 0,
         relation: ConstraintRelation = .equal,
@@ -548,7 +548,7 @@ extension HeightConstrainableProxy {
 
         constrain(
             from: height,
-            to: view.height,
+            to: view0.height,
             multiplier: multiplier,
             constant: offset,
             relation: relation,
@@ -578,7 +578,7 @@ extension SizeConstrainableProxy {
 
     @discardableResult
     func size(
-        to view: SizeConstrainableProxy,
+        to view0: SizeConstrainableProxy,
         multiplier: CGFloat = 1,
         insets: CGSize = .zero,
         relation: ConstraintRelation = .equal,
@@ -586,8 +586,8 @@ extension SizeConstrainableProxy {
     ) -> [NSLayoutConstraint] {
 
         let constraints: [NSLayoutConstraint] = [
-            width(to: view, multiplier: multiplier, offset: insets.width, relation: relation, priority: priority),
-            height(to: view, multiplier: multiplier, offset: insets.height, relation: relation, priority: priority)
+            width(to: view0, multiplier: multiplier, offset: insets.width, relation: relation, priority: priority),
+            height(to: view0, multiplier: multiplier, offset: insets.height, relation: relation, priority: priority)
         ]
 
         return constraints
@@ -604,7 +604,7 @@ extension BaselineConstrainableProxy {
 
     @discardableResult
     func firstBaseline(
-        to view: BaselineConstrainableProxy,
+        to view0: BaselineConstrainableProxy,
         offset: CGFloat = 0,
         relation: ConstraintRelation = .equal,
         priority: UILayoutPriority = .required
@@ -612,7 +612,7 @@ extension BaselineConstrainableProxy {
 
         constrain(
             from: firstBaseline,
-            to: view.firstBaseline,
+            to: view0.firstBaseline,
             offset: offset,
             relation: relation,
             priority: priority
@@ -621,7 +621,7 @@ extension BaselineConstrainableProxy {
 
     @discardableResult
     func firstBaselineToTop(
-        of view: TopConstrainableProxy,
+        of view0: TopConstrainableProxy,
         offset: CGFloat = 0,
         relation: ConstraintRelation = .equal,
         priority: UILayoutPriority = .required
@@ -629,7 +629,7 @@ extension BaselineConstrainableProxy {
 
         constrain(
             from: firstBaseline,
-            to: view.top,
+            to: view0.top,
             offset: offset,
             relation: relation,
             priority: priority
@@ -638,7 +638,7 @@ extension BaselineConstrainableProxy {
 
     @discardableResult
     func firstBaselineToBottom(
-        of view: BottomConstrainableProxy,
+        of view0: BottomConstrainableProxy,
         offset: CGFloat = 0,
         relation: ConstraintRelation = .equal,
         priority: UILayoutPriority = .required
@@ -646,7 +646,7 @@ extension BaselineConstrainableProxy {
 
         constrain(
             from: firstBaseline,
-            to: view.bottom,
+            to: view0.bottom,
             offset: offset,
             relation: relation,
             priority: priority
@@ -655,7 +655,7 @@ extension BaselineConstrainableProxy {
 
     @discardableResult
     func lastBaseline(
-        to view: BaselineConstrainableProxy,
+        to view0: BaselineConstrainableProxy,
         offset: CGFloat = 0,
         relation: ConstraintRelation = .equal,
         priority: UILayoutPriority = .required
@@ -663,7 +663,7 @@ extension BaselineConstrainableProxy {
 
         constrain(
             from: lastBaseline,
-            to: view.lastBaseline,
+            to: view0.lastBaseline,
             offset: offset,
             relation: relation,
             priority: priority
@@ -672,7 +672,7 @@ extension BaselineConstrainableProxy {
 
     @discardableResult
     func lastBaselineToTop(
-        of view: TopConstrainableProxy,
+        of view0: TopConstrainableProxy,
         offset: CGFloat = 0,
         relation: ConstraintRelation = .equal,
         priority: UILayoutPriority = .required
@@ -680,7 +680,7 @@ extension BaselineConstrainableProxy {
 
         constrain(
             from: lastBaseline,
-            to: view.top,
+            to: view0.top,
             offset: offset,
             relation: relation,
             priority: priority
@@ -689,7 +689,7 @@ extension BaselineConstrainableProxy {
 
     @discardableResult
     func lastBaselineToBottom(
-        of view: BottomConstrainableProxy,
+        of view0: BottomConstrainableProxy,
         offset: CGFloat = 0,
         relation: ConstraintRelation = .equal,
         priority: UILayoutPriority = .required
@@ -697,7 +697,7 @@ extension BaselineConstrainableProxy {
 
         constrain(
             from: lastBaseline,
-            to: view.bottom,
+            to: view0.bottom,
             offset: offset,
             relation: relation,
             priority: priority

--- a/Sources/AutoLayout/ConstrainableProxy.swift
+++ b/Sources/AutoLayout/ConstrainableProxy.swift
@@ -333,7 +333,7 @@ extension CenterYConstrainableProxy {
 
     @discardableResult
     func centerY(
-        to view0: PositionConstrainableProxy,
+        to view: PositionConstrainableProxy,
         multiplier: CGFloat = 1,
         offset: CGFloat = 0,
         relation: ConstraintRelation = .equal,
@@ -342,7 +342,7 @@ extension CenterYConstrainableProxy {
 
         center(
             axis: .vertical,
-            to: view0,
+            to: view,
             multiplier: multiplier,
             offset: offset,
             relation: relation,
@@ -352,7 +352,7 @@ extension CenterYConstrainableProxy {
 
     @discardableResult
     func centerYToTop(
-        of view0: PositionConstrainableProxy,
+        of view: PositionConstrainableProxy,
         multiplier: CGFloat = 1,
         offset: CGFloat = 0,
         relation: ConstraintRelation = .equal,
@@ -361,7 +361,7 @@ extension CenterYConstrainableProxy {
 
         center(
             axis: .vertical,
-            to: view0,
+            to: view,
             toAttribute: .top,
             multiplier: multiplier,
             offset: offset,
@@ -372,7 +372,7 @@ extension CenterYConstrainableProxy {
 
     @discardableResult
     func centerYToBottom(
-        of view0: PositionConstrainableProxy,
+        of view: PositionConstrainableProxy,
         multiplier: CGFloat = 1,
         offset: CGFloat = 0,
         relation: ConstraintRelation = .equal,
@@ -381,7 +381,7 @@ extension CenterYConstrainableProxy {
 
         center(
             axis: .vertical,
-            to: view0,
+            to: view,
             toAttribute: .bottom,
             multiplier: multiplier,
             offset: offset,
@@ -400,7 +400,7 @@ extension CenterXConstrainableProxy {
 
     @discardableResult
     func centerX(
-        to view0: PositionConstrainableProxy,
+        to view: PositionConstrainableProxy,
         multiplier: CGFloat = 1,
         offset: CGFloat = 0,
         relation: ConstraintRelation = .equal,
@@ -409,7 +409,7 @@ extension CenterXConstrainableProxy {
 
         center(
             axis: .horizontal,
-            to: view0,
+            to: view,
             multiplier: multiplier,
             offset: offset,
             relation: relation,
@@ -458,15 +458,15 @@ extension CenterConstrainableProxy {
 
     @discardableResult
     func center(
-        in view0: PositionConstrainableProxy,
+        in view: PositionConstrainableProxy,
         offset: CGPoint = .zero,
         relation: ConstraintRelation = .equal,
         priority: UILayoutPriority = .required
     ) -> [NSLayoutConstraint] {
 
         let constraints: [NSLayoutConstraint] = [
-            centerX(to: view0, offset: offset.x, relation: relation, priority: priority),
-            centerY(to: view0, offset: offset.y, relation: relation, priority: priority)
+            centerX(to: view, offset: offset.x, relation: relation, priority: priority),
+            centerY(to: view, offset: offset.y, relation: relation, priority: priority)
         ]
 
         return constraints
@@ -497,7 +497,7 @@ extension WidthConstrainableProxy {
 
     @discardableResult
     func width(
-        to view0: WidthConstrainableProxy,
+        to view: WidthConstrainableProxy,
         multiplier: CGFloat = 1,
         offset: CGFloat = 0,
         relation: ConstraintRelation = .equal,
@@ -506,7 +506,7 @@ extension WidthConstrainableProxy {
 
         constrain(
             from: width,
-            to: view0.width,
+            to: view.width,
             multiplier: multiplier,
             constant: offset,
             relation: relation,
@@ -539,7 +539,7 @@ extension HeightConstrainableProxy {
 
     @discardableResult
     func height(
-        to view0: HeightConstrainableProxy,
+        to view: HeightConstrainableProxy,
         multiplier: CGFloat = 1,
         offset: CGFloat = 0,
         relation: ConstraintRelation = .equal,
@@ -548,7 +548,7 @@ extension HeightConstrainableProxy {
 
         constrain(
             from: height,
-            to: view0.height,
+            to: view.height,
             multiplier: multiplier,
             constant: offset,
             relation: relation,
@@ -578,7 +578,7 @@ extension SizeConstrainableProxy {
 
     @discardableResult
     func size(
-        to view0: SizeConstrainableProxy,
+        to view: SizeConstrainableProxy,
         multiplier: CGFloat = 1,
         insets: CGSize = .zero,
         relation: ConstraintRelation = .equal,
@@ -586,8 +586,8 @@ extension SizeConstrainableProxy {
     ) -> [NSLayoutConstraint] {
 
         let constraints: [NSLayoutConstraint] = [
-            width(to: view0, multiplier: multiplier, offset: insets.width, relation: relation, priority: priority),
-            height(to: view0, multiplier: multiplier, offset: insets.height, relation: relation, priority: priority)
+            width(to: view, multiplier: multiplier, offset: insets.width, relation: relation, priority: priority),
+            height(to: view, multiplier: multiplier, offset: insets.height, relation: relation, priority: priority)
         ]
 
         return constraints
@@ -604,7 +604,7 @@ extension BaselineConstrainableProxy {
 
     @discardableResult
     func firstBaseline(
-        to view0: BaselineConstrainableProxy,
+        to view: BaselineConstrainableProxy,
         offset: CGFloat = 0,
         relation: ConstraintRelation = .equal,
         priority: UILayoutPriority = .required
@@ -612,7 +612,7 @@ extension BaselineConstrainableProxy {
 
         constrain(
             from: firstBaseline,
-            to: view0.firstBaseline,
+            to: view.firstBaseline,
             offset: offset,
             relation: relation,
             priority: priority
@@ -621,7 +621,7 @@ extension BaselineConstrainableProxy {
 
     @discardableResult
     func firstBaselineToTop(
-        of view0: TopConstrainableProxy,
+        of view: TopConstrainableProxy,
         offset: CGFloat = 0,
         relation: ConstraintRelation = .equal,
         priority: UILayoutPriority = .required
@@ -629,7 +629,7 @@ extension BaselineConstrainableProxy {
 
         constrain(
             from: firstBaseline,
-            to: view0.top,
+            to: view.top,
             offset: offset,
             relation: relation,
             priority: priority
@@ -638,7 +638,7 @@ extension BaselineConstrainableProxy {
 
     @discardableResult
     func firstBaselineToBottom(
-        of view0: BottomConstrainableProxy,
+        of view: BottomConstrainableProxy,
         offset: CGFloat = 0,
         relation: ConstraintRelation = .equal,
         priority: UILayoutPriority = .required
@@ -646,7 +646,7 @@ extension BaselineConstrainableProxy {
 
         constrain(
             from: firstBaseline,
-            to: view0.bottom,
+            to: view.bottom,
             offset: offset,
             relation: relation,
             priority: priority
@@ -655,7 +655,7 @@ extension BaselineConstrainableProxy {
 
     @discardableResult
     func lastBaseline(
-        to view0: BaselineConstrainableProxy,
+        to view: BaselineConstrainableProxy,
         offset: CGFloat = 0,
         relation: ConstraintRelation = .equal,
         priority: UILayoutPriority = .required
@@ -663,7 +663,7 @@ extension BaselineConstrainableProxy {
 
         constrain(
             from: lastBaseline,
-            to: view0.lastBaseline,
+            to: view.lastBaseline,
             offset: offset,
             relation: relation,
             priority: priority
@@ -672,7 +672,7 @@ extension BaselineConstrainableProxy {
 
     @discardableResult
     func lastBaselineToTop(
-        of view0: TopConstrainableProxy,
+        of view: TopConstrainableProxy,
         offset: CGFloat = 0,
         relation: ConstraintRelation = .equal,
         priority: UILayoutPriority = .required
@@ -680,7 +680,7 @@ extension BaselineConstrainableProxy {
 
         constrain(
             from: lastBaseline,
-            to: view0.top,
+            to: view.top,
             offset: offset,
             relation: relation,
             priority: priority
@@ -689,7 +689,7 @@ extension BaselineConstrainableProxy {
 
     @discardableResult
     func lastBaselineToBottom(
-        of view0: BottomConstrainableProxy,
+        of view: BottomConstrainableProxy,
         offset: CGFloat = 0,
         relation: ConstraintRelation = .equal,
         priority: UILayoutPriority = .required
@@ -697,7 +697,7 @@ extension BaselineConstrainableProxy {
 
         constrain(
             from: lastBaseline,
-            to: view0.bottom,
+            to: view.bottom,
             offset: offset,
             relation: relation,
             priority: priority

--- a/Sources/AutoLayout/ConstrainableProxy.swift
+++ b/Sources/AutoLayout/ConstrainableProxy.swift
@@ -25,7 +25,7 @@ extension TopConstrainableProxy {
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
 
-        return constrain(
+        constrain(
             from: top,
             to: anotherProxy.top,
             offset: offset,
@@ -42,7 +42,7 @@ extension TopConstrainableProxy {
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
 
-        return constrain(
+        constrain(
             from: top,
             to: anotherProxy.bottom,
             offset: offset,
@@ -67,7 +67,7 @@ extension BottomConstrainableProxy {
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
 
-        return constrain(
+        constrain(
             from: bottom,
             to: anotherProxy.bottom,
             offset: offset,
@@ -84,7 +84,7 @@ extension BottomConstrainableProxy {
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
 
-        return constrain(
+        constrain(
             from: bottom,
             to: anotherProxy.top,
             offset: offset,
@@ -109,7 +109,7 @@ extension LeadingConstrainableProxy {
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
 
-        return constrain(
+        constrain(
             from: leading,
             to: anotherProxy.leading,
             offset: offset,
@@ -126,7 +126,7 @@ extension LeadingConstrainableProxy {
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
 
-        return constrain(
+        constrain(
             from: leading,
             to: anotherProxy.trailing,
             offset: offset,
@@ -143,7 +143,7 @@ extension LeadingConstrainableProxy {
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
 
-        return constrain(
+        constrain(
             from: leading,
             to: anotherProxy.centerX,
             offset: offset,
@@ -168,7 +168,7 @@ extension LeftConstrainableProxy {
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
 
-        return constrain(
+        constrain(
             from: left,
             to: anotherProxy.left,
             offset: offset,
@@ -185,7 +185,7 @@ extension LeftConstrainableProxy {
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
 
-        return constrain(
+        constrain(
             from: left,
             to: anotherProxy.right,
             offset: offset,
@@ -210,7 +210,7 @@ extension RightConstrainableProxy {
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
 
-        return constrain(
+        constrain(
             from: right,
             to: anotherProxy.right,
             offset: offset,
@@ -227,7 +227,7 @@ extension RightConstrainableProxy {
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
 
-        return constrain(
+        constrain(
             from: right,
             to: anotherProxy.left,
             offset: offset,
@@ -252,7 +252,7 @@ extension TrailingConstrainableProxy {
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
 
-        return constrain(
+        constrain(
             from: trailing,
             to: anotherProxy.trailing,
             offset: offset,
@@ -269,7 +269,7 @@ extension TrailingConstrainableProxy {
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
 
-        return constrain(
+        constrain(
             from: trailing,
             to: anotherProxy.leading,
             offset: offset,
@@ -286,7 +286,7 @@ extension TrailingConstrainableProxy {
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
 
-        return constrain(
+        constrain(
             from: trailing,
             to: anotherProxy.centerX,
             offset: offset,
@@ -340,7 +340,7 @@ extension CenterYConstrainableProxy {
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
 
-        return center(
+        center(
             axis: .vertical,
             to: view,
             multiplier: multiplier,
@@ -359,7 +359,7 @@ extension CenterYConstrainableProxy {
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
 
-        return center(
+        center(
             axis: .vertical,
             to: view,
             toAttribute: .top,
@@ -379,7 +379,7 @@ extension CenterYConstrainableProxy {
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
 
-        return center(
+        center(
             axis: .vertical,
             to: view,
             toAttribute: .bottom,
@@ -407,7 +407,7 @@ extension CenterXConstrainableProxy {
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
 
-        return center(
+        center(
             axis: .horizontal,
             to: view,
             multiplier: multiplier,
@@ -425,7 +425,7 @@ extension CenterXConstrainableProxy {
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
 
-        return constrain(
+        constrain(
             from: centerX,
             to: anotherProxy.leading,
             offset: offset,
@@ -442,7 +442,7 @@ extension CenterXConstrainableProxy {
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
 
-        return constrain(
+        constrain(
             from: centerX,
             to: anotherProxy.trailing,
             offset: offset,
@@ -487,7 +487,7 @@ extension WidthConstrainableProxy {
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
 
-        return constrain(
+        constrain(
             dimension: self.width,
             constant: width,
             relation: relation,
@@ -504,7 +504,7 @@ extension WidthConstrainableProxy {
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
 
-        return constrain(
+        constrain(
             from: width,
             to: view.width,
             multiplier: multiplier,
@@ -529,7 +529,7 @@ extension HeightConstrainableProxy {
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
 
-        return constrain(
+        constrain(
             dimension: self.height,
             constant: height,
             relation: relation,
@@ -546,7 +546,7 @@ extension HeightConstrainableProxy {
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
 
-        return constrain(
+        constrain(
             from: height,
             to: view.height,
             multiplier: multiplier,
@@ -610,7 +610,7 @@ extension BaselineConstrainableProxy {
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
 
-        return constrain(
+        constrain(
             from: firstBaseline,
             to: view.firstBaseline,
             offset: offset,
@@ -627,7 +627,7 @@ extension BaselineConstrainableProxy {
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
 
-        return constrain(
+        constrain(
             from: firstBaseline,
             to: view.top,
             offset: offset,
@@ -644,7 +644,7 @@ extension BaselineConstrainableProxy {
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
 
-        return constrain(
+        constrain(
             from: firstBaseline,
             to: view.bottom,
             offset: offset,
@@ -661,7 +661,7 @@ extension BaselineConstrainableProxy {
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
 
-        return constrain(
+        constrain(
             from: lastBaseline,
             to: view.lastBaseline,
             offset: offset,
@@ -678,7 +678,7 @@ extension BaselineConstrainableProxy {
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
 
-        return constrain(
+        constrain(
             from: lastBaseline,
             to: view.top,
             offset: offset,
@@ -695,7 +695,7 @@ extension BaselineConstrainableProxy {
         priority: UILayoutPriority = .required
     ) -> NSLayoutConstraint {
 
-        return constrain(
+        constrain(
             from: lastBaseline,
             to: view.bottom,
             offset: offset,

--- a/Sources/AutoLayout/ConstraintRelation.swift
+++ b/Sources/AutoLayout/ConstraintRelation.swift
@@ -1,0 +1,5 @@
+enum ConstraintRelation: Int {
+    case equal = 0
+    case equalOrLess = -1
+    case equalOrGreater = 1
+}

--- a/Sources/AutoLayout/LayoutGuideProxy.swift
+++ b/Sources/AutoLayout/LayoutGuideProxy.swift
@@ -4,50 +4,30 @@ final class LayoutGuideProxy: PositionConstrainableProxy {
 
     // MARK: - PositionConstrainable
 
-    var top: NSLayoutYAxisAnchor {
-        return guide.topAnchor
-    }
+    var top: NSLayoutYAxisAnchor { guide.topAnchor }
 
-    var bottom: NSLayoutYAxisAnchor {
-        return guide.bottomAnchor
-    }
+    var bottom: NSLayoutYAxisAnchor { guide.bottomAnchor }
 
-    var leading: NSLayoutXAxisAnchor {
-        return guide.leadingAnchor
-    }
+    var leading: NSLayoutXAxisAnchor { guide.leadingAnchor }
 
-    var trailing: NSLayoutXAxisAnchor {
-        return guide.trailingAnchor
-    }
+    var trailing: NSLayoutXAxisAnchor { guide.trailingAnchor }
 
-    var left: NSLayoutXAxisAnchor {
-        return guide.leftAnchor
-    }
+    var left: NSLayoutXAxisAnchor { guide.leftAnchor }
 
-    var right: NSLayoutXAxisAnchor {
-        return guide.rightAnchor
-    }
+    var right: NSLayoutXAxisAnchor { guide.rightAnchor }
 
-    var height: NSLayoutDimension {
-        return guide.heightAnchor
-    }
+    var height: NSLayoutDimension { guide.heightAnchor }
 
-    var width: NSLayoutDimension {
-        return guide.widthAnchor
-    }
+    var width: NSLayoutDimension { guide.widthAnchor }
 
-    var centerY: NSLayoutYAxisAnchor {
-        return guide.centerYAnchor
-    }
+    var centerY: NSLayoutYAxisAnchor { guide.centerYAnchor }
 
-    var centerX: NSLayoutXAxisAnchor {
-        return guide.centerXAnchor
-    }
+    var centerX: NSLayoutXAxisAnchor { guide.centerXAnchor }
 
     // MARK: - ConstrainableProxy
 
     let context: LayoutContext
-    var item: AnyObject { return guide }
+    var item: AnyObject { guide }
 
     private let guide: UILayoutGuide
 

--- a/Sources/AutoLayout/LayoutGuideProxy.swift
+++ b/Sources/AutoLayout/LayoutGuideProxy.swift
@@ -1,0 +1,63 @@
+import UIKit
+
+final class LayoutGuideProxy: PositionConstrainableProxy {
+
+    // MARK: - PositionConstrainable
+
+    var top: NSLayoutYAxisAnchor {
+        return guide.topAnchor
+    }
+
+    var bottom: NSLayoutYAxisAnchor {
+        return guide.bottomAnchor
+    }
+
+    var leading: NSLayoutXAxisAnchor {
+        return guide.leadingAnchor
+    }
+
+    var trailing: NSLayoutXAxisAnchor {
+        return guide.trailingAnchor
+    }
+
+    var left: NSLayoutXAxisAnchor {
+        return guide.leftAnchor
+    }
+
+    var right: NSLayoutXAxisAnchor {
+        return guide.rightAnchor
+    }
+
+    var height: NSLayoutDimension {
+        return guide.heightAnchor
+    }
+
+    var width: NSLayoutDimension {
+        return guide.widthAnchor
+    }
+
+    var centerY: NSLayoutYAxisAnchor {
+        return guide.centerYAnchor
+    }
+
+    var centerX: NSLayoutXAxisAnchor {
+        return guide.centerXAnchor
+    }
+
+    // MARK: - ConstrainableProxy
+
+    let context: LayoutContext
+    var item: AnyObject { return guide }
+
+    private let guide: UILayoutGuide
+
+    // MARK: - Lifecycle
+
+    init(context: LayoutContext, guide: UILayoutGuide) {
+
+        self.context = context
+        self.guide = guide
+    }
+
+    func prepare() {}
+}

--- a/Sources/AutoLayout/LayoutItem.swift
+++ b/Sources/AutoLayout/LayoutItem.swift
@@ -15,7 +15,7 @@ extension UIView: LayoutItem {
 
     func proxy(with context: LayoutContext) -> ViewProxy {
 
-        return ViewProxy(context: context, view: self)
+        ViewProxy(context: context, view: self)
     }
 }
 
@@ -27,6 +27,6 @@ extension UILayoutGuide: LayoutItem {
 
     func proxy(with context: LayoutContext) -> LayoutGuideProxy {
 
-        return LayoutGuideProxy(context: context, guide: self)
+        LayoutGuideProxy(context: context, guide: self)
     }
 }

--- a/Sources/AutoLayout/LayoutItem.swift
+++ b/Sources/AutoLayout/LayoutItem.swift
@@ -1,0 +1,32 @@
+import UIKit
+
+protocol LayoutItem: AnyObject {
+
+    associatedtype ProxyType: ConstrainableProxy
+
+    func proxy(with context: LayoutContext) -> ProxyType
+}
+
+// MARK: - UIView
+
+extension UIView: LayoutItem {
+
+    typealias ProxyType = ViewProxy
+
+    func proxy(with context: LayoutContext) -> ViewProxy {
+
+        return ViewProxy(context: context, view: self)
+    }
+}
+
+// MARK: - UILayoutGuide
+
+extension UILayoutGuide: LayoutItem {
+
+    typealias ProxyType = LayoutGuideProxy
+
+    func proxy(with context: LayoutContext) -> LayoutGuideProxy {
+
+        return LayoutGuideProxy(context: context, guide: self)
+    }
+}

--- a/Sources/AutoLayout/NSLayoutConstraint+Helpers.swift
+++ b/Sources/AutoLayout/NSLayoutConstraint+Helpers.swift
@@ -1,0 +1,16 @@
+import UIKit
+
+extension NSLayoutConstraint {
+
+    func with(priority: UILayoutPriority) -> NSLayoutConstraint {
+
+        self.priority = priority
+        return self
+    }
+
+    func set(active: Bool) -> NSLayoutConstraint {
+
+        isActive = active
+        return self
+    }
+}

--- a/Sources/AutoLayout/ViewProxy.swift
+++ b/Sources/AutoLayout/ViewProxy.swift
@@ -1,0 +1,96 @@
+import UIKit
+
+final class ViewProxy: PositionConstrainableProxy, BaselineConstrainableProxy {
+
+    // MARK: - PositionConstrainableProxy
+
+    var top: NSLayoutYAxisAnchor {
+        return view.topAnchor
+    }
+
+    var bottom: NSLayoutYAxisAnchor {
+        return view.bottomAnchor
+    }
+
+    var leading: NSLayoutXAxisAnchor {
+        return view.leadingAnchor
+    }
+
+    var trailing: NSLayoutXAxisAnchor {
+        return view.trailingAnchor
+    }
+
+    var left: NSLayoutXAxisAnchor {
+        return view.leftAnchor
+    }
+
+    var right: NSLayoutXAxisAnchor {
+        return view.rightAnchor
+    }
+
+    var height: NSLayoutDimension {
+        return view.heightAnchor
+    }
+
+    var width: NSLayoutDimension {
+        return view.widthAnchor
+    }
+
+    var centerY: NSLayoutYAxisAnchor {
+        return view.centerYAnchor
+    }
+
+    var centerX: NSLayoutXAxisAnchor {
+        return view.centerXAnchor
+    }
+
+    // MARK: - BaselineConstrainableProxy
+
+    var firstBaseline: NSLayoutYAxisAnchor {
+        return view.firstBaselineAnchor
+    }
+
+    var lastBaseline: NSLayoutYAxisAnchor {
+        return view.lastBaselineAnchor
+    }
+
+    // MARK: - ConstrainableProxy
+
+    let context: LayoutContext
+    var item: AnyObject { return view }
+
+    // MARK: - Properties
+
+    var layoutMarginsGuide: LayoutGuideProxy {
+        return view.layoutMarginsGuide.proxy(with: context)
+    }
+
+    @available(iOS 11.0, *)
+    var safeAreaLayoutGuide: LayoutGuideProxy {
+        return view.safeAreaLayoutGuide.proxy(with: context)
+    }
+
+    var safeArea: LayoutGuideProxy {
+
+        if #available(iOS 11.0, *) {
+            return safeAreaLayoutGuide
+        } else {
+            return layoutMarginsGuide
+        }
+    }
+
+    private let view: UIView
+
+    // MARK: - Lifecycle
+
+    init(context: LayoutContext, view: UIView) {
+
+        self.context = context
+        self.view = view
+    }
+
+    func prepare() {
+
+        return view.translatesAutoresizingMaskIntoConstraints = false
+    }
+}

--- a/Sources/AutoLayout/ViewProxy.swift
+++ b/Sources/AutoLayout/ViewProxy.swift
@@ -4,71 +4,43 @@ final class ViewProxy: PositionConstrainableProxy, BaselineConstrainableProxy {
 
     // MARK: - PositionConstrainableProxy
 
-    var top: NSLayoutYAxisAnchor {
-        return view.topAnchor
-    }
+    var top: NSLayoutYAxisAnchor { view.topAnchor }
 
-    var bottom: NSLayoutYAxisAnchor {
-        return view.bottomAnchor
-    }
+    var bottom: NSLayoutYAxisAnchor { view.bottomAnchor }
 
-    var leading: NSLayoutXAxisAnchor {
-        return view.leadingAnchor
-    }
+    var leading: NSLayoutXAxisAnchor { view.leadingAnchor }
 
-    var trailing: NSLayoutXAxisAnchor {
-        return view.trailingAnchor
-    }
+    var trailing: NSLayoutXAxisAnchor { view.trailingAnchor }
 
-    var left: NSLayoutXAxisAnchor {
-        return view.leftAnchor
-    }
+    var left: NSLayoutXAxisAnchor { view.leftAnchor }
 
-    var right: NSLayoutXAxisAnchor {
-        return view.rightAnchor
-    }
+    var right: NSLayoutXAxisAnchor { view.rightAnchor }
 
-    var height: NSLayoutDimension {
-        return view.heightAnchor
-    }
+    var height: NSLayoutDimension { view.heightAnchor }
 
-    var width: NSLayoutDimension {
-        return view.widthAnchor
-    }
+    var width: NSLayoutDimension { view.widthAnchor }
 
-    var centerY: NSLayoutYAxisAnchor {
-        return view.centerYAnchor
-    }
+    var centerY: NSLayoutYAxisAnchor { view.centerYAnchor }
 
-    var centerX: NSLayoutXAxisAnchor {
-        return view.centerXAnchor
-    }
+    var centerX: NSLayoutXAxisAnchor { view.centerXAnchor }
 
     // MARK: - BaselineConstrainableProxy
 
-    var firstBaseline: NSLayoutYAxisAnchor {
-        return view.firstBaselineAnchor
-    }
+    var firstBaseline: NSLayoutYAxisAnchor { view.firstBaselineAnchor }
 
-    var lastBaseline: NSLayoutYAxisAnchor {
-        return view.lastBaselineAnchor
-    }
+    var lastBaseline: NSLayoutYAxisAnchor { view.lastBaselineAnchor }
 
     // MARK: - ConstrainableProxy
 
     let context: LayoutContext
-    var item: AnyObject { return view }
+    var item: AnyObject { view }
 
     // MARK: - Properties
 
-    var layoutMarginsGuide: LayoutGuideProxy {
-        return view.layoutMarginsGuide.proxy(with: context)
-    }
+    var layoutMarginsGuide: LayoutGuideProxy { view.layoutMarginsGuide.proxy(with: context) }
 
     @available(iOS 11.0, *)
-    var safeAreaLayoutGuide: LayoutGuideProxy {
-        return view.safeAreaLayoutGuide.proxy(with: context)
-    }
+    var safeAreaLayoutGuide: LayoutGuideProxy { view.safeAreaLayoutGuide.proxy(with: context) }
 
     var safeArea: LayoutGuideProxy {
 
@@ -91,6 +63,6 @@ final class ViewProxy: PositionConstrainableProxy, BaselineConstrainableProxy {
 
     func prepare() {
 
-        return view.translatesAutoresizingMaskIntoConstraints = false
+        view.translatesAutoresizingMaskIntoConstraints = false
     }
 }

--- a/Tests/AlicerceTests/AutoLayout/BaseConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/BaseConstrainableProxyTestCase.swift
@@ -1,0 +1,24 @@
+import XCTest
+
+class BaseConstrainableProxyTestCase: XCTestCase {
+
+    private(set) var host: UIView!
+    private(set) var view: UIView!
+
+    override func setUp() {
+
+        host = UIView(frame: CGRect(x: 0, y: 0, width: 500, height: 500))
+        view = UIView()
+        host.addSubview(view)
+
+        super.setUp()
+    }
+
+    override func tearDown() {
+
+        view = nil
+        host = nil
+
+        super.tearDown()
+    }
+}

--- a/Tests/AlicerceTests/AutoLayout/BaseConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/BaseConstrainableProxyTestCase.swift
@@ -3,21 +3,51 @@ import XCTest
 class BaseConstrainableProxyTestCase: XCTestCase {
 
     private(set) var host: UIView!
-    private(set) var view: UIView!
+    private(set) var view0: UIView!
+    private(set) var view1: UIView!
+    private(set) var view2: UIView!
+    private(set) var view3: UIView!
+    private(set) var view4: UIView!
+    private(set) var view5: UIView!
+    private(set) var layoutGuide: UILayoutGuide!
 
     override func setUp() {
 
         host = UIView(frame: CGRect(x: 0, y: 0, width: 500, height: 500))
-        view = UIView()
-        host.addSubview(view)
+
+        view0 = UIView()
+        view1 = UIView()
+        view2 = UIView()
+        view3 = UIView()
+        view4 = UIView()
+        view5 = UIView()
+
+        layoutGuide = UILayoutGuide()
+
+        host.addSubview(view0)
+        host.addSubview(view1)
+        host.addSubview(view2)
+        host.addSubview(view3)
+        host.addSubview(view4)
+        host.addSubview(view5)
+
+        host.addLayoutGuide(layoutGuide)
 
         super.setUp()
     }
 
     override func tearDown() {
 
-        view = nil
+        view5 = nil
+        view4 = nil
+        view3 = nil
+        view2 = nil
+        view1 = nil
+        view0 = nil
+
         host = nil
+
+        layoutGuide = nil
 
         super.tearDown()
     }

--- a/Tests/AlicerceTests/AutoLayout/BottomConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/BottomConstrainableProxyTestCase.swift
@@ -7,19 +7,22 @@ final class BottomConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         super.setUp()
 
-        view.widthAnchor.constraint(equalToConstant: 100).isActive = true
-        view.heightAnchor.constraint(equalToConstant: 100).isActive = true
+        view0.widthAnchor.constraint(equalToConstant: 100).isActive = true
+        view0.heightAnchor.constraint(equalToConstant: 100).isActive = true
+
+        layoutGuide.widthAnchor.constraint(equalToConstant: 100).isActive = true
+        layoutGuide.heightAnchor.constraint(equalToConstant: 100).isActive = true
     }
 
     func testConstrain_WithBottomConstraint_ShouldSupportRelativeEquality() {
 
         var constraint: NSLayoutConstraint!
-        constrain(host, view) { host, view in
+        constrain(host, view0) { host, view in
             constraint = view.bottom(to: host)
         }
 
         let expected = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .bottom,
             relatedBy: .equal,
             toItem: host,
@@ -34,20 +37,21 @@ final class BottomConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         host.layoutIfNeeded()
 
-        XCTAssertEqual(view.frame.maxY, 500)
+        XCTAssertEqual(view0.frame.maxY, 500)
     }
+
 
     func testConstrain_withBottomConstraint_ShouldSupportRelativeInequalities() {
 
         var constraint1: NSLayoutConstraint!
         var constraint2: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint1 = view.bottom(to: host, relation: .equalOrLess)
-            constraint2 = view.bottom(to: host, relation: .equalOrGreater)
+        constrain(host, view0) { host, view0 in
+            constraint1 = view0.bottom(to: host, relation: .equalOrLess)
+            constraint2 = view0.bottom(to: host, relation: .equalOrGreater)
         }
 
         let expected1 = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .bottom,
             relatedBy: .lessThanOrEqual,
             toItem: host,
@@ -61,7 +65,7 @@ final class BottomConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
         XCTAssertConstraint(constraint1, expected1)
 
         let expected2 = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .bottom,
             relatedBy: .greaterThanOrEqual,
             toItem: host,
@@ -76,18 +80,18 @@ final class BottomConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         host.layoutIfNeeded()
 
-        XCTAssertEqual(view.frame.maxY, 500)
+        XCTAssertEqual(view0.frame.maxY, 500)
     }
 
     func testConstrain_WithBottomConstraint_ShouldSupportPositiveOffset() {
 
         var constraint: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint = view.bottom(to: host, offset: 100)
+        constrain(host, view0) { host, view0 in
+            constraint = view0.bottom(to: host, offset: 100)
         }
 
         let expected = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .bottom,
             relatedBy: .equal,
             toItem: host,
@@ -102,18 +106,18 @@ final class BottomConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         host.layoutIfNeeded()
 
-        XCTAssertEqual(view.frame.maxY, 500 + 100)
+        XCTAssertEqual(view0.frame.maxY, 500 + 100)
     }
 
     func testConstrain_WithBottomConstraint_ShouldSupportNegativeOffset() {
 
         var constraint: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint = view.bottom(to: host, offset: -100)
+        constrain(host, view0) { host, view0 in
+            constraint = view0.bottom(to: host, offset: -100)
         }
 
         let expected = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .bottom,
             relatedBy: .equal,
             toItem: host,
@@ -128,18 +132,18 @@ final class BottomConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         host.layoutIfNeeded()
 
-        XCTAssertEqual(view.frame.maxY, 500 - 100)
+        XCTAssertEqual(view0.frame.maxY, 500 - 100)
     }
 
     func testConstrain_WithBottomConstraint_ShouldSupportTopAttribute() {
 
         var constraint: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint = view.bottomToTop(of: host)
+        constrain(host, view0) { host, view0 in
+            constraint = view0.bottomToTop(of: host)
         }
 
         let expected = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .bottom,
             relatedBy: .equal,
             toItem: host,
@@ -153,18 +157,18 @@ final class BottomConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         host.layoutIfNeeded()
 
-        XCTAssertEqual(view.frame.maxY, 0)
+        XCTAssertEqual(view0.frame.maxY, 0)
     }
 
     func testConstrain_WithBottomConstraint_ShouldSupportCustomPriority() {
 
         var constraint: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint = view.bottom(to: host, priority: .init(666))
+        constrain(host, view0) { host, view0 in
+            constraint = view0.bottom(to: host, priority: .init(666))
         }
 
         let expected = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .bottom,
             relatedBy: .equal,
             toItem: host,
@@ -176,5 +180,76 @@ final class BottomConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
         )
 
         XCTAssertConstraint(constraint, expected)
+    }
+
+    func testConstrain_WithLayoutGuideBottomConstraint_ShouldSupportRelativeEquality() {
+
+        var constraint: NSLayoutConstraint!
+
+        constrain(host, layoutGuide) { host, layoutGuide in
+            constraint = layoutGuide.bottom(to: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: layoutGuide!,
+            attribute: .bottom,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .bottom,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(layoutGuide.layoutFrame.maxY, 500)
+    }
+
+    func testConstrain_WithAlignBottomConstraint_ShouldSupportRelativeEquality() {
+
+        view1.translatesAutoresizingMaskIntoConstraints = false
+        view2.translatesAutoresizingMaskIntoConstraints = false
+
+        var constraints: [NSLayoutConstraint]!
+        constrain(host, view0, view1, view2) { host, view0, view1, view2 in
+            view0.bottom(to: host, offset: -50)
+            constraints = [view0, view1, view2].alignBottom()
+        }
+
+        let expected = [
+            NSLayoutConstraint(
+                item: view0!,
+                attribute: .bottom,
+                relatedBy: .equal,
+                toItem: view1,
+                attribute: .bottom,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: true
+            ),
+            NSLayoutConstraint(
+                item: view0!,
+                attribute: .bottom,
+                relatedBy: .equal,
+                toItem: view2,
+                attribute: .bottom,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: true
+            )
+        ]
+
+        XCTAssertConstraints(constraints, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.maxY, view1.frame.maxY)
+        XCTAssertEqual(view0.frame.maxY, view2.frame.maxY)
     }
 }

--- a/Tests/AlicerceTests/AutoLayout/BottomConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/BottomConstrainableProxyTestCase.swift
@@ -40,7 +40,6 @@ final class BottomConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
         XCTAssertEqual(view0.frame.maxY, 500)
     }
 
-
     func testConstrain_withBottomConstraint_ShouldSupportRelativeInequalities() {
 
         var constraint1: NSLayoutConstraint!
@@ -207,6 +206,13 @@ final class BottomConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
         host.layoutIfNeeded()
 
         XCTAssertEqual(layoutGuide.layoutFrame.maxY, 500)
+    }
+
+    func testConstrain_WithAlignBottomConstraintAndEmptyArray_ShouldReturnEmptyArray() {
+
+        let constraints = [UIView.ProxyType]().alignBottom()
+
+        XCTAssertConstraints(constraints, [])
     }
 
     func testConstrain_WithAlignBottomConstraint_ShouldSupportRelativeEquality() {

--- a/Tests/AlicerceTests/AutoLayout/BottomConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/BottomConstrainableProxyTestCase.swift
@@ -1,0 +1,180 @@
+import XCTest
+@testable import Alicerce
+
+final class BottomConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
+
+    override func setUp() {
+
+        super.setUp()
+
+        view.widthAnchor.constraint(equalToConstant: 100).isActive = true
+        view.heightAnchor.constraint(equalToConstant: 100).isActive = true
+    }
+
+    func testConstrain_WithBottomConstraint_ShouldSupportRelativeEquality() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint = view.bottom(to: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view!,
+            attribute: .bottom,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .bottom,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame.maxY, 500)
+    }
+
+    func testConstrain_withBottomConstraint_ShouldSupportRelativeInequalities() {
+
+        var constraint1: NSLayoutConstraint!
+        var constraint2: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint1 = view.bottom(to: host, relation: .equalOrLess)
+            constraint2 = view.bottom(to: host, relation: .equalOrGreater)
+        }
+
+        let expected1 = NSLayoutConstraint(
+            item: view!,
+            attribute: .bottom,
+            relatedBy: .lessThanOrEqual,
+            toItem: host,
+            attribute: .bottom,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint1, expected1)
+
+        let expected2 = NSLayoutConstraint(
+            item: view!,
+            attribute: .bottom,
+            relatedBy: .greaterThanOrEqual,
+            toItem: host,
+            attribute: .bottom,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint2, expected2)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame.maxY, 500)
+    }
+
+    func testConstrain_WithBottomConstraint_ShouldSupportPositiveOffset() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint = view.bottom(to: host, offset: 100)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view!,
+            attribute: .bottom,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .bottom,
+            multiplier: 1,
+            constant: 100,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame.maxY, 500 + 100)
+    }
+
+    func testConstrain_WithBottomConstraint_ShouldSupportNegativeOffset() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint = view.bottom(to: host, offset: -100)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view!,
+            attribute: .bottom,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .bottom,
+            multiplier: 1,
+            constant: -100,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame.maxY, 500 - 100)
+    }
+
+    func testConstrain_WithBottomConstraint_ShouldSupportTopAttribute() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint = view.bottomToTop(of: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view!,
+            attribute: .bottom,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .top,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true)
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame.maxY, 0)
+    }
+
+    func testConstrain_WithBottomConstraint_ShouldSupportCustomPriority() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint = view.bottom(to: host, priority: .init(666))
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view!,
+            attribute: .bottom,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .bottom,
+            multiplier: 1,
+            constant: 0,
+            priority: .init(666),
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+    }
+}

--- a/Tests/AlicerceTests/AutoLayout/CenterConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/CenterConstrainableProxyTestCase.swift
@@ -1,0 +1,151 @@
+import XCTest
+@testable import Alicerce
+
+class CenterConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
+
+    private(set) var constraints0: [NSLayoutConstraint]!
+    private(set) var constraints1: [NSLayoutConstraint]!
+    private(set) var constraints2: [NSLayoutConstraint]!
+    private(set) var constraints3: [NSLayoutConstraint]!
+    private(set) var constraints4: [NSLayoutConstraint]!
+    private(set) var constraints5: [NSLayoutConstraint]!
+
+    override func tearDown() {
+
+        constraints0 = nil
+        constraints1 = nil
+        constraints2 = nil
+        constraints3 = nil
+        constraints4 = nil
+        constraints5 = nil
+
+        super.tearDown()
+    }
+
+    func testConstrain_WithOneCenterConstraint_ShouldSupportRelativeCenter() {
+
+        constrain(host, view0) { host, view0 in
+            constraints0 = view0.center(in: host)
+        }
+
+        XCTAssertConstraints(constraints0, expectedConstraints(view: view0, to: host))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.center, host.center)
+    }
+
+    func testConstrain_WithTwoCenterConstraint_ShouldSupportRelativeCenter() {
+
+        constrain(host, view0, view1) { host, view0, view1 in
+            constraints0 = view0.center(in: host)
+            constraints1 = view1.center(in: host)
+        }
+
+        XCTAssertConstraints(constraints0, expectedConstraints(view: view0, to: host))
+        XCTAssertConstraints(constraints1, expectedConstraints(view: view1, to: host))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.center, host.center)
+        XCTAssertEqual(view1.center, host.center)
+    }
+
+    func testConstrain_WithThreeCenterConstraint_ShouldSupportRelativeCenter() {
+
+        constrain(host, view0, view1, view2) { host, view0, view1, view2 in
+            constraints0 = view0.center(in: host)
+            constraints1 = view1.center(in: host)
+            constraints2 = view2.center(in: host)
+        }
+
+        XCTAssertConstraints(constraints0, expectedConstraints(view: view0, to: host))
+        XCTAssertConstraints(constraints1, expectedConstraints(view: view1, to: host))
+        XCTAssertConstraints(constraints2, expectedConstraints(view: view2, to: host))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.center, host.center)
+        XCTAssertEqual(view1.center, host.center)
+        XCTAssertEqual(view2.center, host.center)
+    }
+
+    func testConstrain_WithFourCenterConstraint_ShouldSupportRelativeCenter() {
+
+        constrain(host, view0, view1, view2, view3) { host, view0, view1, view2, view3 in
+            constraints0 = view0.center(in: host)
+            constraints1 = view1.center(in: host)
+            constraints2 = view2.center(in: host)
+            constraints3 = view3.center(in: host)
+        }
+
+        XCTAssertConstraints(constraints0, expectedConstraints(view: view0, to: host))
+        XCTAssertConstraints(constraints1, expectedConstraints(view: view1, to: host))
+        XCTAssertConstraints(constraints2, expectedConstraints(view: view2, to: host))
+        XCTAssertConstraints(constraints3, expectedConstraints(view: view3, to: host))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.center, host.center)
+        XCTAssertEqual(view1.center, host.center)
+        XCTAssertEqual(view2.center, host.center)
+        XCTAssertEqual(view3.center, host.center)
+    }
+
+    func testConstrain_WithFiveCenterConstraint_ShouldSupportRelativeCenter() {
+
+        constrain(host, view0, view1, view2, view3, view4) { host, view0, view1, view2, view3, view4 in
+            constraints0 = view0.center(in: host)
+            constraints1 = view1.center(in: host)
+            constraints2 = view2.center(in: host)
+            constraints3 = view3.center(in: host)
+            constraints4 = view4.center(in: host)
+        }
+
+        XCTAssertConstraints(constraints0, expectedConstraints(view: view0, to: host))
+        XCTAssertConstraints(constraints1, expectedConstraints(view: view1, to: host))
+        XCTAssertConstraints(constraints2, expectedConstraints(view: view2, to: host))
+        XCTAssertConstraints(constraints3, expectedConstraints(view: view3, to: host))
+        XCTAssertConstraints(constraints4, expectedConstraints(view: view4, to: host))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.center, host.center)
+        XCTAssertEqual(view1.center, host.center)
+        XCTAssertEqual(view2.center, host.center)
+        XCTAssertEqual(view3.center, host.center)
+        XCTAssertEqual(view4.center, host.center)
+    }
+}
+
+private extension CenterConstrainableProxyTestCase {
+
+    func expectedConstraints(view: UIView, to host: UIView) -> [NSLayoutConstraint] {
+
+        let centerX = NSLayoutConstraint(
+            item: view,
+            attribute: .centerX,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .centerX,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        let centerY = NSLayoutConstraint(
+            item: view,
+            attribute: .centerY,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .centerY,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        return [centerX, centerY]
+    }
+}

--- a/Tests/AlicerceTests/AutoLayout/CenterXConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/CenterXConstrainableProxyTestCase.swift
@@ -190,6 +190,40 @@ class CenterXConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
         XCTAssertEqual(view0.frame.midX, view1.frame.midX)
         XCTAssertEqual(view0.frame.midX, view2.frame.midX)
     }
+
+    func testConstrain_WithLayoutGuideCenterXConstraint_ShouldSupportRelativeEquality() {
+
+        var constraint: NSLayoutConstraint!
+
+        constrain(host, layoutGuide) { host, layoutGuide in
+            constraint = layoutGuide.centerX(to: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: layoutGuide!,
+            attribute: .centerX,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .centerX,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(layoutGuide.layoutFrame.midX, host.frame.midX)
+    }
+
+    func testConstrain_WithCenterXConstraintAndEmptyArray_ShouldReturnEmptyArray() {
+
+        let constraints = [UIView.ProxyType]().alignCenterX()
+
+        XCTAssertConstraints(constraints, [])
+    }
 }
 
 private extension CenterXConstrainableProxyTestCase {

--- a/Tests/AlicerceTests/AutoLayout/CenterXConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/CenterXConstrainableProxyTestCase.swift
@@ -1,0 +1,211 @@
+import XCTest
+@testable import Alicerce
+
+class CenterXConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
+
+    private(set) var constraint0: NSLayoutConstraint!
+    private(set) var constraint1: NSLayoutConstraint!
+    private(set) var constraint2: NSLayoutConstraint!
+    private(set) var constraint3: NSLayoutConstraint!
+    private(set) var constraint4: NSLayoutConstraint!
+    private(set) var constraint5: NSLayoutConstraint!
+
+    override func tearDown() {
+
+        constraint0 = nil
+        constraint1 = nil
+        constraint2 = nil
+        constraint3 = nil
+        constraint4 = nil
+        constraint5 = nil
+
+        super.tearDown()
+    }
+
+    func testConstrain_WithOneCenterXConstraint_ShouldSupportRelativeCenterX() {
+
+        constrain(host, view0) { host, view0 in
+            constraint0 = view0.centerX(to: host)
+        }
+
+        XCTAssertConstraint(constraint0, expectedConstraint(view: view0, to: host))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.center.x, host.center.x)
+    }
+
+    func testConstrain_WithTwoCenterXConstraint_ShouldSupportRelativeCenterX() {
+
+        constrain(host, view0, view1) { host, view0, view1 in
+            constraint0 = view0.centerX(to: host)
+            constraint1 = view1.centerX(to: host)
+        }
+
+        XCTAssertConstraint(constraint0, expectedConstraint(view: view0, to: host))
+        XCTAssertConstraint(constraint1, expectedConstraint(view: view1, to: host))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.center.x, host.center.x)
+        XCTAssertEqual(view1.center.x, host.center.x)
+    }
+
+    func testConstrain_WithThreeCenterXConstraint_ShouldSupportRelativeCenterX() {
+
+        constrain(host, view0, view1, view2) { host, view0, view1, view2 in
+            constraint0 = view0.centerX(to: host)
+            constraint1 = view1.centerX(to: host)
+            constraint2 = view2.centerX(to: host)
+        }
+
+        XCTAssertConstraint(constraint0, expectedConstraint(view: view0, to: host))
+        XCTAssertConstraint(constraint1, expectedConstraint(view: view1, to: host))
+        XCTAssertConstraint(constraint2, expectedConstraint(view: view2, to: host))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.center.x, host.center.x)
+        XCTAssertEqual(view1.center.x, host.center.x)
+        XCTAssertEqual(view2.center.x, host.center.x)
+    }
+
+    func testConstrain_WithFourCenterXConstraint_ShouldSupportRelativeCenterX() {
+
+        constrain(host, view0, view1, view2, view3) { host, view0, view1, view2, view3 in
+            constraint0 = view0.centerX(to: host)
+            constraint1 = view1.centerX(to: host)
+            constraint2 = view2.centerX(to: host)
+            constraint3 = view3.centerX(to: host)
+        }
+
+        XCTAssertConstraint(constraint0, expectedConstraint(view: view0, to: host))
+        XCTAssertConstraint(constraint1, expectedConstraint(view: view1, to: host))
+        XCTAssertConstraint(constraint2, expectedConstraint(view: view2, to: host))
+        XCTAssertConstraint(constraint3, expectedConstraint(view: view3, to: host))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.center.x, host.center.x)
+        XCTAssertEqual(view1.center.x, host.center.x)
+        XCTAssertEqual(view2.center.x, host.center.x)
+        XCTAssertEqual(view3.center.x, host.center.x)
+    }
+
+    func testConstrain_WithFiveCenterXConstraint_ShouldSupportRelativeCenterX() {
+
+        constrain(host, view0, view1, view2, view3, view4) { host, view0, view1, view2, view3, view4 in
+            constraint0 = view0.centerX(to: host)
+            constraint1 = view1.centerX(to: host)
+            constraint2 = view2.centerX(to: host)
+            constraint3 = view3.centerX(to: host)
+            constraint4 = view4.centerX(to: host)
+        }
+
+        XCTAssertConstraint(constraint0, expectedConstraint(view: view0, to: host))
+        XCTAssertConstraint(constraint1, expectedConstraint(view: view1, to: host))
+        XCTAssertConstraint(constraint2, expectedConstraint(view: view2, to: host))
+        XCTAssertConstraint(constraint3, expectedConstraint(view: view3, to: host))
+        XCTAssertConstraint(constraint4, expectedConstraint(view: view4, to: host))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.center.x, host.center.x)
+        XCTAssertEqual(view1.center.x, host.center.x)
+        XCTAssertEqual(view2.center.x, host.center.x)
+        XCTAssertEqual(view3.center.x, host.center.x)
+        XCTAssertEqual(view4.center.x, host.center.x)
+    }
+
+    func testConstrain_WithCenterXToLeadingConstraint_ShouldSupportRelativeCenterX() {
+
+        constrain(host, view0) { host, view0 in
+            constraint0 = view0.centerXToLeading(of: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view0!,
+            attribute: .centerX,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .leading,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint0, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.center.x, host.frame.minX)
+    }
+
+    func testConstrain_WithCenterXToTrailingConstraint_ShouldSupportRelativeCenterX() {
+
+        constrain(host, view0) { host, view0 in
+            constraint0 = view0.centerXToTrailing(of: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view0!,
+            attribute: .centerX,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .trailing,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint0, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.center.x, host.frame.maxX)
+    }
+
+    func testConstrain_WithAlignCenterXConstraint_ShouldSupportRelativeEquality() {
+
+        view1.translatesAutoresizingMaskIntoConstraints = false
+        view2.translatesAutoresizingMaskIntoConstraints = false
+
+        var constraints: [NSLayoutConstraint]!
+        constrain(host, view0, view1, view2) { host, view0, view1, view2 in
+            view0.centerX(to: host)
+            constraints = [view0, view1, view2].alignCenterX()
+        }
+
+        let expected = [
+            expectedConstraint(view: view0, to: view1),
+            expectedConstraint(view: view0, to: view2)
+        ]
+
+        XCTAssertConstraints(constraints, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.midX, view1.frame.midX)
+        XCTAssertEqual(view0.frame.midX, view2.frame.midX)
+    }
+}
+
+private extension CenterXConstrainableProxyTestCase {
+
+    func expectedConstraint(view: UIView, to host: UIView) -> NSLayoutConstraint {
+
+        NSLayoutConstraint(
+            item: view,
+            attribute: .centerX,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .centerX,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+    }
+}

--- a/Tests/AlicerceTests/AutoLayout/CenterYConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/CenterYConstrainableProxyTestCase.swift
@@ -190,6 +190,40 @@ class CenterYConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
         XCTAssertEqual(view0.frame.midY, view1.frame.midY)
         XCTAssertEqual(view0.frame.midY, view2.frame.midY)
     }
+
+    func testConstrain_WithLayoutGuideCenterYConstraint_ShouldSupportRelativeEquality() {
+
+        var constraint: NSLayoutConstraint!
+
+        constrain(host, layoutGuide) { host, layoutGuide in
+            constraint = layoutGuide.centerY(to: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: layoutGuide!,
+            attribute: .centerY,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .centerY,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(layoutGuide.layoutFrame.midY, host.frame.midY)
+    }
+
+    func testConstrain_WithCenterYConstraintAndEmptyArray_ShouldReturnEmptyArray() {
+
+        let constraints = [UIView.ProxyType]().alignCenterY()
+
+        XCTAssertConstraints(constraints, [])
+    }
 }
 
 private extension CenterYConstrainableProxyTestCase {

--- a/Tests/AlicerceTests/AutoLayout/CenterYConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/CenterYConstrainableProxyTestCase.swift
@@ -1,0 +1,211 @@
+import XCTest
+@testable import Alicerce
+
+class CenterYConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
+
+    private(set) var constraint0: NSLayoutConstraint!
+    private(set) var constraint1: NSLayoutConstraint!
+    private(set) var constraint2: NSLayoutConstraint!
+    private(set) var constraint3: NSLayoutConstraint!
+    private(set) var constraint4: NSLayoutConstraint!
+    private(set) var constraint5: NSLayoutConstraint!
+
+    override func tearDown() {
+
+        constraint0 = nil
+        constraint1 = nil
+        constraint2 = nil
+        constraint3 = nil
+        constraint4 = nil
+        constraint5 = nil
+
+        super.tearDown()
+    }
+
+    func testConstrain_WithOneCenterYConstraint_ShouldSupportRelativeCenterY() {
+
+        constrain(host, view0) { host, view0 in
+            constraint0 = view0.centerY(to: host)
+        }
+
+        XCTAssertConstraint(constraint0, expectedConstraint(view: view0, to: host))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.center.y, host.center.y)
+    }
+
+    func testConstrain_WithTwoCenterYConstraint_ShouldSupportRelativeCenterY() {
+
+        constrain(host, view0, view1) { host, view0, view1 in
+            constraint0 = view0.centerY(to: host)
+            constraint1 = view1.centerY(to: host)
+        }
+
+        XCTAssertConstraint(constraint0, expectedConstraint(view: view0, to: host))
+        XCTAssertConstraint(constraint1, expectedConstraint(view: view1, to: host))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.center.y, host.center.y)
+        XCTAssertEqual(view1.center.y, host.center.y)
+    }
+
+    func testConstrain_WithThreeCenterYConstraint_ShouldSupportRelativeCenterY() {
+
+        constrain(host, view0, view1, view2) { host, view0, view1, view2 in
+            constraint0 = view0.centerY(to: host)
+            constraint1 = view1.centerY(to: host)
+            constraint2 = view2.centerY(to: host)
+        }
+
+        XCTAssertConstraint(constraint0, expectedConstraint(view: view0, to: host))
+        XCTAssertConstraint(constraint1, expectedConstraint(view: view1, to: host))
+        XCTAssertConstraint(constraint2, expectedConstraint(view: view2, to: host))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.center.y, host.center.y)
+        XCTAssertEqual(view1.center.y, host.center.y)
+        XCTAssertEqual(view2.center.y, host.center.y)
+    }
+
+    func testConstrain_WithFourCenterYConstraint_ShouldSupportRelativeCenterY() {
+
+        constrain(host, view0, view1, view2, view3) { host, view0, view1, view2, view3 in
+            constraint0 = view0.centerY(to: host)
+            constraint1 = view1.centerY(to: host)
+            constraint2 = view2.centerY(to: host)
+            constraint3 = view3.centerY(to: host)
+        }
+
+        XCTAssertConstraint(constraint0, expectedConstraint(view: view0, to: host))
+        XCTAssertConstraint(constraint1, expectedConstraint(view: view1, to: host))
+        XCTAssertConstraint(constraint2, expectedConstraint(view: view2, to: host))
+        XCTAssertConstraint(constraint3, expectedConstraint(view: view3, to: host))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.center.y, host.center.y)
+        XCTAssertEqual(view1.center.y, host.center.y)
+        XCTAssertEqual(view2.center.y, host.center.y)
+        XCTAssertEqual(view3.center.y, host.center.y)
+    }
+
+    func testConstrain_WithFiveCenterYConstraint_ShouldSupportRelativeCenterY() {
+
+        constrain(host, view0, view1, view2, view3, view4) { host, view0, view1, view2, view3, view4 in
+            constraint0 = view0.centerY(to: host)
+            constraint1 = view1.centerY(to: host)
+            constraint2 = view2.centerY(to: host)
+            constraint3 = view3.centerY(to: host)
+            constraint4 = view4.centerY(to: host)
+        }
+
+        XCTAssertConstraint(constraint0, expectedConstraint(view: view0, to: host))
+        XCTAssertConstraint(constraint1, expectedConstraint(view: view1, to: host))
+        XCTAssertConstraint(constraint2, expectedConstraint(view: view2, to: host))
+        XCTAssertConstraint(constraint3, expectedConstraint(view: view3, to: host))
+        XCTAssertConstraint(constraint4, expectedConstraint(view: view4, to: host))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.center.y, host.center.y)
+        XCTAssertEqual(view1.center.y, host.center.y)
+        XCTAssertEqual(view2.center.y, host.center.y)
+        XCTAssertEqual(view3.center.y, host.center.y)
+        XCTAssertEqual(view4.center.y, host.center.y)
+    }
+
+    func testConstrain_WithCenterYToTopConstraint_ShouldSupportRelativeCenterY() {
+
+        constrain(host, view0) { host, view0 in
+            constraint0 = view0.centerYToTop(of: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view0!,
+            attribute: .centerY,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .top,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint0, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.center.y, host.frame.minY)
+    }
+
+    func testConstrain_WithCenterYToBottomConstraint_ShouldSupportRelativeCenterY() {
+
+        constrain(host, view0) { host, view0 in
+            constraint0 = view0.centerYToBottom(of: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view0!,
+            attribute: .centerY,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .bottom,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint0, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.center.y, host.frame.maxY)
+    }
+
+    func testConstrain_WithAlignCenterXConstraint_ShouldSupportRelativeEquality() {
+
+        view1.translatesAutoresizingMaskIntoConstraints = false
+        view2.translatesAutoresizingMaskIntoConstraints = false
+
+        var constraints: [NSLayoutConstraint]!
+        constrain(host, view0, view1, view2) { host, view0, view1, view2 in
+            view0.centerY(to: host)
+            constraints = [view0, view1, view2].alignCenterY()
+        }
+
+        let expected = [
+            expectedConstraint(view: view0, to: view1),
+            expectedConstraint(view: view0, to: view2)
+        ]
+
+        XCTAssertConstraints(constraints, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.midY, view1.frame.midY)
+        XCTAssertEqual(view0.frame.midY, view2.frame.midY)
+    }
+}
+
+private extension CenterYConstrainableProxyTestCase {
+
+    func expectedConstraint(view: UIView, to host: UIView) -> NSLayoutConstraint {
+
+        NSLayoutConstraint(
+            item: view,
+            attribute: .centerY,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .centerY,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+    }
+}

--- a/Tests/AlicerceTests/AutoLayout/EdgesConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/EdgesConstrainableProxyTestCase.swift
@@ -1,0 +1,381 @@
+// swiftlint:disable function_body_length
+
+import XCTest
+@testable import Alicerce
+
+final class EdgesConstrainableProxyTestCase: XCTestCase {
+
+    var host: UIView!
+    var view: UIView!
+
+    override func setUp() {
+
+        host = UIView(frame: CGRect(x: 0, y: 0, width: 500, height: 500))
+        view = UIView()
+
+        host.addSubview(view)
+
+        super.setUp()
+    }
+
+    override func tearDown() {
+
+        view = nil
+        host = nil
+
+        super.tearDown()
+    }
+
+    func testConstrain_WithEdgesConstraints_ShouldSupportRelativeEquality() {
+
+        var constraints: [NSLayoutConstraint]!
+        constrain(host, view) { host, view in
+            constraints = view.edges(to: host)
+        }
+
+        let expected = [
+            NSLayoutConstraint(
+                item: view!,
+                attribute: .top,
+                relatedBy: .equal,
+                toItem: host,
+                attribute: .top,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: true
+            ),
+            NSLayoutConstraint(
+                item: view!,
+                attribute: .leading,
+                relatedBy: .equal,
+                toItem: host,
+                attribute: .leading,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: true
+            ),
+            NSLayoutConstraint(
+                item: view!,
+                attribute: .bottom,
+                relatedBy: .equal,
+                toItem: host,
+                attribute: .bottom,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: true
+            ),
+            NSLayoutConstraint(
+                item: view!,
+                attribute: .trailing,
+                relatedBy: .equal,
+                toItem: host,
+                attribute: .trailing,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: true
+            )
+        ]
+
+        XCTAssertEdgesConstraints(constraints, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame, host.frame)
+    }
+
+    func testConstrain_withEdgesConstraints_ShouldSupportRelativeInequalities() {
+
+        var constraints1: [NSLayoutConstraint]!
+        var constraints2: [NSLayoutConstraint]!
+        constrain(host, view) { host, view in
+            constraints1 = view.edges(to: host, relation: .equalOrLess)
+            constraints2 = view.edges(to: host, relation: .equalOrGreater)
+        }
+
+        let expected1 = [
+            NSLayoutConstraint(
+                item: view!,
+                attribute: .top,
+                relatedBy: .lessThanOrEqual,
+                toItem: host,
+                attribute: .top,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: true
+            ),
+            NSLayoutConstraint(
+                item: view!,
+                attribute: .leading,
+                relatedBy: .lessThanOrEqual,
+                toItem: host,
+                attribute: .leading,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: true
+            ),
+            NSLayoutConstraint(
+                item: view!,
+                attribute: .bottom,
+                relatedBy: .lessThanOrEqual,
+                toItem: host,
+                attribute: .bottom,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: true
+            ),
+            NSLayoutConstraint(
+                item: view!,
+                attribute: .trailing,
+                relatedBy: .lessThanOrEqual,
+                toItem: host,
+                attribute: .trailing,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: true
+            )
+        ]
+
+        XCTAssertEdgesConstraints(constraints1, expected1)
+
+        let expected2 = [
+            NSLayoutConstraint(
+                item: view!,
+                attribute: .top,
+                relatedBy: .greaterThanOrEqual,
+                toItem: host,
+                attribute: .top,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: true
+            ),
+            NSLayoutConstraint(
+                item: view!,
+                attribute: .leading,
+                relatedBy: .greaterThanOrEqual,
+                toItem: host,
+                attribute: .leading,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: true
+            ),
+            NSLayoutConstraint(
+                item: view!,
+                attribute: .bottom,
+                relatedBy: .greaterThanOrEqual,
+                toItem: host,
+                attribute: .bottom,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: true
+            ),
+            NSLayoutConstraint(
+                item: view!,
+                attribute: .trailing,
+                relatedBy: .greaterThanOrEqual,
+                toItem: host,
+                attribute: .trailing,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: true
+            )
+        ]
+
+        XCTAssertEdgesConstraints(constraints2, expected2)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame, host.frame)
+    }
+
+    func testConstrain_WithEdgesConstraints_ShouldSupportInsets() {
+
+        let insets = UIEdgeInsets(top: 10, left: 20, bottom: 30, right: 40)
+
+        var constraints: [NSLayoutConstraint]!
+        constrain(host, view) { host, view in
+            constraints = view.edges(to: host, insets: insets)
+        }
+
+        let expected = [
+            NSLayoutConstraint(
+                item: view!,
+                attribute: .top,
+                relatedBy: .equal,
+                toItem: host,
+                attribute: .top,
+                multiplier: 1,
+                constant: 10,
+                priority: .required,
+                active: true
+            ),
+            NSLayoutConstraint(
+                item: view!,
+                attribute: .leading,
+                relatedBy: .equal,
+                toItem: host,
+                attribute: .leading,
+                multiplier: 1,
+                constant: 20,
+                priority: .required,
+                active: true
+            ),
+            NSLayoutConstraint(
+                item: view!,
+                attribute: .bottom,
+                relatedBy: .equal,
+                toItem: host,
+                attribute: .bottom,
+                multiplier: 1,
+                constant: -30,
+                priority: .required,
+                active: true
+            ),
+            NSLayoutConstraint(
+                item: view!,
+                attribute: .trailing,
+                relatedBy: .equal,
+                toItem: host,
+                attribute: .trailing,
+                multiplier: 1,
+                constant: -40,
+                priority: .required,
+                active: true
+            )
+        ]
+
+        XCTAssertEdgesConstraints(constraints, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame, host.frame.inset(by: insets))
+    }
+
+    func testConstrain_WithEdgesConstraints_ShouldSupportCustomPriority() {
+
+        var constraints: [NSLayoutConstraint]!
+        constrain(host, view) { host, view in
+            constraints = view.edges(to: host, priority: .init(666))
+        }
+
+        let expected = [
+            NSLayoutConstraint(
+                item: view!,
+                attribute: .top,
+                relatedBy: .equal,
+                toItem: host,
+                attribute: .top,
+                multiplier: 1,
+                constant: 0,
+                priority: .init(666),
+                active: true
+            ),
+            NSLayoutConstraint(
+                item: view!,
+                attribute: .leading,
+                relatedBy: .equal,
+                toItem: host,
+                attribute: .leading,
+                multiplier: 1,
+                constant: 0,
+                priority: .init(666),
+                active: true
+            ),
+            NSLayoutConstraint(
+                item: view!,
+                attribute: .bottom,
+                relatedBy: .equal,
+                toItem: host,
+                attribute: .bottom,
+                multiplier: 1,
+                constant: 0,
+                priority: .init(666),
+                active: true
+            ),
+            NSLayoutConstraint(
+                item: view!,
+                attribute: .trailing,
+                relatedBy: .equal,
+                toItem: host,
+                attribute: .trailing,
+                multiplier: 1,
+                constant: 0,
+                priority: .init(666),
+                active: true
+            )
+        ]
+
+        XCTAssertEdgesConstraints(constraints, expected)
+    }
+}
+
+// MARK: - XCTAssertEdgesConstraints
+
+private func XCTAssertEdgesConstraints(
+    _ constraints1: [NSLayoutConstraint],
+    _ constraints2: [NSLayoutConstraint],
+    file: StaticString = #file,
+    line: UInt = #line
+) {
+
+    guard constraints1.count == 4 else {
+        XCTFail("Invalid number of constraints.", file: file, line: line)
+        return
+    }
+
+    guard constraints1.count == constraints2.count else {
+        XCTFail("Arrays count doesn't match.", file: file, line: line)
+        return
+    }
+
+    if let top = extract(attribute: .top, from: constraints1, constraints2) {
+        XCTAssertConstraint(top.left, top.right, file: file, line: line)
+    } else {
+        XCTFail("Missing top constraints.", file: file, line: line)
+    }
+
+    if let bottom = extract(attribute: .bottom, from: constraints1, constraints2) {
+        XCTAssertConstraint(bottom.left, bottom.right, file: file, line: line)
+    } else {
+        XCTFail("Missing bottom constraints.", file: file, line: line)
+    }
+
+    if let leading = extract(attribute: .leading, from: constraints1, constraints2) {
+        XCTAssertConstraint(leading.left, leading.right, file: file, line: line)
+    } else {
+        XCTFail("Missing leading constraints.", file: file, line: line)
+    }
+
+    if let trailing = extract(attribute: .trailing, from: constraints1, constraints2) {
+        XCTAssertConstraint(trailing.left, trailing.right, file: file, line: line)
+    } else {
+        XCTFail("Missing trailing constraints.", file: file, line: line)
+    }
+}
+
+private func extract(
+    attribute: NSLayoutConstraint.Attribute,
+    from left: [NSLayoutConstraint],
+    _ right: [NSLayoutConstraint]
+) -> (left: NSLayoutConstraint, right: NSLayoutConstraint)? {
+
+    guard
+        let left = left.first(where: { $0.firstAttribute == attribute }),
+        let right = right.first(where: { $0.firstAttribute == attribute })
+    else {
+        return nil
+    }
+
+    return (left, right)
+}

--- a/Tests/AlicerceTests/AutoLayout/FirstBaselineConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/FirstBaselineConstrainableProxyTestCase.swift
@@ -1,0 +1,79 @@
+import XCTest
+@testable import Alicerce
+
+final class FirstBaselineConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
+
+    override func setUp() {
+
+        super.setUp()
+
+        view0.widthAnchor.constraint(equalToConstant: 100).isActive = true
+        view0.heightAnchor.constraint(equalToConstant: 100).isActive = true
+    }
+
+    func testConstrain_WithFirstBaselineConstraint_ShouldSupportRelativeEquality() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view0) { host, view in
+            constraint = view.firstBaseline(to: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view0!,
+            attribute: .firstBaseline,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .firstBaseline,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+    }
+
+    func testConstrain_WithFirstBaselineToTopConstraint_ShouldSupportRelativeEquality() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view0) { host, view in
+            constraint = view.firstBaselineToTop(of: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view0!,
+            attribute: .firstBaseline,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .top,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+    }
+
+    func testConstrain_WithFirstBaselineToBottomConstraint_ShouldSupportRelativeEquality() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view0) { host, view in
+            constraint = view.firstBaselineToBottom(of: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view0!,
+            attribute: .firstBaseline,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .bottom,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+    }
+}

--- a/Tests/AlicerceTests/AutoLayout/HeightConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/HeightConstrainableProxyTestCase.swift
@@ -182,6 +182,90 @@ class HeightConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
         XCTAssertEqual(view0.frame.height, view1.frame.height)
         XCTAssertEqual(view0.frame.height, view2.frame.height)
     }
+
+    func testConstrain_WithLayoutGuideHeightConstraint_ShouldSupportRelativeEquality() {
+
+        var constraint: NSLayoutConstraint!
+
+        constrain(host, layoutGuide) { host, layoutGuide in
+            constraint = layoutGuide.height(to: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: layoutGuide!,
+            attribute: .height,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .height,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(layoutGuide.layoutFrame.height, host.frame.height)
+    }
+
+    func testArrayConstrain_WithHeightConstraintGroupReplacement_ShouldSupportAbsoluteEquality() {
+
+        let constraintGroup = ConstraintGroup()
+
+        constrain([view0, view1, view2], replacing: constraintGroup) { proxies in
+            proxies.forEach { $0.height(100) }
+        }
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.height, 100)
+        XCTAssertEqual(view1.frame.height, 100)
+        XCTAssertEqual(view2.frame.height, 100)
+
+        constrain([view0, view1, view2], replacing: constraintGroup) { proxies in
+            proxies.forEach { $0.height(200) }
+        }
+
+        host.setNeedsLayout()
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.height, 200)
+        XCTAssertEqual(view1.frame.height, 200)
+        XCTAssertEqual(view2.frame.height, 200)
+    }
+
+    func testArrayConstrain_WithHeightConstraintClearingGroup_ShouldSupportRelativeEquality() {
+
+        let constraintGroup = ConstraintGroup()
+
+        constrain([view0, view1, view2], replacing: constraintGroup) { proxies in
+            proxies.forEach { $0.height(100) }
+        }
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.height, 100)
+        XCTAssertEqual(view1.frame.height, 100)
+        XCTAssertEqual(view2.frame.height, 100)
+
+        constrain(clearing: constraintGroup)
+
+        host.setNeedsLayout()
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.height, 0)
+        XCTAssertEqual(view1.frame.height, 0)
+        XCTAssertEqual(view2.frame.height, 0)
+    }
+
+    func testConstrain_WithHeightConstraintAndEmptyArray_ShouldReturnEmptyArray() {
+
+        let constraints = [UIView.ProxyType]().equalHeight()
+
+        XCTAssertConstraints(constraints, [])
+    }
 }
 
 private extension HeightConstrainableProxyTestCase {

--- a/Tests/AlicerceTests/AutoLayout/HeightConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/HeightConstrainableProxyTestCase.swift
@@ -1,0 +1,228 @@
+import XCTest
+@testable import Alicerce
+
+class HeightConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
+
+    private(set) var constraint0: NSLayoutConstraint!
+    private(set) var constraint1: NSLayoutConstraint!
+    private(set) var constraint2: NSLayoutConstraint!
+    private(set) var constraint3: NSLayoutConstraint!
+    private(set) var constraint4: NSLayoutConstraint!
+    private(set) var constraint5: NSLayoutConstraint!
+
+    override func tearDown() {
+
+        constraint0 = nil
+        constraint1 = nil
+        constraint2 = nil
+        constraint3 = nil
+        constraint4 = nil
+        constraint5 = nil
+
+        super.tearDown()
+    }
+
+    func testConstrain_WithOneHeightConstraint_ShouldSupportAbsoluteHeight() {
+
+        constrain(view0) { view0 in
+            constraint0 = view0.height(Constants.height0)
+        }
+
+        XCTAssertConstraint(constraint0, expectedConstraint(view: view0, height: Constants.height0))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.height, Constants.height0)
+    }
+
+    func testConstrain_WithTwoHeightConstraint_ShouldSupportAbsoluteHeight() {
+
+        constrain(view0, view1) { view0, view1 in
+            constraint0 = view0.height(Constants.height0)
+            constraint1 = view1.height(Constants.height1)
+        }
+
+        XCTAssertConstraint(constraint0, expectedConstraint(view: view0, height: Constants.height0))
+        XCTAssertConstraint(constraint1, expectedConstraint(view: view1, height: Constants.height1))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.height, Constants.height0)
+        XCTAssertEqual(view1.frame.height, Constants.height1)
+    }
+
+    func testConstrain_WithThreeHeightConstraint_ShouldSupportAbsoluteHeight() {
+
+        constrain(view0, view1, view2) { view0, view1, view2 in
+            constraint0 = view0.height(Constants.height0)
+            constraint1 = view1.height(Constants.height1)
+            constraint2 = view2.height(Constants.height2)
+        }
+
+        XCTAssertConstraint(constraint0, expectedConstraint(view: view0, height: Constants.height0))
+        XCTAssertConstraint(constraint1, expectedConstraint(view: view1, height: Constants.height1))
+        XCTAssertConstraint(constraint2, expectedConstraint(view: view2, height: Constants.height2))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.height, Constants.height0)
+        XCTAssertEqual(view1.frame.height, Constants.height1)
+        XCTAssertEqual(view2.frame.height, Constants.height2)
+    }
+
+    func testConstrain_WithFourHeightConstraint_ShouldSupportAbsoluteHeight() {
+
+        constrain(view0, view1, view2, view3) { view0, view1, view2, view3 in
+            constraint0 = view0.height(Constants.height0)
+            constraint1 = view1.height(Constants.height1)
+            constraint2 = view2.height(Constants.height2)
+            constraint3 = view3.height(Constants.height3)
+        }
+
+        XCTAssertConstraint(constraint0, expectedConstraint(view: view0, height: Constants.height0))
+        XCTAssertConstraint(constraint1, expectedConstraint(view: view1, height: Constants.height1))
+        XCTAssertConstraint(constraint2, expectedConstraint(view: view2, height: Constants.height2))
+        XCTAssertConstraint(constraint3, expectedConstraint(view: view3, height: Constants.height3))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.height, Constants.height0)
+        XCTAssertEqual(view1.frame.height, Constants.height1)
+        XCTAssertEqual(view2.frame.height, Constants.height2)
+        XCTAssertEqual(view3.frame.height, Constants.height3)
+    }
+
+    func testConstrain_WithFiveHeightConstraint_ShouldSupportAbsoluteHeight() {
+
+        constrain(view0, view1, view2, view3, view4) { view0, view1, view2, view3, view4 in
+            constraint0 = view0.height(Constants.height0)
+            constraint1 = view1.height(Constants.height1)
+            constraint2 = view2.height(Constants.height2)
+            constraint3 = view3.height(Constants.height3)
+            constraint4 = view4.height(Constants.height4)
+        }
+
+        XCTAssertConstraint(constraint0, expectedConstraint(view: view0, height: Constants.height0))
+        XCTAssertConstraint(constraint1, expectedConstraint(view: view1, height: Constants.height1))
+        XCTAssertConstraint(constraint2, expectedConstraint(view: view2, height: Constants.height2))
+        XCTAssertConstraint(constraint3, expectedConstraint(view: view3, height: Constants.height3))
+        XCTAssertConstraint(constraint4, expectedConstraint(view: view4, height: Constants.height4))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.height, Constants.height0)
+        XCTAssertEqual(view1.frame.height, Constants.height1)
+        XCTAssertEqual(view2.frame.height, Constants.height2)
+        XCTAssertEqual(view3.frame.height, Constants.height3)
+        XCTAssertEqual(view4.frame.height, Constants.height4)
+    }
+
+    func testConstrain_WithSixHeightConstraint_ShouldSupportAbsoluteHeight() {
+
+        constrain(view0, view1, view2, view3, view4, view5) { view0, view1, view2, view3, view4, view5 in
+            constraint0 = view0.height(Constants.height0)
+            constraint1 = view1.height(Constants.height1)
+            constraint2 = view2.height(Constants.height2)
+            constraint3 = view3.height(Constants.height3)
+            constraint4 = view4.height(Constants.height4)
+            constraint5 = view5.height(Constants.height5)
+        }
+
+        XCTAssertConstraint(constraint0, expectedConstraint(view: view0, height: Constants.height0))
+        XCTAssertConstraint(constraint1, expectedConstraint(view: view1, height: Constants.height1))
+        XCTAssertConstraint(constraint2, expectedConstraint(view: view2, height: Constants.height2))
+        XCTAssertConstraint(constraint3, expectedConstraint(view: view3, height: Constants.height3))
+        XCTAssertConstraint(constraint4, expectedConstraint(view: view4, height: Constants.height4))
+        XCTAssertConstraint(constraint5, expectedConstraint(view: view5, height: Constants.height5))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.height, Constants.height0)
+        XCTAssertEqual(view1.frame.height, Constants.height1)
+        XCTAssertEqual(view2.frame.height, Constants.height2)
+        XCTAssertEqual(view3.frame.height, Constants.height3)
+        XCTAssertEqual(view4.frame.height, Constants.height4)
+        XCTAssertEqual(view5.frame.height, Constants.height5)
+    }
+
+    func testConstrain_WithHeightConstraint_ShouldSupportRelativeHeight() {
+
+        constrain(host, view0) { host, view0 in
+            constraint0 = view0.height(to: host)
+        }
+
+        XCTAssertConstraint(constraint0, expectedConstraint(view: view0, to: host))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.height, host.frame.height)
+    }
+
+    func testConstrain_WithHeightConstraint_ShouldSupportRelativeEquality() {
+
+        view1.translatesAutoresizingMaskIntoConstraints = false
+        view2.translatesAutoresizingMaskIntoConstraints = false
+
+        var constraints: [NSLayoutConstraint]!
+        constrain(host, view0, view1, view2) { host, view0, view1, view2 in
+            view0.height(Constants.height0)
+            constraints = [view0, view1, view2].equalHeight()
+        }
+
+        let expected = [
+            expectedConstraint(view: view0, to: view1),
+            expectedConstraint(view: view0, to: view2)
+        ]
+
+        XCTAssertConstraints(constraints, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.height, Constants.height0)
+        XCTAssertEqual(view0.frame.height, view1.frame.height)
+        XCTAssertEqual(view0.frame.height, view2.frame.height)
+    }
+}
+
+private extension HeightConstrainableProxyTestCase {
+
+    func expectedConstraint(view: UIView, height: CGFloat) -> NSLayoutConstraint {
+
+        NSLayoutConstraint(
+            item: view,
+            attribute: .height,
+            relatedBy: .equal,
+            toItem: nil,
+            attribute: .height,
+            multiplier: 1,
+            constant: height,
+            priority: .required,
+            active: true
+        )
+    }
+
+    func expectedConstraint(view: UIView, to host: UIView) -> NSLayoutConstraint {
+
+        NSLayoutConstraint(
+            item: view,
+            attribute: .height,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .height,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+    }
+}
+
+private enum Constants {
+
+    static let height0: CGFloat = 100
+    static let height1: CGFloat = 200
+    static let height2: CGFloat = 300
+    static let height3: CGFloat = 400
+    static let height4: CGFloat = 500
+    static let height5: CGFloat = 600
+}

--- a/Tests/AlicerceTests/AutoLayout/LastBaselineConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/LastBaselineConstrainableProxyTestCase.swift
@@ -1,0 +1,79 @@
+import XCTest
+@testable import Alicerce
+
+final class LastBaselineConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
+
+    override func setUp() {
+
+        super.setUp()
+
+        view0.widthAnchor.constraint(equalToConstant: 100).isActive = true
+        view0.heightAnchor.constraint(equalToConstant: 100).isActive = true
+    }
+
+    func testConstrain_WithLastBaselineConstraint_ShouldSupportRelativeEquality() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view0) { host, view in
+            constraint = view.lastBaseline(to: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view0!,
+            attribute: .lastBaseline,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .lastBaseline,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+    }
+
+    func testConstrain_WithLastBaselineToTopConstraint_ShouldSupportRelativeEquality() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view0) { host, view in
+            constraint = view.lastBaselineToTop(of: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view0!,
+            attribute: .lastBaseline,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .top,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+    }
+
+    func testConstrain_WithLastBaselineToBottomConstraint_ShouldSupportRelativeEquality() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view0) { host, view in
+            constraint = view.lastBaselineToBottom(of: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view0!,
+            attribute: .lastBaseline,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .bottom,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+    }
+}

--- a/Tests/AlicerceTests/AutoLayout/LeadingConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/LeadingConstrainableProxyTestCase.swift
@@ -7,19 +7,19 @@ final class LeadingConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         super.setUp()
 
-        view.widthAnchor.constraint(equalToConstant: 100).isActive = true
-        view.heightAnchor.constraint(equalToConstant: 100).isActive = true
+        view0.widthAnchor.constraint(equalToConstant: 100).isActive = true
+        view0.heightAnchor.constraint(equalToConstant: 100).isActive = true
     }
 
     func testConstrain_WithLeadingConstraint_ShouldSupportRelativeEquality() {
 
         var constraint: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint = view.leading(to: host)
+        constrain(host, view0) { host, view0 in
+            constraint = view0.leading(to: host)
         }
 
         let expected = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .leading,
             relatedBy: .equal,
             toItem: host,
@@ -34,20 +34,20 @@ final class LeadingConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         host.layoutIfNeeded()
 
-        XCTAssertEqual(view.frame.minX, 0)
+        XCTAssertEqual(view0.frame.minX, 0)
     }
 
     func testConstrain_withLeadingConstraint_ShouldSupportRelativeInequalities() {
 
         var constraint1: NSLayoutConstraint!
         var constraint2: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint1 = view.leading(to: host, relation: .equalOrLess)
-            constraint2 = view.leading(to: host, relation: .equalOrGreater)
+        constrain(host, view0) { host, view0 in
+            constraint1 = view0.leading(to: host, relation: .equalOrLess)
+            constraint2 = view0.leading(to: host, relation: .equalOrGreater)
         }
 
         let expected1 = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .leading,
             relatedBy: .lessThanOrEqual,
             toItem: host,
@@ -61,7 +61,7 @@ final class LeadingConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
         XCTAssertConstraint(constraint1, expected1)
 
         let expected2 = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .leading,
             relatedBy: .greaterThanOrEqual,
             toItem: host,
@@ -76,18 +76,18 @@ final class LeadingConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         host.layoutIfNeeded()
 
-        XCTAssertEqual(view.frame.minX, 0)
+        XCTAssertEqual(view0.frame.minX, 0)
     }
 
     func testConstrain_WithLeadingConstraint_ShouldSupportPositiveOffset() {
 
         var constraint: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint = view.leading(to: host, offset: 100)
+        constrain(host, view0) { host, view0 in
+            constraint = view0.leading(to: host, offset: 100)
         }
 
         let expected = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .leading,
             relatedBy: .equal,
             toItem: host,
@@ -102,18 +102,18 @@ final class LeadingConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         host.layoutIfNeeded()
 
-        XCTAssertEqual(view.frame.minX, 100)
+        XCTAssertEqual(view0.frame.minX, 100)
     }
 
     func testConstrain_WithLeadingConstraint_ShouldSupportNegativeOffset() {
 
         var constraint: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint = view.leading(to: host, offset: -100)
+        constrain(host, view0) { host, view0 in
+            constraint = view0.leading(to: host, offset: -100)
         }
 
         let expected = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .leading,
             relatedBy: .equal,
             toItem: host,
@@ -128,18 +128,18 @@ final class LeadingConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         host.layoutIfNeeded()
 
-        XCTAssertEqual(view.frame.minX, -100)
+        XCTAssertEqual(view0.frame.minX, -100)
     }
 
     func testConstrain_WithLeadingConstraint_ShouldSupportTrailingAttribute() {
 
         var constraint: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint = view.leadingToTrailing(of: host)
+        constrain(host, view0) { host, view0 in
+            constraint = view0.leadingToTrailing(of: host)
         }
 
         let expected = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .leading,
             relatedBy: .equal,
             toItem: host,
@@ -153,18 +153,43 @@ final class LeadingConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         host.layoutIfNeeded()
 
-        XCTAssertEqual(view.frame.minX, 500)
+        XCTAssertEqual(view0.frame.minX, 500)
+    }
+
+    func testConstrain_WithLeadingConstraint_ShouldSupportCenterXAttribute() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view0) { host, view0 in
+            constraint = view0.leadingToCenterX(of: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view0!,
+            attribute: .leading,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .centerX,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true)
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.minX, 250)
     }
 
     func testConstrain_WithLeadingConstraint_ShouldSupportCustomPriority() {
 
         var constraint: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint = view.leading(to: host, priority: .init(666))
+        constrain(host, view0) { host, view0 in
+            constraint = view0.leading(to: host, priority: .init(666))
         }
 
         let expected = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .leading,
             relatedBy: .equal,
             toItem: host,
@@ -176,5 +201,49 @@ final class LeadingConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
         )
 
         XCTAssertConstraint(constraint, expected)
+    }
+
+    func testConstrain_WithAlignLeadingConstraint_ShouldSupportRelativeEquality() {
+
+        view1.translatesAutoresizingMaskIntoConstraints = false
+        view2.translatesAutoresizingMaskIntoConstraints = false
+
+        var constraints: [NSLayoutConstraint]!
+        constrain(host, view0, view1, view2) { host, view0, view1, view2 in
+            view0.leading(to: host, offset: 50)
+            constraints = [view0, view1, view2].alignLeading()
+        }
+
+        let expected = [
+            NSLayoutConstraint(
+                item: view0!,
+                attribute: .leading,
+                relatedBy: .equal,
+                toItem: view1,
+                attribute: .leading,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: true
+            ),
+            NSLayoutConstraint(
+                item: view0!,
+                attribute: .leading,
+                relatedBy: .equal,
+                toItem: view2,
+                attribute: .leading,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: true
+            )
+        ]
+
+        XCTAssertConstraints(constraints, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.minX, view1.frame.minX)
+        XCTAssertEqual(view0.frame.minX, view2.frame.minX)
     }
 }

--- a/Tests/AlicerceTests/AutoLayout/LeadingConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/LeadingConstrainableProxyTestCase.swift
@@ -203,6 +203,40 @@ final class LeadingConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
         XCTAssertConstraint(constraint, expected)
     }
 
+    func testConstrain_WithLayoutGuideLeadingConstraint_ShouldSupportRelativeEquality() {
+
+        var constraint: NSLayoutConstraint!
+
+        constrain(host, layoutGuide) { host, layoutGuide in
+            constraint = layoutGuide.leading(to: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: layoutGuide!,
+            attribute: .leading,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .leading,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(layoutGuide.layoutFrame.minX, host.frame.minX)
+    }
+
+    func testConstrain_WithAlignLeadingConstraintAndEmptyArray_ShouldReturnEmptyArray() {
+
+        let constraints = [UIView.ProxyType]().alignLeading()
+
+        XCTAssertConstraints(constraints, [])
+    }
+
     func testConstrain_WithAlignLeadingConstraint_ShouldSupportRelativeEquality() {
 
         view1.translatesAutoresizingMaskIntoConstraints = false

--- a/Tests/AlicerceTests/AutoLayout/LeadingConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/LeadingConstrainableProxyTestCase.swift
@@ -1,0 +1,180 @@
+import XCTest
+@testable import Alicerce
+
+final class LeadingConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
+
+    override func setUp() {
+
+        super.setUp()
+
+        view.widthAnchor.constraint(equalToConstant: 100).isActive = true
+        view.heightAnchor.constraint(equalToConstant: 100).isActive = true
+    }
+
+    func testConstrain_WithLeadingConstraint_ShouldSupportRelativeEquality() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint = view.leading(to: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view!,
+            attribute: .leading,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .leading,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame.minX, 0)
+    }
+
+    func testConstrain_withLeadingConstraint_ShouldSupportRelativeInequalities() {
+
+        var constraint1: NSLayoutConstraint!
+        var constraint2: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint1 = view.leading(to: host, relation: .equalOrLess)
+            constraint2 = view.leading(to: host, relation: .equalOrGreater)
+        }
+
+        let expected1 = NSLayoutConstraint(
+            item: view!,
+            attribute: .leading,
+            relatedBy: .lessThanOrEqual,
+            toItem: host,
+            attribute: .leading,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint1, expected1)
+
+        let expected2 = NSLayoutConstraint(
+            item: view!,
+            attribute: .leading,
+            relatedBy: .greaterThanOrEqual,
+            toItem: host,
+            attribute: .leading,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint2, expected2)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame.minX, 0)
+    }
+
+    func testConstrain_WithLeadingConstraint_ShouldSupportPositiveOffset() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint = view.leading(to: host, offset: 100)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view!,
+            attribute: .leading,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .leading,
+            multiplier: 1,
+            constant: 100,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame.minX, 100)
+    }
+
+    func testConstrain_WithLeadingConstraint_ShouldSupportNegativeOffset() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint = view.leading(to: host, offset: -100)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view!,
+            attribute: .leading,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .leading,
+            multiplier: 1,
+            constant: -100,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame.minX, -100)
+    }
+
+    func testConstrain_WithLeadingConstraint_ShouldSupportTrailingAttribute() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint = view.leadingToTrailing(of: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view!,
+            attribute: .leading,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .trailing,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true)
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame.minX, 500)
+    }
+
+    func testConstrain_WithLeadingConstraint_ShouldSupportCustomPriority() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint = view.leading(to: host, priority: .init(666))
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view!,
+            attribute: .leading,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .leading,
+            multiplier: 1,
+            constant: 0,
+            priority: .init(666),
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+    }
+}

--- a/Tests/AlicerceTests/AutoLayout/LeadingTrailingConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/LeadingTrailingConstrainableProxyTestCase.swift
@@ -1,0 +1,67 @@
+import XCTest
+@testable import Alicerce
+
+final class LeadingTrailingConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
+
+    override func setUp() {
+
+        super.setUp()
+
+        view0.widthAnchor.constraint(equalToConstant: 100).isActive = true
+        view0.heightAnchor.constraint(equalToConstant: 100).isActive = true
+
+        view1.widthAnchor.constraint(equalToConstant: 100).isActive = true
+        view1.heightAnchor.constraint(equalToConstant: 100).isActive = true
+
+        view2.widthAnchor.constraint(equalToConstant: 100).isActive = true
+        view2.heightAnchor.constraint(equalToConstant: 100).isActive = true
+    }
+
+    func testConstrain_WithDistributeHorizontallyConstraint_ShouldSupportRelativeEquality() {
+
+        var constraints: [NSLayoutConstraint]!
+        constrain(host, view0, view1, view2) { host, view0, view1, view2 in
+            view0.leading(to: host, offset: 50)
+            constraints = [view0, view1, view2].distributeHorizontally()
+        }
+
+        let expected = [
+            NSLayoutConstraint(
+                item: view1!,
+                attribute: .leading,
+                relatedBy: .equal,
+                toItem: view0,
+                attribute: .trailing,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: true
+            ),
+            NSLayoutConstraint(
+                item: view2!,
+                attribute: .leading,
+                relatedBy: .equal,
+                toItem: view1,
+                attribute: .trailing,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: true
+            )
+        ]
+
+        XCTAssertConstraints(constraints, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.maxX, view1.frame.minX)
+        XCTAssertEqual(view1.frame.maxX, view2.frame.minX)
+    }
+
+    func testConstrain_WithDistributeHorizontallyConstraintAndEmptyArray_ShouldReturnEmptyArray() {
+
+        let constraints = [UIView.ProxyType]().distributeHorizontally()
+
+        XCTAssertConstraints(constraints, [])
+    }
+}

--- a/Tests/AlicerceTests/AutoLayout/LeftConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/LeftConstrainableProxyTestCase.swift
@@ -1,0 +1,180 @@
+import XCTest
+@testable import Alicerce
+
+final class LeftConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
+
+    override func setUp() {
+
+        super.setUp()
+
+        view.widthAnchor.constraint(equalToConstant: 100).isActive = true
+        view.heightAnchor.constraint(equalToConstant: 100).isActive = true
+    }
+
+    func testConstrain_WithLeftConstraint_ShouldSupportRelativeEquality() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint = view.left(to: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view!,
+            attribute: .left,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .left,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame.minX, 0)
+    }
+
+    func testConstrain_withLeftConstraint_ShouldSupportRelativeInequalities() {
+
+        var constraint1: NSLayoutConstraint!
+        var constraint2: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint1 = view.left(to: host, relation: .equalOrLess)
+            constraint2 = view.left(to: host, relation: .equalOrGreater)
+        }
+
+        let expected1 = NSLayoutConstraint(
+            item: view!,
+            attribute: .left,
+            relatedBy: .lessThanOrEqual,
+            toItem: host,
+            attribute: .left,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint1, expected1)
+
+        let expected2 = NSLayoutConstraint(
+            item: view!,
+            attribute: .left,
+            relatedBy: .greaterThanOrEqual,
+            toItem: host,
+            attribute: .left,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint2, expected2)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame.minX, 0)
+    }
+
+    func testConstrain_WithLeftConstraint_ShouldSupportPositiveOffset() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint = view.left(to: host, offset: 100)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view!,
+            attribute: .left,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .left,
+            multiplier: 1,
+            constant: 100,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame.minX, 100)
+    }
+
+    func testConstrain_WithLeftConstraint_ShouldSupportNegativeOffset() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint = view.left(to: host, offset: -100)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view!,
+            attribute: .left,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .left,
+            multiplier: 1,
+            constant: -100,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame.minX, -100)
+    }
+
+    func testConstrain_WithLeftConstraint_ShouldSupportRightAttribute() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint = view.leftToRight(of: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view!,
+            attribute: .left,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .right,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true)
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame.minX, 500)
+    }
+
+    func testConstrain_WithLeftConstraint_ShouldSupportCustomPriority() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint = view.left(to: host, priority: .init(666))
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view!,
+            attribute: .left,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .left,
+            multiplier: 1,
+            constant: 0,
+            priority: .init(666),
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+    }
+}

--- a/Tests/AlicerceTests/AutoLayout/LeftConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/LeftConstrainableProxyTestCase.swift
@@ -177,4 +177,31 @@ final class LeftConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         XCTAssertConstraint(constraint, expected)
     }
+
+    func testConstrain_WithLayoutGuideLeftConstraint_ShouldSupportRelativeEquality() {
+
+        var constraint: NSLayoutConstraint!
+
+        constrain(host, layoutGuide) { host, layoutGuide in
+            constraint = layoutGuide.left(to: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: layoutGuide!,
+            attribute: .left,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .left,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(layoutGuide.layoutFrame.minX, host.frame.minX)
+    }
 }

--- a/Tests/AlicerceTests/AutoLayout/LeftConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/LeftConstrainableProxyTestCase.swift
@@ -7,19 +7,19 @@ final class LeftConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         super.setUp()
 
-        view.widthAnchor.constraint(equalToConstant: 100).isActive = true
-        view.heightAnchor.constraint(equalToConstant: 100).isActive = true
+        view0.widthAnchor.constraint(equalToConstant: 100).isActive = true
+        view0.heightAnchor.constraint(equalToConstant: 100).isActive = true
     }
 
     func testConstrain_WithLeftConstraint_ShouldSupportRelativeEquality() {
 
         var constraint: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint = view.left(to: host)
+        constrain(host, view0) { host, view0 in
+            constraint = view0.left(to: host)
         }
 
         let expected = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .left,
             relatedBy: .equal,
             toItem: host,
@@ -34,20 +34,20 @@ final class LeftConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         host.layoutIfNeeded()
 
-        XCTAssertEqual(view.frame.minX, 0)
+        XCTAssertEqual(view0.frame.minX, 0)
     }
 
     func testConstrain_withLeftConstraint_ShouldSupportRelativeInequalities() {
 
         var constraint1: NSLayoutConstraint!
         var constraint2: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint1 = view.left(to: host, relation: .equalOrLess)
-            constraint2 = view.left(to: host, relation: .equalOrGreater)
+        constrain(host, view0) { host, view0 in
+            constraint1 = view0.left(to: host, relation: .equalOrLess)
+            constraint2 = view0.left(to: host, relation: .equalOrGreater)
         }
 
         let expected1 = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .left,
             relatedBy: .lessThanOrEqual,
             toItem: host,
@@ -61,7 +61,7 @@ final class LeftConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
         XCTAssertConstraint(constraint1, expected1)
 
         let expected2 = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .left,
             relatedBy: .greaterThanOrEqual,
             toItem: host,
@@ -76,18 +76,18 @@ final class LeftConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         host.layoutIfNeeded()
 
-        XCTAssertEqual(view.frame.minX, 0)
+        XCTAssertEqual(view0.frame.minX, 0)
     }
 
     func testConstrain_WithLeftConstraint_ShouldSupportPositiveOffset() {
 
         var constraint: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint = view.left(to: host, offset: 100)
+        constrain(host, view0) { host, view0 in
+            constraint = view0.left(to: host, offset: 100)
         }
 
         let expected = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .left,
             relatedBy: .equal,
             toItem: host,
@@ -102,18 +102,18 @@ final class LeftConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         host.layoutIfNeeded()
 
-        XCTAssertEqual(view.frame.minX, 100)
+        XCTAssertEqual(view0.frame.minX, 100)
     }
 
     func testConstrain_WithLeftConstraint_ShouldSupportNegativeOffset() {
 
         var constraint: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint = view.left(to: host, offset: -100)
+        constrain(host, view0) { host, view0 in
+            constraint = view0.left(to: host, offset: -100)
         }
 
         let expected = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .left,
             relatedBy: .equal,
             toItem: host,
@@ -128,18 +128,18 @@ final class LeftConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         host.layoutIfNeeded()
 
-        XCTAssertEqual(view.frame.minX, -100)
+        XCTAssertEqual(view0.frame.minX, -100)
     }
 
     func testConstrain_WithLeftConstraint_ShouldSupportRightAttribute() {
 
         var constraint: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint = view.leftToRight(of: host)
+        constrain(host, view0) { host, view0 in
+            constraint = view0.leftToRight(of: host)
         }
 
         let expected = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .left,
             relatedBy: .equal,
             toItem: host,
@@ -153,18 +153,18 @@ final class LeftConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         host.layoutIfNeeded()
 
-        XCTAssertEqual(view.frame.minX, 500)
+        XCTAssertEqual(view0.frame.minX, 500)
     }
 
     func testConstrain_WithLeftConstraint_ShouldSupportCustomPriority() {
 
         var constraint: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint = view.left(to: host, priority: .init(666))
+        constrain(host, view0) { host, view0 in
+            constraint = view0.left(to: host, priority: .init(666))
         }
 
         let expected = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .left,
             relatedBy: .equal,
             toItem: host,

--- a/Tests/AlicerceTests/AutoLayout/NSLayoutConstraint+TestHelpers.swift
+++ b/Tests/AlicerceTests/AutoLayout/NSLayoutConstraint+TestHelpers.swift
@@ -1,0 +1,30 @@
+import UIKit
+
+extension NSLayoutConstraint {
+
+    convenience init(
+        item item1: Any,
+        attribute attribute1: NSLayoutConstraint.Attribute,
+        relatedBy relation: NSLayoutConstraint.Relation,
+        toItem item2: Any?,
+        attribute attribute2: NSLayoutConstraint.Attribute,
+        multiplier: CGFloat,
+        constant: CGFloat,
+        priority: UILayoutPriority,
+        active: Bool
+    ) {
+
+        self.init(
+            item: item1,
+            attribute: attribute1,
+            relatedBy: relation,
+            toItem: item2,
+            attribute: attribute2,
+            multiplier: multiplier,
+            constant: constant
+        )
+
+        self.priority = priority
+        isActive = active
+    }
+}

--- a/Tests/AlicerceTests/AutoLayout/NSLayoutConstraintTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/NSLayoutConstraintTestCase.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import Alicerce
+
+final class NSLayoutConstraintTestCase: XCTestCase {
+
+    var host: UIView!
+    var constraint: NSLayoutConstraint!
+
+    override func setUp() {
+
+        host = UIView()
+        let view = UIView()
+
+        host.addSubview(view)
+
+        constraint = NSLayoutConstraint(
+            item: view,
+            attribute: .height,
+            relatedBy: .equal,
+            toItem: nil,
+            attribute: .notAnAttribute,
+            multiplier: 1,
+            constant: 10
+        )
+
+        super.setUp()
+    }
+
+    override func tearDown() {
+
+        constraint = nil
+        host = nil
+
+        super.tearDown()
+    }
+
+    // MARK: - Priorities
+
+    func testWithPriority_WithDefaultValues_ShouldUpdatePriority() {
+
+        _ = constraint.with(priority: .defaultLow)
+        XCTAssertEqual(constraint.priority, .defaultLow)
+
+        _ = constraint.with(priority: .defaultHigh)
+        XCTAssertEqual(constraint.priority, .defaultHigh)
+
+        _ = constraint.with(priority: .fittingSizeLevel)
+        XCTAssertEqual(constraint.priority, .fittingSizeLevel)
+
+        _ = constraint.with(priority: .required)
+        XCTAssertEqual(constraint.priority, .required)
+    }
+
+    func testWithPriority_WithCustomValues_ShouldUpdatePriority() {
+
+        _ = constraint.with(priority: .init(666))
+        XCTAssertEqual(constraint.priority, .init(666))
+
+        _ = constraint.with(priority: .init(1))
+        XCTAssertEqual(constraint.priority, .init(1))
+    }
+
+    func testWithPriority_WithAnyValue_ShouldReturnItself() {
+
+        XCTAssert(constraint.with(priority: .defaultHigh) === constraint)
+        XCTAssert(constraint.with(priority: .init(666)) === constraint)
+    }
+
+    // MARK: - Activation
+
+    func testSetActive_WithTrue_ShouldActivateConstraint() {
+
+        constraint.isActive = false
+
+        _ = constraint.set(active: true)
+        XCTAssertTrue(constraint.isActive)
+    }
+
+    func testSetActive_WithFalse_ShouldDeactivateConstraint() {
+
+        constraint.isActive = true
+
+        _ = constraint.set(active: false)
+        XCTAssertFalse(constraint.isActive)
+    }
+
+    func testSetActive_WithAnyValue_ShouldReturnItself() {
+
+        XCTAssert(constraint.set(active: false) === constraint)
+        XCTAssert(constraint.set(active: true) === constraint)
+    }
+}

--- a/Tests/AlicerceTests/AutoLayout/RightConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/RightConstrainableProxyTestCase.swift
@@ -177,4 +177,31 @@ final class RightConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         XCTAssertConstraint(constraint, expected)
     }
+
+    func testConstrain_WithLayoutGuideRightConstraint_ShouldSupportRelativeEquality() {
+
+        var constraint: NSLayoutConstraint!
+
+        constrain(host, layoutGuide) { host, layoutGuide in
+            constraint = layoutGuide.right(to: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: layoutGuide!,
+            attribute: .right,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .right,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(layoutGuide.layoutFrame.maxX, host.frame.maxX)
+    }
 }

--- a/Tests/AlicerceTests/AutoLayout/RightConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/RightConstrainableProxyTestCase.swift
@@ -7,19 +7,19 @@ final class RightConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         super.setUp()
 
-        view.widthAnchor.constraint(equalToConstant: 100).isActive = true
-        view.heightAnchor.constraint(equalToConstant: 100).isActive = true
+        view0.widthAnchor.constraint(equalToConstant: 100).isActive = true
+        view0.heightAnchor.constraint(equalToConstant: 100).isActive = true
     }
 
     func testConstrain_WithRightConstraint_ShouldSupportRelativeEquality() {
 
         var constraint: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint = view.right(to: host)
+        constrain(host, view0) { host, view0 in
+            constraint = view0.right(to: host)
         }
 
         let expected = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .right,
             relatedBy: .equal,
             toItem: host,
@@ -34,20 +34,20 @@ final class RightConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         host.layoutIfNeeded()
 
-        XCTAssertEqual(view.frame.maxX, 500)
+        XCTAssertEqual(view0.frame.maxX, 500)
     }
 
     func testConstrain_withRightConstraint_ShouldSupportRelativeInequalities() {
 
         var constraint1: NSLayoutConstraint!
         var constraint2: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint1 = view.right(to: host, relation: .equalOrLess)
-            constraint2 = view.right(to: host, relation: .equalOrGreater)
+        constrain(host, view0) { host, view0 in
+            constraint1 = view0.right(to: host, relation: .equalOrLess)
+            constraint2 = view0.right(to: host, relation: .equalOrGreater)
         }
 
         let expected1 = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .right,
             relatedBy: .lessThanOrEqual,
             toItem: host,
@@ -61,7 +61,7 @@ final class RightConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
         XCTAssertConstraint(constraint1, expected1)
 
         let expected2 = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .right,
             relatedBy: .greaterThanOrEqual,
             toItem: host,
@@ -76,18 +76,18 @@ final class RightConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         host.layoutIfNeeded()
 
-        XCTAssertEqual(view.frame.maxX, 500)
+        XCTAssertEqual(view0.frame.maxX, 500)
     }
 
     func testConstrain_WithRightConstraint_ShouldSupportPositiveOffset() {
 
         var constraint: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint = view.right(to: host, offset: 100)
+        constrain(host, view0) { host, view0 in
+            constraint = view0.right(to: host, offset: 100)
         }
 
         let expected = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .right,
             relatedBy: .equal,
             toItem: host,
@@ -102,18 +102,18 @@ final class RightConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         host.layoutIfNeeded()
 
-        XCTAssertEqual(view.frame.maxX, 500 + 100)
+        XCTAssertEqual(view0.frame.maxX, 500 + 100)
     }
 
     func testConstrain_WithRightConstraint_ShouldSupportNegativeOffset() {
 
         var constraint: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint = view.right(to: host, offset: -100)
+        constrain(host, view0) { host, view0 in
+            constraint = view0.right(to: host, offset: -100)
         }
 
         let expected = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .right,
             relatedBy: .equal,
             toItem: host,
@@ -128,18 +128,18 @@ final class RightConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         host.layoutIfNeeded()
 
-        XCTAssertEqual(view.frame.maxX, 500 - 100)
+        XCTAssertEqual(view0.frame.maxX, 500 - 100)
     }
 
     func testConstrain_WithRightConstraint_ShouldSupportLeftAttribute() {
 
         var constraint: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint = view.rightToLeft(of: host)
+        constrain(host, view0) { host, view0 in
+            constraint = view0.rightToLeft(of: host)
         }
 
         let expected = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .right,
             relatedBy: .equal,
             toItem: host,
@@ -153,18 +153,18 @@ final class RightConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         host.layoutIfNeeded()
 
-        XCTAssertEqual(view.frame.maxX, 0)
+        XCTAssertEqual(view0.frame.maxX, 0)
     }
 
     func testConstrain_WithRightConstraint_ShouldSupportCustomPriority() {
 
         var constraint: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint = view.right(to: host, priority: .init(666))
+        constrain(host, view0) { host, view0 in
+            constraint = view0.right(to: host, priority: .init(666))
         }
 
         let expected = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .right,
             relatedBy: .equal,
             toItem: host,

--- a/Tests/AlicerceTests/AutoLayout/RightConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/RightConstrainableProxyTestCase.swift
@@ -1,0 +1,180 @@
+import XCTest
+@testable import Alicerce
+
+final class RightConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
+
+    override func setUp() {
+
+        super.setUp()
+
+        view.widthAnchor.constraint(equalToConstant: 100).isActive = true
+        view.heightAnchor.constraint(equalToConstant: 100).isActive = true
+    }
+
+    func testConstrain_WithRightConstraint_ShouldSupportRelativeEquality() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint = view.right(to: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view!,
+            attribute: .right,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .right,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame.maxX, 500)
+    }
+
+    func testConstrain_withRightConstraint_ShouldSupportRelativeInequalities() {
+
+        var constraint1: NSLayoutConstraint!
+        var constraint2: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint1 = view.right(to: host, relation: .equalOrLess)
+            constraint2 = view.right(to: host, relation: .equalOrGreater)
+        }
+
+        let expected1 = NSLayoutConstraint(
+            item: view!,
+            attribute: .right,
+            relatedBy: .lessThanOrEqual,
+            toItem: host,
+            attribute: .right,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint1, expected1)
+
+        let expected2 = NSLayoutConstraint(
+            item: view!,
+            attribute: .right,
+            relatedBy: .greaterThanOrEqual,
+            toItem: host,
+            attribute: .right,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint2, expected2)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame.maxX, 500)
+    }
+
+    func testConstrain_WithRightConstraint_ShouldSupportPositiveOffset() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint = view.right(to: host, offset: 100)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view!,
+            attribute: .right,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .right,
+            multiplier: 1,
+            constant: 100,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame.maxX, 500 + 100)
+    }
+
+    func testConstrain_WithRightConstraint_ShouldSupportNegativeOffset() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint = view.right(to: host, offset: -100)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view!,
+            attribute: .right,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .right,
+            multiplier: 1,
+            constant: -100,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame.maxX, 500 - 100)
+    }
+
+    func testConstrain_WithRightConstraint_ShouldSupportLeftAttribute() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint = view.rightToLeft(of: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view!,
+            attribute: .right,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .left,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true)
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame.maxX, 0)
+    }
+
+    func testConstrain_WithRightConstraint_ShouldSupportCustomPriority() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint = view.right(to: host, priority: .init(666))
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view!,
+            attribute: .right,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .right,
+            multiplier: 1,
+            constant: 0,
+            priority: .init(666),
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+    }
+}

--- a/Tests/AlicerceTests/AutoLayout/SizeConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/SizeConstrainableProxyTestCase.swift
@@ -1,0 +1,231 @@
+import XCTest
+@testable import Alicerce
+
+class SizeConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
+
+    private(set) var constraints0: [NSLayoutConstraint]!
+    private(set) var constraints1: [NSLayoutConstraint]!
+    private(set) var constraints2: [NSLayoutConstraint]!
+    private(set) var constraints3: [NSLayoutConstraint]!
+    private(set) var constraints4: [NSLayoutConstraint]!
+    private(set) var constraints5: [NSLayoutConstraint]!
+
+    override func tearDown() {
+
+        constraints0 = nil
+        constraints1 = nil
+        constraints2 = nil
+        constraints3 = nil
+        constraints4 = nil
+        constraints5 = nil
+
+        super.tearDown()
+    }
+
+    func testConstrain_WithOneSizeConstraint_ShouldSupportAbsoluteWidth() {
+
+        constrain(view0) { view0 in
+            constraints0 = view0.size(Constants.size0)
+        }
+
+        XCTAssertConstraints(constraints0, expectedConstraints(view: view0, size: Constants.size0))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.size, Constants.size0)
+    }
+
+    func testConstrain_WithTwoSizeConstraint_ShouldSupportAbsoluteWidth() {
+
+        constrain(view0, view1) { view0, view1 in
+            constraints0 = view0.size(Constants.size0)
+            constraints1 = view1.size(Constants.size1)
+        }
+
+        XCTAssertConstraints(constraints0, expectedConstraints(view: view0, size: Constants.size0))
+        XCTAssertConstraints(constraints1, expectedConstraints(view: view1, size: Constants.size1))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.size, Constants.size0)
+        XCTAssertEqual(view1.frame.size, Constants.size1)
+    }
+
+    func testConstrain_WithThreeSizeConstraint_ShouldSupportAbsoluteWidth() {
+
+        constrain(view0, view1, view2) { view0, view1, view2 in
+            constraints0 = view0.size(Constants.size0)
+            constraints1 = view1.size(Constants.size1)
+            constraints2 = view2.size(Constants.size2)
+        }
+
+        XCTAssertConstraints(constraints0, expectedConstraints(view: view0, size: Constants.size0))
+        XCTAssertConstraints(constraints1, expectedConstraints(view: view1, size: Constants.size1))
+        XCTAssertConstraints(constraints2, expectedConstraints(view: view2, size: Constants.size2))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.size, Constants.size0)
+        XCTAssertEqual(view1.frame.size, Constants.size1)
+        XCTAssertEqual(view2.frame.size, Constants.size2)
+    }
+
+    func testConstrain_WithFourSizeConstraint_ShouldSupportAbsoluteWidth() {
+
+        constrain(view0, view1, view2, view3) { view0, view1, view2, view3 in
+            constraints0 = view0.size(Constants.size0)
+            constraints1 = view1.size(Constants.size1)
+            constraints2 = view2.size(Constants.size2)
+            constraints3 = view3.size(Constants.size3)
+        }
+
+        XCTAssertConstraints(constraints0, expectedConstraints(view: view0, size: Constants.size0))
+        XCTAssertConstraints(constraints1, expectedConstraints(view: view1, size: Constants.size1))
+        XCTAssertConstraints(constraints2, expectedConstraints(view: view2, size: Constants.size2))
+        XCTAssertConstraints(constraints3, expectedConstraints(view: view3, size: Constants.size3))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.size, Constants.size0)
+        XCTAssertEqual(view1.frame.size, Constants.size1)
+        XCTAssertEqual(view2.frame.size, Constants.size2)
+        XCTAssertEqual(view3.frame.size, Constants.size3)
+    }
+
+    func testConstrain_WithFiveSizeConstraint_ShouldSupportAbsoluteWidth() {
+
+        constrain(view0, view1, view2, view3, view4) { view0, view1, view2, view3, view4 in
+            constraints0 = view0.size(Constants.size0)
+            constraints1 = view1.size(Constants.size1)
+            constraints2 = view2.size(Constants.size2)
+            constraints3 = view3.size(Constants.size3)
+            constraints4 = view4.size(Constants.size4)
+        }
+
+        XCTAssertConstraints(constraints0, expectedConstraints(view: view0, size: Constants.size0))
+        XCTAssertConstraints(constraints1, expectedConstraints(view: view1, size: Constants.size1))
+        XCTAssertConstraints(constraints2, expectedConstraints(view: view2, size: Constants.size2))
+        XCTAssertConstraints(constraints3, expectedConstraints(view: view3, size: Constants.size3))
+        XCTAssertConstraints(constraints4, expectedConstraints(view: view4, size: Constants.size4))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.size, Constants.size0)
+        XCTAssertEqual(view1.frame.size, Constants.size1)
+        XCTAssertEqual(view2.frame.size, Constants.size2)
+        XCTAssertEqual(view3.frame.size, Constants.size3)
+        XCTAssertEqual(view4.frame.size, Constants.size4)
+    }
+
+    func testConstrain_WithSixSizeConstraint_ShouldSupportAbsoluteWidth() {
+
+        constrain(view0, view1, view2, view3, view4, view5) { view0, view1, view2, view3, view4, view5 in
+            constraints0 = view0.size(Constants.size0)
+            constraints1 = view1.size(Constants.size1)
+            constraints2 = view2.size(Constants.size2)
+            constraints3 = view3.size(Constants.size3)
+            constraints4 = view4.size(Constants.size4)
+            constraints5 = view5.size(Constants.size5)
+        }
+
+        XCTAssertConstraints(constraints0, expectedConstraints(view: view0, size: Constants.size0))
+        XCTAssertConstraints(constraints1, expectedConstraints(view: view1, size: Constants.size1))
+        XCTAssertConstraints(constraints2, expectedConstraints(view: view2, size: Constants.size2))
+        XCTAssertConstraints(constraints3, expectedConstraints(view: view3, size: Constants.size3))
+        XCTAssertConstraints(constraints4, expectedConstraints(view: view4, size: Constants.size4))
+        XCTAssertConstraints(constraints5, expectedConstraints(view: view5, size: Constants.size5))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.size, Constants.size0)
+        XCTAssertEqual(view1.frame.size, Constants.size1)
+        XCTAssertEqual(view2.frame.size, Constants.size2)
+        XCTAssertEqual(view3.frame.size, Constants.size3)
+        XCTAssertEqual(view4.frame.size, Constants.size4)
+        XCTAssertEqual(view5.frame.size, Constants.size5)
+    }
+
+    func testConstrain_WithSizeConstraint_ShouldSupportRelativeWidth() {
+
+        constrain(host, view0) { host, view0 in
+            constraints0 = view0.size(to: host)
+        }
+
+        XCTAssertConstraints(constraints0, expectedConstraints(view: view0, to: host))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.size, host.frame.size)
+    }
+}
+
+private extension SizeConstrainableProxyTestCase {
+
+    private func expectedConstraints(view: UIView, size: CGSize) -> [NSLayoutConstraint] {
+
+        let width = NSLayoutConstraint(
+            item: view,
+            attribute: .width,
+            relatedBy: .equal,
+            toItem: nil,
+            attribute: .width,
+            multiplier: 1,
+            constant: size.width,
+            priority: .required,
+            active: true
+        )
+
+        let height = NSLayoutConstraint(
+            item: view,
+            attribute: .height,
+            relatedBy: .equal,
+            toItem: nil,
+            attribute: .height,
+            multiplier: 1,
+            constant: size.height,
+            priority: .required,
+            active: true
+        )
+
+        return [width, height]
+    }
+
+    private func expectedConstraints(view: UIView, to host: UIView) -> [NSLayoutConstraint] {
+
+        let width = NSLayoutConstraint(
+            item: view,
+            attribute: .width,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .width,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        let height = NSLayoutConstraint(
+            item: view,
+            attribute: .height,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .height,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        return [width, height]
+    }
+}
+
+private enum Constants {
+
+    static let size0 = CGSize(width: 100, height: 100)
+    static let size1 = CGSize(width: 200, height: 200)
+    static let size2 = CGSize(width: 300, height: 300)
+    static let size3 = CGSize(width: 400, height: 400)
+    static let size4 = CGSize(width: 500, height: 500)
+    static let size5 = CGSize(width: 600, height: 600)
+}

--- a/Tests/AlicerceTests/AutoLayout/TopBottomConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/TopBottomConstrainableProxyTestCase.swift
@@ -1,0 +1,67 @@
+import XCTest
+@testable import Alicerce
+
+final class TopBottomConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
+
+    override func setUp() {
+
+        super.setUp()
+
+        view0.widthAnchor.constraint(equalToConstant: 100).isActive = true
+        view0.heightAnchor.constraint(equalToConstant: 100).isActive = true
+
+        view1.widthAnchor.constraint(equalToConstant: 100).isActive = true
+        view1.heightAnchor.constraint(equalToConstant: 100).isActive = true
+
+        view2.widthAnchor.constraint(equalToConstant: 100).isActive = true
+        view2.heightAnchor.constraint(equalToConstant: 100).isActive = true
+    }
+
+    func testConstrain_WithDistributeVerticallyConstraint_ShouldSupportRelativeEquality() {
+
+        var constraints: [NSLayoutConstraint]!
+        constrain(host, view0, view1, view2) { host, view0, view1, view2 in
+            view0.top(to: host, offset: 50)
+            constraints = [view0, view1, view2].distributeVertically()
+        }
+
+        let expected = [
+            NSLayoutConstraint(
+                item: view1!,
+                attribute: .top,
+                relatedBy: .equal,
+                toItem: view0,
+                attribute: .bottom,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: true
+            ),
+            NSLayoutConstraint(
+                item: view2!,
+                attribute: .top,
+                relatedBy: .equal,
+                toItem: view1,
+                attribute: .bottom,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: true
+            )
+        ]
+
+        XCTAssertConstraints(constraints, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.maxY, view1.frame.minY)
+        XCTAssertEqual(view1.frame.maxY, view2.frame.minY)
+    }
+
+    func testConstrain_WithDistributeVerticallyConstraintAndEmptyArray_ShouldReturnEmptyArray() {
+
+        let constraints = [UIView.ProxyType]().distributeVertically()
+
+        XCTAssertConstraints(constraints, [])
+    }
+}

--- a/Tests/AlicerceTests/AutoLayout/TopConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/TopConstrainableProxyTestCase.swift
@@ -1,0 +1,180 @@
+import XCTest
+@testable import Alicerce
+
+final class TopConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
+
+    override func setUp() {
+
+        super.setUp()
+
+        view.widthAnchor.constraint(equalToConstant: 100).isActive = true
+        view.heightAnchor.constraint(equalToConstant: 100).isActive = true
+    }
+
+    func testConstrain_WithTopConstraint_ShouldSupportRelativeEquality() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint = view.top(to: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view!,
+            attribute: .top,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .top,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame.minY, 0)
+    }
+
+    func testConstrain_withTopConstraint_ShouldSupportRelativeInequalities() {
+
+        var constraint1: NSLayoutConstraint!
+        var constraint2: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint1 = view.top(to: host, relation: .equalOrLess)
+            constraint2 = view.top(to: host, relation: .equalOrGreater)
+        }
+
+        let expected1 = NSLayoutConstraint(
+            item: view!,
+            attribute: .top,
+            relatedBy: .lessThanOrEqual,
+            toItem: host,
+            attribute: .top,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint1, expected1)
+
+        let expected2 = NSLayoutConstraint(
+            item: view!,
+            attribute: .top,
+            relatedBy: .greaterThanOrEqual,
+            toItem: host,
+            attribute: .top,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint2, expected2)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame.minY, 0)
+    }
+
+    func testConstrain_WithTopConstraint_ShouldSupportPositiveOffset() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint = view.top(to: host, offset: 100)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view!,
+            attribute: .top,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .top,
+            multiplier: 1,
+            constant: 100,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame.minY, 100)
+    }
+
+    func testConstrain_WithTopConstraint_ShouldSupportNegativeOffset() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint = view.top(to: host, offset: -100)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view!,
+            attribute: .top,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .top,
+            multiplier: 1,
+            constant: -100,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame.minY, -100)
+    }
+
+    func testConstrain_WithTopConstraint_ShouldSupportBottomAttribute() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint = view.topToBottom(of: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view!,
+            attribute: .top,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .bottom,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true)
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame.minY, 500)
+    }
+
+    func testConstrain_WithTopConstraint_ShouldSupportCustomPriority() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint = view.top(to: host, priority: .init(666))
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view!,
+            attribute: .top,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .top,
+            multiplier: 1,
+            constant: 0,
+            priority: .init(666),
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+    }
+}

--- a/Tests/AlicerceTests/AutoLayout/TopConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/TopConstrainableProxyTestCase.swift
@@ -7,19 +7,19 @@ final class TopConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         super.setUp()
 
-        view.widthAnchor.constraint(equalToConstant: 100).isActive = true
-        view.heightAnchor.constraint(equalToConstant: 100).isActive = true
+        view0.widthAnchor.constraint(equalToConstant: 100).isActive = true
+        view0.heightAnchor.constraint(equalToConstant: 100).isActive = true
     }
 
     func testConstrain_WithTopConstraint_ShouldSupportRelativeEquality() {
 
         var constraint: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint = view.top(to: host)
+        constrain(host, view0) { host, view0 in
+            constraint = view0.top(to: host)
         }
 
         let expected = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .top,
             relatedBy: .equal,
             toItem: host,
@@ -34,20 +34,20 @@ final class TopConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         host.layoutIfNeeded()
 
-        XCTAssertEqual(view.frame.minY, 0)
+        XCTAssertEqual(view0.frame.minY, 0)
     }
 
     func testConstrain_withTopConstraint_ShouldSupportRelativeInequalities() {
 
         var constraint1: NSLayoutConstraint!
         var constraint2: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint1 = view.top(to: host, relation: .equalOrLess)
-            constraint2 = view.top(to: host, relation: .equalOrGreater)
+        constrain(host, view0) { host, view0 in
+            constraint1 = view0.top(to: host, relation: .equalOrLess)
+            constraint2 = view0.top(to: host, relation: .equalOrGreater)
         }
 
         let expected1 = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .top,
             relatedBy: .lessThanOrEqual,
             toItem: host,
@@ -61,7 +61,7 @@ final class TopConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
         XCTAssertConstraint(constraint1, expected1)
 
         let expected2 = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .top,
             relatedBy: .greaterThanOrEqual,
             toItem: host,
@@ -76,18 +76,18 @@ final class TopConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         host.layoutIfNeeded()
 
-        XCTAssertEqual(view.frame.minY, 0)
+        XCTAssertEqual(view0.frame.minY, 0)
     }
 
     func testConstrain_WithTopConstraint_ShouldSupportPositiveOffset() {
 
         var constraint: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint = view.top(to: host, offset: 100)
+        constrain(host, view0) { host, view0 in
+            constraint = view0.top(to: host, offset: 100)
         }
 
         let expected = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .top,
             relatedBy: .equal,
             toItem: host,
@@ -102,18 +102,18 @@ final class TopConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         host.layoutIfNeeded()
 
-        XCTAssertEqual(view.frame.minY, 100)
+        XCTAssertEqual(view0.frame.minY, 100)
     }
 
     func testConstrain_WithTopConstraint_ShouldSupportNegativeOffset() {
 
         var constraint: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint = view.top(to: host, offset: -100)
+        constrain(host, view0) { host, view0 in
+            constraint = view0.top(to: host, offset: -100)
         }
 
         let expected = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .top,
             relatedBy: .equal,
             toItem: host,
@@ -128,18 +128,18 @@ final class TopConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         host.layoutIfNeeded()
 
-        XCTAssertEqual(view.frame.minY, -100)
+        XCTAssertEqual(view0.frame.minY, -100)
     }
 
     func testConstrain_WithTopConstraint_ShouldSupportBottomAttribute() {
 
         var constraint: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint = view.topToBottom(of: host)
+        constrain(host, view0) { host, view0 in
+            constraint = view0.topToBottom(of: host)
         }
 
         let expected = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .top,
             relatedBy: .equal,
             toItem: host,
@@ -153,18 +153,18 @@ final class TopConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         host.layoutIfNeeded()
 
-        XCTAssertEqual(view.frame.minY, 500)
+        XCTAssertEqual(view0.frame.minY, 500)
     }
 
     func testConstrain_WithTopConstraint_ShouldSupportCustomPriority() {
 
         var constraint: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint = view.top(to: host, priority: .init(666))
+        constrain(host, view0) { host, view0 in
+            constraint = view0.top(to: host, priority: .init(666))
         }
 
         let expected = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .top,
             relatedBy: .equal,
             toItem: host,
@@ -176,5 +176,49 @@ final class TopConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
         )
 
         XCTAssertConstraint(constraint, expected)
+    }
+
+    func testConstrain_WithAlignTopConstraint_ShouldSupportRelativeEquality() {
+
+        view1.translatesAutoresizingMaskIntoConstraints = false
+        view2.translatesAutoresizingMaskIntoConstraints = false
+
+        var constraints: [NSLayoutConstraint]!
+        constrain(host, view0, view1, view2) { host, view0, view1, view2 in
+            view0.top(to: host, offset: 50)
+            constraints = [view0, view1, view2].alignTop()
+        }
+
+        let expected = [
+            NSLayoutConstraint(
+                item: view0!,
+                attribute: .top,
+                relatedBy: .equal,
+                toItem: view1,
+                attribute: .top,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: true
+            ),
+            NSLayoutConstraint(
+                item: view0!,
+                attribute: .top,
+                relatedBy: .equal,
+                toItem: view2,
+                attribute: .top,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: true
+            )
+        ]
+
+        XCTAssertConstraints(constraints, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.minY, view1.frame.minY)
+        XCTAssertEqual(view0.frame.minY, view2.frame.minY)
     }
 }

--- a/Tests/AlicerceTests/AutoLayout/TopConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/TopConstrainableProxyTestCase.swift
@@ -178,6 +178,75 @@ final class TopConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
         XCTAssertConstraint(constraint, expected)
     }
 
+    func testConstrain_WithLayoutGuideTopConstraint_ShouldSupportRelativeEquality() {
+
+        var constraint: NSLayoutConstraint!
+
+        constrain(host, layoutGuide) { host, layoutGuide in
+            constraint = layoutGuide.top(to: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: layoutGuide!,
+            attribute: .top,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .top,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(layoutGuide.layoutFrame.minY, host.frame.minY)
+    }
+
+    func testConstrain_WithSafeAreaTopConstraint_ShouldSupportRelativeEquality() {
+
+        var constraint: NSLayoutConstraint!
+
+        constrain(host, view0) { host, view0 in
+            constraint = view0.top(to: host.safeArea)
+        }
+
+        let hostSafeAreaLayoutGuide: UILayoutGuide = {
+            if #available(iOS 11.0, *) {
+                return host.safeAreaLayoutGuide
+            } else {
+                return host.layoutMarginsGuide
+            }
+        }()
+
+        let expected = NSLayoutConstraint(
+            item: view0!,
+            attribute: .top,
+            relatedBy: .equal,
+            toItem: hostSafeAreaLayoutGuide,
+            attribute: .top,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(layoutGuide.layoutFrame.minY, host.frame.minY)
+    }
+
+    func testConstrain_WithAlignTopConstraintAndEmptyArray_ShouldReturnEmptyArray() {
+
+        let constraints = [UIView.ProxyType]().alignTop()
+
+        XCTAssertConstraints(constraints, [])
+    }
+
     func testConstrain_WithAlignTopConstraint_ShouldSupportRelativeEquality() {
 
         view1.translatesAutoresizingMaskIntoConstraints = false

--- a/Tests/AlicerceTests/AutoLayout/TrailingConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/TrailingConstrainableProxyTestCase.swift
@@ -1,0 +1,180 @@
+import XCTest
+@testable import Alicerce
+
+final class TrailingConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
+
+    override func setUp() {
+
+        super.setUp()
+
+        view.widthAnchor.constraint(equalToConstant: 100).isActive = true
+        view.heightAnchor.constraint(equalToConstant: 100).isActive = true
+    }
+
+    func testConstrain_WithTrailingConstraint_ShouldSupportRelativeEquality() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint = view.trailing(to: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view!,
+            attribute: .trailing,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .trailing,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame.maxX, 500)
+    }
+
+    func testConstrain_withTrailingConstraint_ShouldSupportRelativeInequalities() {
+
+        var constraint1: NSLayoutConstraint!
+        var constraint2: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint1 = view.trailing(to: host, relation: .equalOrLess)
+            constraint2 = view.trailing(to: host, relation: .equalOrGreater)
+        }
+
+        let expected1 = NSLayoutConstraint(
+            item: view!,
+            attribute: .trailing,
+            relatedBy: .lessThanOrEqual,
+            toItem: host,
+            attribute: .trailing,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint1, expected1)
+
+        let expected2 = NSLayoutConstraint(
+            item: view!,
+            attribute: .trailing,
+            relatedBy: .greaterThanOrEqual,
+            toItem: host,
+            attribute: .trailing,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint2, expected2)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame.maxX, 500)
+    }
+
+    func testConstrain_WithTrailingConstraint_ShouldSupportPositiveOffset() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint = view.trailing(to: host, offset: 100)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view!,
+            attribute: .trailing,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .trailing,
+            multiplier: 1,
+            constant: 100,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame.maxX, 500 + 100)
+    }
+
+    func testConstrain_WithTrailingConstraint_ShouldSupportNegativeOffset() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint = view.trailing(to: host, offset: -100)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view!,
+            attribute: .trailing,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .trailing,
+            multiplier: 1,
+            constant: -100,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame.maxX, 500 - 100)
+    }
+
+    func testConstrain_WithTrailingConstraint_ShouldSupportLeadingAttribute() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint = view.trailingToLeading(of: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view!,
+            attribute: .trailing,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .leading,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true)
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame.maxX, 0)
+    }
+
+    func testConstrain_WithTrailingConstraint_ShouldSupportCustomPriority() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view) { host, view in
+            constraint = view.trailing(to: host, priority: .init(666))
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view!,
+            attribute: .trailing,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .trailing,
+            multiplier: 1,
+            constant: 0,
+            priority: .init(666),
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+    }
+}

--- a/Tests/AlicerceTests/AutoLayout/TrailingConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/TrailingConstrainableProxyTestCase.swift
@@ -7,19 +7,19 @@ final class TrailingConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         super.setUp()
 
-        view.widthAnchor.constraint(equalToConstant: 100).isActive = true
-        view.heightAnchor.constraint(equalToConstant: 100).isActive = true
+        view0.widthAnchor.constraint(equalToConstant: 100).isActive = true
+        view0.heightAnchor.constraint(equalToConstant: 100).isActive = true
     }
 
     func testConstrain_WithTrailingConstraint_ShouldSupportRelativeEquality() {
 
         var constraint: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint = view.trailing(to: host)
+        constrain(host, view0) { host, view0 in
+            constraint = view0.trailing(to: host)
         }
 
         let expected = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .trailing,
             relatedBy: .equal,
             toItem: host,
@@ -34,20 +34,20 @@ final class TrailingConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         host.layoutIfNeeded()
 
-        XCTAssertEqual(view.frame.maxX, 500)
+        XCTAssertEqual(view0.frame.maxX, host.frame.maxX)
     }
 
     func testConstrain_withTrailingConstraint_ShouldSupportRelativeInequalities() {
 
         var constraint1: NSLayoutConstraint!
         var constraint2: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint1 = view.trailing(to: host, relation: .equalOrLess)
-            constraint2 = view.trailing(to: host, relation: .equalOrGreater)
+        constrain(host, view0) { host, view0 in
+            constraint1 = view0.trailing(to: host, relation: .equalOrLess)
+            constraint2 = view0.trailing(to: host, relation: .equalOrGreater)
         }
 
         let expected1 = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .trailing,
             relatedBy: .lessThanOrEqual,
             toItem: host,
@@ -61,7 +61,7 @@ final class TrailingConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
         XCTAssertConstraint(constraint1, expected1)
 
         let expected2 = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .trailing,
             relatedBy: .greaterThanOrEqual,
             toItem: host,
@@ -76,18 +76,18 @@ final class TrailingConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         host.layoutIfNeeded()
 
-        XCTAssertEqual(view.frame.maxX, 500)
+        XCTAssertEqual(view0.frame.maxX, 500)
     }
 
     func testConstrain_WithTrailingConstraint_ShouldSupportPositiveOffset() {
 
         var constraint: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint = view.trailing(to: host, offset: 100)
+        constrain(host, view0) { host, view0 in
+            constraint = view0.trailing(to: host, offset: 100)
         }
 
         let expected = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .trailing,
             relatedBy: .equal,
             toItem: host,
@@ -102,18 +102,18 @@ final class TrailingConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         host.layoutIfNeeded()
 
-        XCTAssertEqual(view.frame.maxX, 500 + 100)
+        XCTAssertEqual(view0.frame.maxX, 500 + 100)
     }
 
     func testConstrain_WithTrailingConstraint_ShouldSupportNegativeOffset() {
 
         var constraint: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint = view.trailing(to: host, offset: -100)
+        constrain(host, view0) { host, view0 in
+            constraint = view0.trailing(to: host, offset: -100)
         }
 
         let expected = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .trailing,
             relatedBy: .equal,
             toItem: host,
@@ -128,18 +128,18 @@ final class TrailingConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         host.layoutIfNeeded()
 
-        XCTAssertEqual(view.frame.maxX, 500 - 100)
+        XCTAssertEqual(view0.frame.maxX, 500 - 100)
     }
 
     func testConstrain_WithTrailingConstraint_ShouldSupportLeadingAttribute() {
 
         var constraint: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint = view.trailingToLeading(of: host)
+        constrain(host, view0) { host, view0 in
+            constraint = view0.trailingToLeading(of: host)
         }
 
         let expected = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .trailing,
             relatedBy: .equal,
             toItem: host,
@@ -153,18 +153,44 @@ final class TrailingConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         host.layoutIfNeeded()
 
-        XCTAssertEqual(view.frame.maxX, 0)
+        XCTAssertEqual(view0.frame.maxX, 0)
     }
+
+    func testConstrain_WithTrailingConstraint_ShouldSupportCenterXAttribute() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view0) { host, view0 in
+            constraint = view0.trailingToCenterX(of: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view0!,
+            attribute: .trailing,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .centerX,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true)
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.maxX, 250)
+    }
+
 
     func testConstrain_WithTrailingConstraint_ShouldSupportCustomPriority() {
 
         var constraint: NSLayoutConstraint!
-        constrain(host, view) { host, view in
-            constraint = view.trailing(to: host, priority: .init(666))
+        constrain(host, view0) { host, view0 in
+            constraint = view0.trailing(to: host, priority: .init(666))
         }
 
         let expected = NSLayoutConstraint(
-            item: view!,
+            item: view0!,
             attribute: .trailing,
             relatedBy: .equal,
             toItem: host,
@@ -176,5 +202,50 @@ final class TrailingConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
         )
 
         XCTAssertConstraint(constraint, expected)
+    }
+
+    func testConstrain_WithAlignTrailingConstraint_ShouldSupportRelativeEquality() {
+
+        var constraints: [NSLayoutConstraint]!
+
+        view1.translatesAutoresizingMaskIntoConstraints = false
+        view2.translatesAutoresizingMaskIntoConstraints = false
+
+        constrain(host, view0, view1, view2) { host, view0, view1, view2 in
+            view0.trailing(to: host, offset: -50)
+            constraints = [view0, view1, view2].alignTrailing()
+        }
+
+        let expected = [
+            NSLayoutConstraint(
+                item: view0!,
+                attribute: .trailing,
+                relatedBy: .equal,
+                toItem: view1,
+                attribute: .trailing,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: true
+            ),
+            NSLayoutConstraint(
+                item: view0!,
+                attribute: .trailing,
+                relatedBy: .equal,
+                toItem: view2,
+                attribute: .trailing,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: true
+            )
+        ]
+
+        XCTAssertConstraints(constraints, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.maxX, view1.frame.maxX)
+        XCTAssertEqual(view0.frame.maxX, view2.frame.maxX)
     }
 }

--- a/Tests/AlicerceTests/AutoLayout/TrailingConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/TrailingConstrainableProxyTestCase.swift
@@ -204,6 +204,40 @@ final class TrailingConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
         XCTAssertConstraint(constraint, expected)
     }
 
+    func testConstrain_WithLayoutGuideTrailingConstraint_ShouldSupportRelativeEquality() {
+
+        var constraint: NSLayoutConstraint!
+
+        constrain(host, layoutGuide) { host, layoutGuide in
+            constraint = layoutGuide.trailing(to: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: layoutGuide!,
+            attribute: .trailing,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .trailing,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(layoutGuide.layoutFrame.maxX, host.frame.maxX)
+    }
+
+    func testConstrain_WithAlignTrailingConstraintAndEmptyArray_ShouldReturnEmptyArray() {
+
+        let constraints = [UIView.ProxyType]().alignTrailing()
+
+        XCTAssertConstraints(constraints, [])
+    }
+
     func testConstrain_WithAlignTrailingConstraint_ShouldSupportRelativeEquality() {
 
         var constraints: [NSLayoutConstraint]!

--- a/Tests/AlicerceTests/AutoLayout/WidthConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/WidthConstrainableProxyTestCase.swift
@@ -1,0 +1,251 @@
+import XCTest
+@testable import Alicerce
+
+class WidthConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
+
+    private(set) var constraint0: NSLayoutConstraint!
+    private(set) var constraint1: NSLayoutConstraint!
+    private(set) var constraint2: NSLayoutConstraint!
+    private(set) var constraint3: NSLayoutConstraint!
+    private(set) var constraint4: NSLayoutConstraint!
+    private(set) var constraint5: NSLayoutConstraint!
+
+    override func tearDown() {
+
+        constraint0 = nil
+        constraint1 = nil
+        constraint2 = nil
+        constraint3 = nil
+        constraint4 = nil
+        constraint5 = nil
+
+        super.tearDown()
+    }
+
+    func testConstrain_WithOneWidthConstraint_ShouldSupportAbsoluteWidth() {
+
+        constrain(view0) { view0 in
+            constraint0 = view0.width(Constants.width0)
+        }
+
+        XCTAssertConstraint(constraint0, expectedConstraint(view: view0, width: Constants.width0))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.width, Constants.width0)
+    }
+
+    func testConstrain_WithTwoWidthConstraint_ShouldSupportAbsoluteWidth() {
+
+        constrain(view0, view1) { view0, view1 in
+            constraint0 = view0.width(Constants.width0)
+            constraint1 = view1.width(Constants.width1)
+        }
+
+        XCTAssertConstraint(constraint0, expectedConstraint(view: view0, width: Constants.width0))
+        XCTAssertConstraint(constraint1, expectedConstraint(view: view1, width: Constants.width1))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.width, Constants.width0)
+        XCTAssertEqual(view1.frame.width, Constants.width1)
+    }
+
+    func testConstrain_WithThreeWidthConstraint_ShouldSupportAbsoluteWidth() {
+
+        constrain(view0, view1, view2) { view0, view1, view2 in
+            constraint0 = view0.width(Constants.width0)
+            constraint1 = view1.width(Constants.width1)
+            constraint2 = view2.width(Constants.width2)
+        }
+
+        XCTAssertConstraint(constraint0, expectedConstraint(view: view0, width: Constants.width0))
+        XCTAssertConstraint(constraint1, expectedConstraint(view: view1, width: Constants.width1))
+        XCTAssertConstraint(constraint2, expectedConstraint(view: view2, width: Constants.width2))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.width, Constants.width0)
+        XCTAssertEqual(view1.frame.width, Constants.width1)
+        XCTAssertEqual(view2.frame.width, Constants.width2)
+    }
+
+    func testConstrain_WithFourWidthConstraint_ShouldSupportAbsoluteWidth() {
+
+        constrain(view0, view1, view2, view3) { view0, view1, view2, view3 in
+            constraint0 = view0.width(Constants.width0)
+            constraint1 = view1.width(Constants.width1)
+            constraint2 = view2.width(Constants.width2)
+            constraint3 = view3.width(Constants.width3)
+        }
+
+        XCTAssertConstraint(constraint0, expectedConstraint(view: view0, width: Constants.width0))
+        XCTAssertConstraint(constraint1, expectedConstraint(view: view1, width: Constants.width1))
+        XCTAssertConstraint(constraint2, expectedConstraint(view: view2, width: Constants.width2))
+        XCTAssertConstraint(constraint3, expectedConstraint(view: view3, width: Constants.width3))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.width, Constants.width0)
+        XCTAssertEqual(view1.frame.width, Constants.width1)
+        XCTAssertEqual(view2.frame.width, Constants.width2)
+        XCTAssertEqual(view3.frame.width, Constants.width3)
+    }
+
+    func testConstrain_WithFiveWidthConstraint_ShouldSupportAbsoluteWidth() {
+
+        constrain(view0, view1, view2, view3, view4) { view0, view1, view2, view3, view4 in
+            constraint0 = view0.width(Constants.width0)
+            constraint1 = view1.width(Constants.width1)
+            constraint2 = view2.width(Constants.width2)
+            constraint3 = view3.width(Constants.width3)
+            constraint4 = view4.width(Constants.width4)
+        }
+
+        XCTAssertConstraint(constraint0, expectedConstraint(view: view0, width: Constants.width0))
+        XCTAssertConstraint(constraint1, expectedConstraint(view: view1, width: Constants.width1))
+        XCTAssertConstraint(constraint2, expectedConstraint(view: view2, width: Constants.width2))
+        XCTAssertConstraint(constraint3, expectedConstraint(view: view3, width: Constants.width3))
+        XCTAssertConstraint(constraint4, expectedConstraint(view: view4, width: Constants.width4))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.width, Constants.width0)
+        XCTAssertEqual(view1.frame.width, Constants.width1)
+        XCTAssertEqual(view2.frame.width, Constants.width2)
+        XCTAssertEqual(view3.frame.width, Constants.width3)
+        XCTAssertEqual(view4.frame.width, Constants.width4)
+    }
+
+    func testConstrain_WithSixWidthConstraint_ShouldSupportAbsoluteWidth() {
+
+        constrain(view0, view1, view2, view3, view4, view5) { view0, view1, view2, view3, view4, view5 in
+            constraint0 = view0.width(Constants.width0)
+            constraint1 = view1.width(Constants.width1)
+            constraint2 = view2.width(Constants.width2)
+            constraint3 = view3.width(Constants.width3)
+            constraint4 = view4.width(Constants.width4)
+            constraint5 = view5.width(Constants.width5)
+        }
+
+        XCTAssertConstraint(constraint0, expectedConstraint(view: view0, width: Constants.width0))
+        XCTAssertConstraint(constraint1, expectedConstraint(view: view1, width: Constants.width1))
+        XCTAssertConstraint(constraint2, expectedConstraint(view: view2, width: Constants.width2))
+        XCTAssertConstraint(constraint3, expectedConstraint(view: view3, width: Constants.width3))
+        XCTAssertConstraint(constraint4, expectedConstraint(view: view4, width: Constants.width4))
+        XCTAssertConstraint(constraint5, expectedConstraint(view: view5, width: Constants.width5))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.width, Constants.width0)
+        XCTAssertEqual(view1.frame.width, Constants.width1)
+        XCTAssertEqual(view2.frame.width, Constants.width2)
+        XCTAssertEqual(view3.frame.width, Constants.width3)
+        XCTAssertEqual(view4.frame.width, Constants.width4)
+        XCTAssertEqual(view5.frame.width, Constants.width5)
+    }
+
+    func testConstrain_WithWidthConstraint_ShouldSupportRelativeWidth() {
+
+        constrain(host, view0) { host, view0 in
+            constraint0 = view0.width(to: host)
+        }
+
+        XCTAssertConstraint(constraint0, expectedConstraint(view: view0, to: host))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.width, host.frame.width)
+    }
+
+    func testConstrain_WithWidthConstantConstraint_ShouldSupportRelativeEquality() {
+
+        var constraints: [NSLayoutConstraint]!
+        constrain(host, view0, view1, view2) { host, view0, view1, view2 in
+            constraints = [view0, view1, view2].equal(width: Constants.width0)
+        }
+
+        let expected = [
+            expectedConstraint(view: view0, width: Constants.width0),
+            expectedConstraint(view: view1, width: Constants.width0),
+            expectedConstraint(view: view2, width: Constants.width0)
+        ]
+
+        XCTAssertConstraints(constraints, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.width, Constants.width0)
+        XCTAssertEqual(view1.frame.width, Constants.width0)
+        XCTAssertEqual(view2.frame.width, Constants.width0)
+    }
+
+    func testConstrain_WithWidthConstraint_ShouldSupportRelativeEquality() {
+
+        view1.translatesAutoresizingMaskIntoConstraints = false
+        view2.translatesAutoresizingMaskIntoConstraints = false
+
+        var constraints: [NSLayoutConstraint]!
+        constrain(host, view0, view1, view2) { host, view0, view1, view2 in
+            view0.width(Constants.width0)
+            constraints = [view0, view1, view2].equalWidth()
+        }
+
+        let expected = [
+            expectedConstraint(view: view0, to: view1),
+            expectedConstraint(view: view0, to: view2)
+        ]
+
+        XCTAssertConstraints(constraints, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.width, Constants.width0)
+        XCTAssertEqual(view0.frame.width, view1.frame.width)
+        XCTAssertEqual(view0.frame.width, view2.frame.width)
+    }
+}
+
+private extension WidthConstrainableProxyTestCase {
+
+    func expectedConstraint(view: UIView, width: CGFloat) -> NSLayoutConstraint {
+
+        NSLayoutConstraint(
+            item: view,
+            attribute: .width,
+            relatedBy: .equal,
+            toItem: nil,
+            attribute: .width,
+            multiplier: 1,
+            constant: width,
+            priority: .required,
+            active: true
+        )
+    }
+
+    func expectedConstraint(view: UIView, to host: UIView) -> NSLayoutConstraint {
+
+        NSLayoutConstraint(
+            item: view,
+            attribute: .width,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .width,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+    }
+
+}
+
+private enum Constants {
+
+    static let width0: CGFloat = 100
+    static let width1: CGFloat = 200
+    static let width2: CGFloat = 300
+    static let width3: CGFloat = 400
+    static let width4: CGFloat = 500
+    static let width5: CGFloat = 600
+}

--- a/Tests/AlicerceTests/AutoLayout/WidthConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/WidthConstrainableProxyTestCase.swift
@@ -204,6 +204,40 @@ class WidthConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
         XCTAssertEqual(view0.frame.width, view1.frame.width)
         XCTAssertEqual(view0.frame.width, view2.frame.width)
     }
+
+    func testConstrain_WithLayoutGuideWidthConstraint_ShouldSupportRelativeEquality() {
+
+        var constraint: NSLayoutConstraint!
+
+        constrain(host, layoutGuide) { host, layoutGuide in
+            constraint = layoutGuide.width(to: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: layoutGuide!,
+            attribute: .width,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .width,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(layoutGuide.layoutFrame.width, host.frame.width)
+    }
+
+    func testConstrain_WithWidthConstraintAndEmptyArray_ShouldReturnEmptyArray() {
+
+        let constraints = [UIView.ProxyType]().equalWidth()
+
+        XCTAssertConstraints(constraints, [])
+    }
 }
 
 private extension WidthConstrainableProxyTestCase {

--- a/Tests/AlicerceTests/AutoLayout/XCTAssertConstraint.swift
+++ b/Tests/AlicerceTests/AutoLayout/XCTAssertConstraint.swift
@@ -1,0 +1,27 @@
+import XCTest
+
+func XCTAssertConstraint(
+    _ constraint1: NSLayoutConstraint,
+    _ constraint2: NSLayoutConstraint,
+    file: StaticString = #file,
+    line: UInt = #line
+) {
+
+    if let item = constraint1.firstItem as? UIView, item === constraint2.firstItem {
+        XCTAssertFalse(item.translatesAutoresizingMaskIntoConstraints, file: file, line: line)
+    }
+
+    XCTAssert(constraint1.firstItem === constraint2.firstItem, file: file, line: line)
+    XCTAssertEqual(constraint1.firstAttribute, constraint2.firstAttribute, file: file, line: line)
+
+    XCTAssert(constraint1.secondItem === constraint2.secondItem, file: file, line: line)
+    XCTAssertEqual(constraint1.secondAttribute, constraint2.secondAttribute, file: file, line: line)
+
+    XCTAssertEqual(constraint1.relation, constraint2.relation, file: file, line: line)
+
+    XCTAssertEqual(constraint1.multiplier, constraint2.multiplier, file: file, line: line)
+    XCTAssertEqual(constraint1.constant, constraint2.constant, file: file, line: line)
+
+    XCTAssertEqual(constraint1.isActive, constraint2.isActive, file: file, line: line)
+    XCTAssertEqual(constraint1.priority, constraint2.priority, file: file, line: line)
+}

--- a/Tests/AlicerceTests/AutoLayout/XCTAssertConstraint.swift
+++ b/Tests/AlicerceTests/AutoLayout/XCTAssertConstraint.swift
@@ -25,3 +25,32 @@ func XCTAssertConstraint(
     XCTAssertEqual(constraint1.isActive, constraint2.isActive, file: file, line: line)
     XCTAssertEqual(constraint1.priority, constraint2.priority, file: file, line: line)
 }
+
+func XCTAssertConstraints(
+    _ constraints1: [NSLayoutConstraint],
+    _ constraints2: [NSLayoutConstraint],
+    file: StaticString = #file,
+    line: UInt = #line
+) {
+
+    zip(constraints1, constraints2).forEach { constraint1, constraint2 in
+
+        if let item = constraint1.firstItem as? UIView, item === constraint2.firstItem {
+            XCTAssertFalse(item.translatesAutoresizingMaskIntoConstraints, file: file, line: line)
+        }
+
+        XCTAssert(constraint1.firstItem === constraint2.firstItem, file: file, line: line)
+        XCTAssertEqual(constraint1.firstAttribute, constraint2.firstAttribute, file: file, line: line)
+
+        XCTAssert(constraint1.secondItem === constraint2.secondItem, file: file, line: line)
+        XCTAssertEqual(constraint1.secondAttribute, constraint2.secondAttribute, file: file, line: line)
+
+        XCTAssertEqual(constraint1.relation, constraint2.relation, file: file, line: line)
+
+        XCTAssertEqual(constraint1.multiplier, constraint2.multiplier, file: file, line: line)
+        XCTAssertEqual(constraint1.constant, constraint2.constant, file: file, line: line)
+
+        XCTAssertEqual(constraint1.isActive, constraint2.isActive, file: file, line: line)
+        XCTAssertEqual(constraint1.priority, constraint2.priority, file: file, line: line)
+    }
+}


### PR DESCRIPTION
### Checklist
- [x] I've rebased my changes on top of `master`
- [x] I've built and run the project to see all new and existing tests pass
- [x] I've followed the [Mindera swift style guide](https://github.com/Mindera/swift-style-guide)
- [x] I've read the [Contribution Guidelines](https://github.com/Mindera/Alicerce/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

The `NSLayoutAnchor` API is very verbose and resulted on big blocks of Auto Layout code that increased the size of the view files and was not very easy to read.

As an alternative, [Cartography](https://github.com/robb/Cartography) provides a simple and readable DSL to handle Auto Layout code but we've found that the [operator overload](https://github.com/robb/Cartography/issues/215) used on that library was causing our compile times to increase.

### Description

All credit goes to @renatorodrigues for the implementation 🙏 

The implementation is heavily inspired on [Cartography](https://github.com/robb/Cartography) and [TinyConstraints](https://github.com/roberthein/TinyConstraints).

Without using custom operators, we can still have a more accessible API for our Auto Layout code and avoid the increased build times caused by operator overloads.