### PR TITLE
Set `public` access control on the Auto Layout's public API methods

### DIFF
--- a/Sources/AutoLayout/Array+ConstrainableProxy.swift
+++ b/Sources/AutoLayout/Array+ConstrainableProxy.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-extension Array where Element: LeadingConstrainableProxy {
+public extension Array where Element: LeadingConstrainableProxy {
 
     @discardableResult
     func alignLeading() -> [NSLayoutConstraint] {
@@ -10,7 +10,7 @@ extension Array where Element: LeadingConstrainableProxy {
     }
 }
 
-extension Array where Element: TrailingConstrainableProxy {
+public extension Array where Element: TrailingConstrainableProxy {
 
     @discardableResult
     func alignTrailing() -> [NSLayoutConstraint] {
@@ -20,7 +20,7 @@ extension Array where Element: TrailingConstrainableProxy {
     }
 }
 
-extension Array where Element: TopConstrainableProxy {
+public extension Array where Element: TopConstrainableProxy {
 
     @discardableResult
     func alignTop() -> [NSLayoutConstraint] {
@@ -30,7 +30,7 @@ extension Array where Element: TopConstrainableProxy {
     }
 }
 
-extension Array where Element: BottomConstrainableProxy {
+public extension Array where Element: BottomConstrainableProxy {
 
     @discardableResult
     func alignBottom() -> [NSLayoutConstraint] {
@@ -40,7 +40,7 @@ extension Array where Element: BottomConstrainableProxy {
     }
 }
 
-extension Array where Element: PositionConstrainableProxy {
+public extension Array where Element: PositionConstrainableProxy {
 
     @discardableResult
     func alignCenterX() -> [NSLayoutConstraint] {
@@ -57,7 +57,7 @@ extension Array where Element: PositionConstrainableProxy {
     }
 }
 
-extension Array where Element: WidthConstrainableProxy {
+public extension Array where Element: WidthConstrainableProxy {
 
     @discardableResult
     func equalWidth() -> [NSLayoutConstraint] {
@@ -73,7 +73,7 @@ extension Array where Element: WidthConstrainableProxy {
     }
 }
 
-extension Array where Element: HeightConstrainableProxy {
+public extension Array where Element: HeightConstrainableProxy {
 
     @discardableResult
     func equalHeight() -> [NSLayoutConstraint] {
@@ -83,7 +83,7 @@ extension Array where Element: HeightConstrainableProxy {
     }
 }
 
-extension Array where Element: LeadingConstrainableProxy & TrailingConstrainableProxy {
+public extension Array where Element: LeadingConstrainableProxy & TrailingConstrainableProxy {
 
     @discardableResult
     func distributeHorizontally(margin: CGFloat = 0.0) -> [NSLayoutConstraint] {
@@ -95,7 +95,7 @@ extension Array where Element: LeadingConstrainableProxy & TrailingConstrainable
     }
 }
 
-extension Array where Element: TopConstrainableProxy & BottomConstrainableProxy {
+public extension Array where Element: TopConstrainableProxy & BottomConstrainableProxy {
 
     @discardableResult
     func distributeVertically(margin: CGFloat = 0.0) -> [NSLayoutConstraint] {

--- a/Sources/AutoLayout/Constrain.swift
+++ b/Sources/AutoLayout/Constrain.swift
@@ -2,7 +2,7 @@
 
 import UIKit
 
-final class LayoutContext {
+public final class LayoutContext {
 
     fileprivate var constraints: [NSLayoutConstraint] = []
 
@@ -12,14 +12,16 @@ final class LayoutContext {
     }
 }
 
-final class ConstraintGroup {
+public final class ConstraintGroup {
+
+    public init() { }
 
     fileprivate var constraints: [NSLayoutConstraint] = [] {
         willSet { uninstall(constraints) }
         didSet { install(constraints) }
     }
 
-    var isActive: Bool {
+    public var isActive: Bool {
         get { constraints.allSatisfy { $0.isActive } }
         set { newValue ? install(constraints) : uninstall(constraints) }
     }
@@ -36,7 +38,7 @@ final class ConstraintGroup {
 }
 
 @discardableResult
-func constrain<A: LayoutItem>(
+public func constrain<A: LayoutItem>(
     _ a: A,
     replacing group: ConstraintGroup = .init(),
     constraints: (A.ProxyType) -> Void
@@ -54,7 +56,7 @@ func constrain<A: LayoutItem>(
 }
 
 @discardableResult
-func constrain<A: LayoutItem, B: LayoutItem>(
+public func constrain<A: LayoutItem, B: LayoutItem>(
     _ a: A,
     _ b: B,
     replacing group: ConstraintGroup = .init(),
@@ -74,7 +76,7 @@ func constrain<A: LayoutItem, B: LayoutItem>(
 }
 
 @discardableResult
-func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem>(
+public func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem>(
     _ a: A,
     _ b: B,
     _ c: C,
@@ -96,7 +98,7 @@ func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem>(
 }
 
 @discardableResult
-func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem>(
+public func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem>(
     _ a: A,
     _ b: B,
     _ c: C,
@@ -120,7 +122,7 @@ func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem>(
 }
 
 @discardableResult
-func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem, E: LayoutItem>(
+public func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem, E: LayoutItem>(
     _ a: A,
     _ b: B,
     _ c: C,
@@ -146,7 +148,7 @@ func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem, E: La
 }
 
 @discardableResult
-func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem, E: LayoutItem, F: LayoutItem>(
+public func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem, E: LayoutItem, F: LayoutItem>(
     _ a: A,
     _ b: B,
     _ c: C,
@@ -174,7 +176,7 @@ func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem, E: La
 }
 
 @discardableResult
-func constrain<T: LayoutItem>(
+public func constrain<T: LayoutItem>(
     _ items: [T],
     replacing group: ConstraintGroup = .init(),
     constraints: ([T.ProxyType]) -> Void
@@ -192,7 +194,7 @@ func constrain<T: LayoutItem>(
 }
 
 @discardableResult
-func constrain(
+public func constrain(
     clearing group: ConstraintGroup = .init()
 ) -> ConstraintGroup {
 

--- a/Sources/AutoLayout/ConstrainableProxy.swift
+++ b/Sources/AutoLayout/ConstrainableProxy.swift
@@ -2,7 +2,7 @@
 
 import UIKit
 
-protocol ConstrainableProxy: AnyObject {
+public protocol ConstrainableProxy: AnyObject {
 
     var context: LayoutContext { get }
     var item: AnyObject { get }
@@ -10,12 +10,12 @@ protocol ConstrainableProxy: AnyObject {
     func prepare()
 }
 
-protocol TopConstrainableProxy: ConstrainableProxy {
+public protocol TopConstrainableProxy: ConstrainableProxy {
 
     var top: NSLayoutYAxisAnchor { get }
 }
 
-extension TopConstrainableProxy {
+public extension TopConstrainableProxy {
 
     @discardableResult
     func top(
@@ -52,12 +52,12 @@ extension TopConstrainableProxy {
     }
 }
 
-protocol BottomConstrainableProxy: ConstrainableProxy {
+public protocol BottomConstrainableProxy: ConstrainableProxy {
 
     var bottom: NSLayoutYAxisAnchor { get }
 }
 
-extension BottomConstrainableProxy {
+public extension BottomConstrainableProxy {
 
     @discardableResult
     func bottom(
@@ -94,12 +94,12 @@ extension BottomConstrainableProxy {
     }
 }
 
-protocol LeadingConstrainableProxy: ConstrainableProxy {
+public protocol LeadingConstrainableProxy: ConstrainableProxy {
 
     var leading: NSLayoutXAxisAnchor { get }
 }
 
-extension LeadingConstrainableProxy {
+public extension LeadingConstrainableProxy {
 
     @discardableResult
     func leading(
@@ -153,12 +153,12 @@ extension LeadingConstrainableProxy {
     }
 }
 
-protocol LeftConstrainableProxy: ConstrainableProxy {
+public protocol LeftConstrainableProxy: ConstrainableProxy {
 
     var left: NSLayoutXAxisAnchor { get }
 }
 
-extension LeftConstrainableProxy {
+public extension LeftConstrainableProxy {
 
     @discardableResult
     func left(
@@ -195,12 +195,12 @@ extension LeftConstrainableProxy {
     }
 }
 
-protocol RightConstrainableProxy: ConstrainableProxy {
+public protocol RightConstrainableProxy: ConstrainableProxy {
 
     var right: NSLayoutXAxisAnchor { get }
 }
 
-extension RightConstrainableProxy {
+public extension RightConstrainableProxy {
 
     @discardableResult
     func right(
@@ -237,12 +237,12 @@ extension RightConstrainableProxy {
     }
 }
 
-protocol TrailingConstrainableProxy: ConstrainableProxy {
+public protocol TrailingConstrainableProxy: ConstrainableProxy {
 
     var trailing: NSLayoutXAxisAnchor { get }
 }
 
-extension TrailingConstrainableProxy {
+public extension TrailingConstrainableProxy {
 
     @discardableResult
     func trailing(
@@ -296,14 +296,14 @@ extension TrailingConstrainableProxy {
     }
 }
 
-protocol EdgesConstrainableProxy: TopConstrainableProxy,
+public protocol EdgesConstrainableProxy: TopConstrainableProxy,
     BottomConstrainableProxy,
     LeadingConstrainableProxy,
     TrailingConstrainableProxy,
     LeftConstrainableProxy,
     RightConstrainableProxy {}
 
-extension EdgesConstrainableProxy {
+public extension EdgesConstrainableProxy {
 
     @discardableResult
     func edges(
@@ -324,12 +324,12 @@ extension EdgesConstrainableProxy {
     }
 }
 
-protocol CenterYConstrainableProxy: ConstrainableProxy {
+public protocol CenterYConstrainableProxy: ConstrainableProxy {
 
     var centerY: NSLayoutYAxisAnchor { get }
 }
 
-extension CenterYConstrainableProxy {
+public extension CenterYConstrainableProxy {
 
     @discardableResult
     func centerY(
@@ -391,12 +391,12 @@ extension CenterYConstrainableProxy {
     }
 }
 
-protocol CenterXConstrainableProxy: ConstrainableProxy {
+public protocol CenterXConstrainableProxy: ConstrainableProxy {
 
     var centerX: NSLayoutXAxisAnchor { get }
 }
 
-extension CenterXConstrainableProxy {
+public extension CenterXConstrainableProxy {
 
     @discardableResult
     func centerX(
@@ -452,9 +452,9 @@ extension CenterXConstrainableProxy {
     }
 }
 
-protocol CenterConstrainableProxy: CenterXConstrainableProxy, CenterYConstrainableProxy {}
+public protocol CenterConstrainableProxy: CenterXConstrainableProxy, CenterYConstrainableProxy {}
 
-extension CenterConstrainableProxy {
+public extension CenterConstrainableProxy {
 
     @discardableResult
     func center(
@@ -473,12 +473,12 @@ extension CenterConstrainableProxy {
     }
 }
 
-protocol WidthConstrainableProxy: ConstrainableProxy {
+public protocol WidthConstrainableProxy: ConstrainableProxy {
 
     var width: NSLayoutDimension { get }
 }
 
-extension WidthConstrainableProxy {
+public extension WidthConstrainableProxy {
 
     @discardableResult
     func width(
@@ -515,12 +515,12 @@ extension WidthConstrainableProxy {
     }
 }
 
-protocol HeightConstrainableProxy: ConstrainableProxy {
+public protocol HeightConstrainableProxy: ConstrainableProxy {
 
     var height: NSLayoutDimension { get }
 }
 
-extension HeightConstrainableProxy {
+public extension HeightConstrainableProxy {
 
     @discardableResult
     func height(
@@ -557,9 +557,9 @@ extension HeightConstrainableProxy {
     }
 }
 
-protocol SizeConstrainableProxy: WidthConstrainableProxy, HeightConstrainableProxy {}
+public protocol SizeConstrainableProxy: WidthConstrainableProxy, HeightConstrainableProxy {}
 
-extension SizeConstrainableProxy {
+public extension SizeConstrainableProxy {
 
     @discardableResult
     func size(
@@ -594,13 +594,13 @@ extension SizeConstrainableProxy {
     }
 }
 
-protocol BaselineConstrainableProxy: ConstrainableProxy {
+public protocol BaselineConstrainableProxy: ConstrainableProxy {
 
     var firstBaseline: NSLayoutYAxisAnchor { get }
     var lastBaseline: NSLayoutYAxisAnchor { get }
 }
 
-extension BaselineConstrainableProxy {
+public extension BaselineConstrainableProxy {
 
     @discardableResult
     func firstBaseline(
@@ -705,7 +705,7 @@ extension BaselineConstrainableProxy {
     }
 }
 
-protocol PositionConstrainableProxy: EdgesConstrainableProxy, SizeConstrainableProxy, CenterConstrainableProxy {}
+public protocol PositionConstrainableProxy: EdgesConstrainableProxy, SizeConstrainableProxy, CenterConstrainableProxy {}
 
 // MARK: - Helpers
 

--- a/Sources/AutoLayout/ConstraintRelation.swift
+++ b/Sources/AutoLayout/ConstraintRelation.swift
@@ -1,4 +1,4 @@
-enum ConstraintRelation: Int {
+public enum ConstraintRelation: Int {
     case equal = 0
     case equalOrLess = -1
     case equalOrGreater = 1

--- a/Sources/AutoLayout/LayoutGuideProxy.swift
+++ b/Sources/AutoLayout/LayoutGuideProxy.swift
@@ -1,33 +1,33 @@
 import UIKit
 
-final class LayoutGuideProxy: PositionConstrainableProxy {
+public final class LayoutGuideProxy: PositionConstrainableProxy {
 
     // MARK: - PositionConstrainable
 
-    var top: NSLayoutYAxisAnchor { guide.topAnchor }
+    public var top: NSLayoutYAxisAnchor { guide.topAnchor }
 
-    var bottom: NSLayoutYAxisAnchor { guide.bottomAnchor }
+    public var bottom: NSLayoutYAxisAnchor { guide.bottomAnchor }
 
-    var leading: NSLayoutXAxisAnchor { guide.leadingAnchor }
+    public var leading: NSLayoutXAxisAnchor { guide.leadingAnchor }
 
-    var trailing: NSLayoutXAxisAnchor { guide.trailingAnchor }
+    public var trailing: NSLayoutXAxisAnchor { guide.trailingAnchor }
 
-    var left: NSLayoutXAxisAnchor { guide.leftAnchor }
+    public var left: NSLayoutXAxisAnchor { guide.leftAnchor }
 
-    var right: NSLayoutXAxisAnchor { guide.rightAnchor }
+    public var right: NSLayoutXAxisAnchor { guide.rightAnchor }
 
-    var height: NSLayoutDimension { guide.heightAnchor }
+    public var height: NSLayoutDimension { guide.heightAnchor }
 
-    var width: NSLayoutDimension { guide.widthAnchor }
+    public var width: NSLayoutDimension { guide.widthAnchor }
 
-    var centerY: NSLayoutYAxisAnchor { guide.centerYAnchor }
+    public var centerY: NSLayoutYAxisAnchor { guide.centerYAnchor }
 
-    var centerX: NSLayoutXAxisAnchor { guide.centerXAnchor }
+    public var centerX: NSLayoutXAxisAnchor { guide.centerXAnchor }
 
     // MARK: - ConstrainableProxy
 
-    let context: LayoutContext
-    var item: AnyObject { guide }
+    public let context: LayoutContext
+    public var item: AnyObject { guide }
 
     private let guide: UILayoutGuide
 
@@ -39,5 +39,5 @@ final class LayoutGuideProxy: PositionConstrainableProxy {
         self.guide = guide
     }
 
-    func prepare() {}
+    public func prepare() {}
 }

--- a/Sources/AutoLayout/LayoutItem.swift
+++ b/Sources/AutoLayout/LayoutItem.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-protocol LayoutItem: AnyObject {
+public protocol LayoutItem: AnyObject {
 
     associatedtype ProxyType: ConstrainableProxy
 
@@ -11,9 +11,9 @@ protocol LayoutItem: AnyObject {
 
 extension UIView: LayoutItem {
 
-    typealias ProxyType = ViewProxy
+    public typealias ProxyType = ViewProxy
 
-    func proxy(with context: LayoutContext) -> ViewProxy {
+    public func proxy(with context: LayoutContext) -> ViewProxy {
 
         ViewProxy(context: context, view: self)
     }
@@ -23,9 +23,9 @@ extension UIView: LayoutItem {
 
 extension UILayoutGuide: LayoutItem {
 
-    typealias ProxyType = LayoutGuideProxy
+    public typealias ProxyType = LayoutGuideProxy
 
-    func proxy(with context: LayoutContext) -> LayoutGuideProxy {
+    public func proxy(with context: LayoutContext) -> LayoutGuideProxy {
 
         LayoutGuideProxy(context: context, guide: self)
     }

--- a/Sources/AutoLayout/NSLayoutConstraint+Helpers.swift
+++ b/Sources/AutoLayout/NSLayoutConstraint+Helpers.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-extension NSLayoutConstraint {
+public extension NSLayoutConstraint {
 
     func with(priority: UILayoutPriority) -> NSLayoutConstraint {
 

--- a/Sources/AutoLayout/ViewProxy.swift
+++ b/Sources/AutoLayout/ViewProxy.swift
@@ -1,48 +1,48 @@
 import UIKit
 
-final class ViewProxy: PositionConstrainableProxy, BaselineConstrainableProxy {
+public final class ViewProxy: PositionConstrainableProxy, BaselineConstrainableProxy {
 
     // MARK: - PositionConstrainableProxy
 
-    var top: NSLayoutYAxisAnchor { view.topAnchor }
+    public var top: NSLayoutYAxisAnchor { view.topAnchor }
 
-    var bottom: NSLayoutYAxisAnchor { view.bottomAnchor }
+    public var bottom: NSLayoutYAxisAnchor { view.bottomAnchor }
 
-    var leading: NSLayoutXAxisAnchor { view.leadingAnchor }
+    public var leading: NSLayoutXAxisAnchor { view.leadingAnchor }
 
-    var trailing: NSLayoutXAxisAnchor { view.trailingAnchor }
+    public var trailing: NSLayoutXAxisAnchor { view.trailingAnchor }
 
-    var left: NSLayoutXAxisAnchor { view.leftAnchor }
+    public var left: NSLayoutXAxisAnchor { view.leftAnchor }
 
-    var right: NSLayoutXAxisAnchor { view.rightAnchor }
+    public var right: NSLayoutXAxisAnchor { view.rightAnchor }
 
-    var height: NSLayoutDimension { view.heightAnchor }
+    public var height: NSLayoutDimension { view.heightAnchor }
 
-    var width: NSLayoutDimension { view.widthAnchor }
+    public var width: NSLayoutDimension { view.widthAnchor }
 
-    var centerY: NSLayoutYAxisAnchor { view.centerYAnchor }
+    public var centerY: NSLayoutYAxisAnchor { view.centerYAnchor }
 
-    var centerX: NSLayoutXAxisAnchor { view.centerXAnchor }
+    public var centerX: NSLayoutXAxisAnchor { view.centerXAnchor }
 
     // MARK: - BaselineConstrainableProxy
 
-    var firstBaseline: NSLayoutYAxisAnchor { view.firstBaselineAnchor }
+    public var firstBaseline: NSLayoutYAxisAnchor { view.firstBaselineAnchor }
 
-    var lastBaseline: NSLayoutYAxisAnchor { view.lastBaselineAnchor }
+    public var lastBaseline: NSLayoutYAxisAnchor { view.lastBaselineAnchor }
 
     // MARK: - ConstrainableProxy
 
-    let context: LayoutContext
-    var item: AnyObject { view }
+    public let context: LayoutContext
+    public var item: AnyObject { view }
 
     // MARK: - Properties
 
-    var layoutMarginsGuide: LayoutGuideProxy { view.layoutMarginsGuide.proxy(with: context) }
+    public var layoutMarginsGuide: LayoutGuideProxy { view.layoutMarginsGuide.proxy(with: context) }
 
     @available(iOS 11.0, *)
-    var safeAreaLayoutGuide: LayoutGuideProxy { view.safeAreaLayoutGuide.proxy(with: context) }
+    public var safeAreaLayoutGuide: LayoutGuideProxy { view.safeAreaLayoutGuide.proxy(with: context) }
 
-    var safeArea: LayoutGuideProxy {
+    public var safeArea: LayoutGuideProxy {
 
         if #available(iOS 11.0, *) {
             return safeAreaLayoutGuide
@@ -61,7 +61,7 @@ final class ViewProxy: PositionConstrainableProxy, BaselineConstrainableProxy {
         self.view = view
     }
 
-    func prepare() {
+    public func prepare() {
 
         view.translatesAutoresizingMaskIntoConstraints = false
     }


### PR DESCRIPTION
### Checklist
- [x] I've rebased my changes on top of `master`
- [x] I've built and run the project to see all new and existing tests pass
- [x] I've followed the [Mindera swift style guide](https://github.com/Mindera/swift-style-guide)
- [x] I've read the [Contribution Guidelines](https://github.com/Mindera/Alicerce/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

On #210 we've failed to define the correct access control modifiers for the Auto Layout DSLs public API, making it impossible to use when imported into another project 😓

### Description

Changed the needed methods and classes to feature a `public` access control.

Tested the implementation by importing `Alicerce` into another project (that was already using this Auto Layout DSL locally).

Deleted the local files and pointed all Auto Layout logic to `Alicerce`, making sure no needed methods remained inaccessible.