### PR TITLE
Remove then function

### DIFF
--- a/Sources/Extensions/Foundation/Optional.swift
+++ b/Sources/Extensions/Foundation/Optional.swift
@@ -1,13 +1,6 @@
 import Foundation
 
-public extension Optional {
-
-    func then(f: (Wrapped) -> Void) {
-        if let wrapped = self { f(wrapped) }
-    }
-}
-
-// Credits to John Sundell 
+// Credits to John Sundell
 // https://github.com/JohnSundell/Require/
 
 public extension Optional {

--- a/Tests/AlicerceTests/Extensions/Foundation/OptionalTests.swift
+++ b/Tests/AlicerceTests/Extensions/Foundation/OptionalTests.swift
@@ -7,7 +7,7 @@ final class OptionalTests: XCTestCase {
     func testThen_UsingNonOptionalValue_ShouldUnwrapTheValue() {
         var anOptionalString: String? = "😎"
 
-        anOptionalString.then { value in
+        if let value = anOptionalString {
             XCTAssertEqual(anOptionalString, value, "🔥: \(value) not unwrapped! 😱")
             anOptionalString = "😇"
         }
@@ -18,7 +18,7 @@ final class OptionalTests: XCTestCase {
     func testThen_UsingOptionalValue_ShoudNotUnwrapTheValue() {
         let nullValue: String? = nil
 
-        nullValue.then { _ in
+        if let _ = nullValue {
             XCTFail("💥 nil unwrapped 😱")
         }
     }

--- a/Tests/AlicerceTests/Extensions/Foundation/OptionalTests.swift
+++ b/Tests/AlicerceTests/Extensions/Foundation/OptionalTests.swift
@@ -4,25 +4,6 @@ import XCTest
 
 final class OptionalTests: XCTestCase {
 
-    func testThen_UsingNonOptionalValue_ShouldUnwrapTheValue() {
-        var anOptionalString: String? = "😎"
-
-        if let value = anOptionalString {
-            XCTAssertEqual(anOptionalString, value, "🔥: \(value) not unwrapped! 😱")
-            anOptionalString = "😇"
-        }
-
-        XCTAssertEqual(anOptionalString, "😇", "🔥: then closure not executed! 😱")
-    }
-
-    func testThen_UsingOptionalValue_ShoudNotUnwrapTheValue() {
-        let nullValue: String? = nil
-
-        if let _ = nullValue {
-            XCTFail("💥 nil unwrapped 😱")
-        }
-    }
-
     func testRequire_UsingNonOptionalValue_ShouldUnwrapTheValue() {
         let anOptionalString: String? = "😎"
 


### PR DESCRIPTION
<!-- Thanks for contributing to _Alicerce 🏗_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've rebased my changes on top of `master`
- [x] I've built and run the project to see all new and existing tests pass
- [x] I've followed the [Mindera swift style guide](https://github.com/Mindera/swift-style-guide)
- [x] I've read the [Contribution Guidelines](https://github.com/Mindera/Alicerce/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The `then()` function lacks flow control compared to the "guard" or "if let" statements which provide a more eloquent and _out-of-the-box_ structure when dealing with nil values.

### Description
<!-- Describe your changes in detail -->
<!-- Please describe in detail how you tested your changes. -->
Remove then function from Optional.swift,
Amend OptionalTests.swift.
