### PR TITLE
Migrate to Swift 5️⃣.1️⃣

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: swift
-osx_image: xcode10.2
+osx_image: xcode11.3
 
 xcode_project: Alicerce.xcodeproj
 
@@ -20,7 +20,7 @@ jobs:
         - XCODE_PROJECT_NAME=Alicerce
         - XCODE_SDK=iphonesimulator
         - XCODE_ACTION='build test'
-        - XCODE_DESTINATION='platform=iOS Simulator,name=iPhone 6s,OS=latest'
+        - XCODE_DESTINATION='platform=iOS Simulator,name=iPhone 11 Pro,OS=latest'
         - XCODE_DERIVED_DATA_PATH=build
         - XCODE_SCHEME=Alicerce
       script:

--- a/Alicerce.podspec
+++ b/Alicerce.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
     s.source        = { :git => 'https://github.com/Mindera/Alicerce.git', :tag => "#{s.version}" }
 
     s.module_name   = 'Alicerce'
-    s.swift_version = '5.0'
+    s.swift_version = '5.1'
 
     s.ios.deployment_target = '10.0'
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,13 @@ TODO
 
 ## Compatibility ✅
 
-### `0.7.0` (latest) ... `master` 
+### `master` 
+
+- iOS 10.0+
+- Xcode 11+
+- Swift 5.1
+
+### `0.7.0` (latest)
 
 - iOS 10.0+
 - Xcode 10.2


### PR DESCRIPTION
<!-- Thanks for contributing to _Alicerce 🏗_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've rebased my changes on top of `master`
- [x] I've built and run the project to see all new and existing tests pass
- [x] I've followed the [Mindera swift style guide](https://github.com/Mindera/swift-style-guide)
- [x] I've read the [Contribution Guidelines](https://github.com/Mindera/Alicerce/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Update project to Swift 5.1, Xcode 11+.

### Description

- Update .podspec’s `swift_version` to `5.1`.

- Update .travis.yml’s `osx_image` to `xcode11.3` , and `XCODE_DESTINATION` device to be iPhone 11 Pro, as the iPhone 6s simulator is no longer available with the latest iOS by default on Xcode 11.

- Update Compatibility section in `README.md`.
