### PR TITLE
Improve constrain API by defining ConstraintGroup initial isActive state

### DIFF
--- a/Sources/AutoLayout/Constrain.swift
+++ b/Sources/AutoLayout/Constrain.swift
@@ -17,21 +17,20 @@ public final class ConstraintGroup {
     public init() { }
 
     fileprivate var constraints: [NSLayoutConstraint] = [] {
-        willSet { uninstall(constraints) }
-        didSet { install(constraints) }
+        willSet { uninstall() }
     }
 
     public var isActive: Bool {
         get { constraints.allSatisfy { $0.isActive } }
-        set { newValue ? install(constraints) : uninstall(constraints) }
+        set { newValue ? install() : uninstall() }
     }
 
-    private func install(_ constraints: [NSLayoutConstraint]) {
+    private func install() {
 
         NSLayoutConstraint.activate(constraints)
     }
 
-    private func uninstall(_ constraints: [NSLayoutConstraint]) {
+    private func uninstall() {
 
         NSLayoutConstraint.deactivate(constraints)
     }
@@ -41,6 +40,7 @@ public final class ConstraintGroup {
 public func constrain<A: LayoutItem>(
     _ a: A,
     replacing group: ConstraintGroup = .init(),
+    isActive: Bool = true,
     constraints: (A.ProxyType) -> Void
 ) -> ConstraintGroup {
 
@@ -51,6 +51,7 @@ public func constrain<A: LayoutItem>(
     constraints(a)
 
     group.constraints = context.constraints
+    group.isActive = isActive
 
     return group
 }
@@ -60,6 +61,7 @@ public func constrain<A: LayoutItem, B: LayoutItem>(
     _ a: A,
     _ b: B,
     replacing group: ConstraintGroup = .init(),
+    isActive: Bool = true,
     constraints: (A.ProxyType, B.ProxyType) -> Void
 ) -> ConstraintGroup {
 
@@ -71,6 +73,7 @@ public func constrain<A: LayoutItem, B: LayoutItem>(
     constraints(a, b)
 
     group.constraints = context.constraints
+    group.isActive = isActive
 
     return group
 }
@@ -81,6 +84,7 @@ public func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem>(
     _ b: B,
     _ c: C,
     replacing group: ConstraintGroup = .init(),
+    isActive: Bool = true,
     constraints: (A.ProxyType, B.ProxyType, C.ProxyType) -> Void
 ) -> ConstraintGroup {
 
@@ -93,6 +97,7 @@ public func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem>(
     constraints(a, b, c)
 
     group.constraints = context.constraints
+    group.isActive = isActive
 
     return group
 }
@@ -104,6 +109,7 @@ public func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem
     _ c: C,
     _ d: D,
     replacing group: ConstraintGroup = .init(),
+    isActive: Bool = true,
     constraints: (A.ProxyType, B.ProxyType, C.ProxyType, D.ProxyType) -> Void
 ) -> ConstraintGroup {
 
@@ -117,6 +123,7 @@ public func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem
     constraints(a, b, c, d)
 
     group.constraints = context.constraints
+    group.isActive = isActive
 
     return group
 }
@@ -129,6 +136,7 @@ public func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem
     _ d: D,
     _ e: E,
     replacing group: ConstraintGroup = .init(),
+    isActive: Bool = true,
     constraints: (A.ProxyType, B.ProxyType, C.ProxyType, D.ProxyType, E.ProxyType) -> Void
 ) -> ConstraintGroup {
 
@@ -143,6 +151,7 @@ public func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem
     constraints(a, b, c, d, e)
 
     group.constraints = context.constraints
+    group.isActive = isActive
 
     return group
 }
@@ -156,6 +165,7 @@ public func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem
     _ e: E,
     _ f: F,
     replacing group: ConstraintGroup = .init(),
+    isActive: Bool = true,
     constraints: (A.ProxyType, B.ProxyType, C.ProxyType, D.ProxyType, E.ProxyType, F.ProxyType) -> Void
 ) -> ConstraintGroup {
 
@@ -171,6 +181,7 @@ public func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem
     constraints(a, b, c, d, e, f)
 
     group.constraints = context.constraints
+    group.isActive = isActive
 
     return group
 }
@@ -179,6 +190,7 @@ public func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem
 public func constrain<T: LayoutItem>(
     _ items: [T],
     replacing group: ConstraintGroup = .init(),
+    isActive: Bool = true,
     constraints: ([T.ProxyType]) -> Void
 ) -> ConstraintGroup {
 
@@ -189,6 +201,7 @@ public func constrain<T: LayoutItem>(
     constraints(proxies)
 
     group.constraints = context.constraints
+    group.isActive = isActive
 
     return group
 }

--- a/Sources/AutoLayout/Constrain.swift
+++ b/Sources/AutoLayout/Constrain.swift
@@ -17,20 +17,25 @@ public final class ConstraintGroup {
     public init() { }
 
     fileprivate var constraints: [NSLayoutConstraint] = [] {
-        willSet { uninstall() }
+        willSet {
+            if isActive { deactivate() }
+        }
+        didSet {
+            if isActive { activate() }
+        }
     }
 
     public var isActive: Bool {
         get { constraints.allSatisfy { $0.isActive } }
-        set { newValue ? install() : uninstall() }
+        set { newValue ? activate() : deactivate() }
     }
 
-    private func install() {
+    private func activate() {
 
         NSLayoutConstraint.activate(constraints)
     }
 
-    private func uninstall() {
+    private func deactivate() {
 
         NSLayoutConstraint.deactivate(constraints)
     }
@@ -40,7 +45,7 @@ public final class ConstraintGroup {
 public func constrain<A: LayoutItem>(
     _ a: A,
     replacing group: ConstraintGroup = .init(),
-    isActive: Bool = true,
+    activate: Bool = true,
     constraints: (A.ProxyType) -> Void
 ) -> ConstraintGroup {
 
@@ -51,7 +56,7 @@ public func constrain<A: LayoutItem>(
     constraints(a)
 
     group.constraints = context.constraints
-    group.isActive = isActive
+    group.isActive = activate
 
     return group
 }
@@ -61,7 +66,7 @@ public func constrain<A: LayoutItem, B: LayoutItem>(
     _ a: A,
     _ b: B,
     replacing group: ConstraintGroup = .init(),
-    isActive: Bool = true,
+    activate: Bool = true,
     constraints: (A.ProxyType, B.ProxyType) -> Void
 ) -> ConstraintGroup {
 
@@ -73,7 +78,7 @@ public func constrain<A: LayoutItem, B: LayoutItem>(
     constraints(a, b)
 
     group.constraints = context.constraints
-    group.isActive = isActive
+    group.isActive = activate
 
     return group
 }
@@ -84,7 +89,7 @@ public func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem>(
     _ b: B,
     _ c: C,
     replacing group: ConstraintGroup = .init(),
-    isActive: Bool = true,
+    activate: Bool = true,
     constraints: (A.ProxyType, B.ProxyType, C.ProxyType) -> Void
 ) -> ConstraintGroup {
 
@@ -97,7 +102,7 @@ public func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem>(
     constraints(a, b, c)
 
     group.constraints = context.constraints
-    group.isActive = isActive
+    group.isActive = activate
 
     return group
 }
@@ -109,7 +114,7 @@ public func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem
     _ c: C,
     _ d: D,
     replacing group: ConstraintGroup = .init(),
-    isActive: Bool = true,
+    activate: Bool = true,
     constraints: (A.ProxyType, B.ProxyType, C.ProxyType, D.ProxyType) -> Void
 ) -> ConstraintGroup {
 
@@ -123,7 +128,7 @@ public func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem
     constraints(a, b, c, d)
 
     group.constraints = context.constraints
-    group.isActive = isActive
+    group.isActive = activate
 
     return group
 }
@@ -136,7 +141,7 @@ public func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem
     _ d: D,
     _ e: E,
     replacing group: ConstraintGroup = .init(),
-    isActive: Bool = true,
+    activate: Bool = true,
     constraints: (A.ProxyType, B.ProxyType, C.ProxyType, D.ProxyType, E.ProxyType) -> Void
 ) -> ConstraintGroup {
 
@@ -151,7 +156,7 @@ public func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem
     constraints(a, b, c, d, e)
 
     group.constraints = context.constraints
-    group.isActive = isActive
+    group.isActive = activate
 
     return group
 }
@@ -165,7 +170,7 @@ public func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem
     _ e: E,
     _ f: F,
     replacing group: ConstraintGroup = .init(),
-    isActive: Bool = true,
+    activate: Bool = true,
     constraints: (A.ProxyType, B.ProxyType, C.ProxyType, D.ProxyType, E.ProxyType, F.ProxyType) -> Void
 ) -> ConstraintGroup {
 
@@ -181,7 +186,7 @@ public func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem
     constraints(a, b, c, d, e, f)
 
     group.constraints = context.constraints
-    group.isActive = isActive
+    group.isActive = activate
 
     return group
 }
@@ -190,7 +195,7 @@ public func constrain<A: LayoutItem, B: LayoutItem, C: LayoutItem, D: LayoutItem
 public func constrain<T: LayoutItem>(
     _ items: [T],
     replacing group: ConstraintGroup = .init(),
-    isActive: Bool = true,
+    activate: Bool = true,
     constraints: ([T.ProxyType]) -> Void
 ) -> ConstraintGroup {
 
@@ -201,7 +206,7 @@ public func constrain<T: LayoutItem>(
     constraints(proxies)
 
     group.constraints = context.constraints
-    group.isActive = isActive
+    group.isActive = activate
 
     return group
 }

--- a/Sources/Persistence/PersistencePerformanceMetricsTracker.swift
+++ b/Sources/Persistence/PersistencePerformanceMetricsTracker.swift
@@ -105,7 +105,7 @@ public extension PersistencePerformanceMetricsTracker {
             try execute { result in
 
                 switch result {
-                case .success(let blobSize, let memSize):
+                case .success((let blobSize, let memSize)):
                     stopMetadata([self.blobSizeMetadataKey : blobSize, self.usedMemoryMetadataKey : memSize])
                 case .failure(let error):
                     stopMetadata([self.errorMetadataKey : error])
@@ -122,7 +122,7 @@ public extension PersistencePerformanceMetricsTracker {
             try execute { result in
 
                 switch result {
-                case .success(let blobSize, let memSize):
+                case .success((let blobSize, let memSize)):
                     stopMetadata([self.blobSizeMetadataKey : blobSize, self.usedMemoryMetadataKey : memSize])
                 case .failure(let error):
                     stopMetadata([self.errorMetadataKey : error])
@@ -141,7 +141,7 @@ public extension PersistencePerformanceMetricsTracker {
             try execute { result in
 
                 switch result {
-                case .success(let blobSize, let diskSize):
+                case .success((let blobSize, let diskSize)):
                     stopMetadata([self.blobSizeMetadataKey : blobSize, self.usedDiskMetadataKey : diskSize])
                 case .failure(let error):
                     stopMetadata([self.errorMetadataKey : error])
@@ -158,7 +158,7 @@ public extension PersistencePerformanceMetricsTracker {
             try execute { result in
 
                 switch result {
-                case .success(let blobSize, let diskSize):
+                case .success((let blobSize, let diskSize)):
                     stopMetadata([self.blobSizeMetadataKey : blobSize, self.usedDiskMetadataKey : diskSize])
                 case .failure(let error):
                     stopMetadata([self.errorMetadataKey : error])

--- a/Sources/Persistence/PersistencePerformanceMetricsTracker.swift
+++ b/Sources/Persistence/PersistencePerformanceMetricsTracker.swift
@@ -105,7 +105,7 @@ public extension PersistencePerformanceMetricsTracker {
             try execute { result in
 
                 switch result {
-                case .success((let blobSize, let memSize)):
+                case .success(let blobSize, let memSize):
                     stopMetadata([self.blobSizeMetadataKey : blobSize, self.usedMemoryMetadataKey : memSize])
                 case .failure(let error):
                     stopMetadata([self.errorMetadataKey : error])
@@ -122,7 +122,7 @@ public extension PersistencePerformanceMetricsTracker {
             try execute { result in
 
                 switch result {
-                case .success((let blobSize, let memSize)):
+                case .success(let blobSize, let memSize):
                     stopMetadata([self.blobSizeMetadataKey : blobSize, self.usedMemoryMetadataKey : memSize])
                 case .failure(let error):
                     stopMetadata([self.errorMetadataKey : error])
@@ -141,7 +141,7 @@ public extension PersistencePerformanceMetricsTracker {
             try execute { result in
 
                 switch result {
-                case .success((let blobSize, let diskSize)):
+                case .success(let blobSize, let diskSize):
                     stopMetadata([self.blobSizeMetadataKey : blobSize, self.usedDiskMetadataKey : diskSize])
                 case .failure(let error):
                     stopMetadata([self.errorMetadataKey : error])
@@ -158,7 +158,7 @@ public extension PersistencePerformanceMetricsTracker {
             try execute { result in
 
                 switch result {
-                case .success((let blobSize, let diskSize)):
+                case .success(let blobSize, let diskSize):
                     stopMetadata([self.blobSizeMetadataKey : blobSize, self.usedDiskMetadataKey : diskSize])
                 case .failure(let error):
                     stopMetadata([self.errorMetadataKey : error])

--- a/Tests/AlicerceTests/AutoLayout/BottomConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/BottomConstrainableProxyTestCase.swift
@@ -258,4 +258,62 @@ final class BottomConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
         XCTAssertEqual(view0.frame.maxY, view1.frame.maxY)
         XCTAssertEqual(view0.frame.maxY, view2.frame.maxY)
     }
+
+    func testConstrain_WithBottomConstraintAndTwoConstraintGroups_ShouldReturnCorrectIsActiveValue() {
+
+        var constraint0: NSLayoutConstraint!
+        let constraintGroup0 =  constrain(host, view0, activate: false) { host, view0 in
+            constraint0 = view0.bottom(to: host)
+        }
+
+        var constraint1: NSLayoutConstraint!
+        let constraintGroup1 = constrain(host, view0, activate: false) { host, view0 in
+            constraint1 = view0.bottom(to: host, offset: -100)
+        }
+
+        let expected = [
+            NSLayoutConstraint(
+                item: view0!,
+                attribute: .bottom,
+                relatedBy: .equal,
+                toItem: host,
+                attribute: .bottom,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: false
+            ),
+            NSLayoutConstraint(
+                item: view0!,
+                attribute: .bottom,
+                relatedBy: .equal,
+                toItem: host,
+                attribute: .bottom,
+                multiplier: 1,
+                constant: -100,
+                priority: .required,
+                active: false
+            )
+        ]
+
+        XCTAssertConstraints([constraint0, constraint1], expected)
+
+        constraintGroup0.isActive = true
+
+        host.layoutIfNeeded()
+
+        XCTAssert(constraintGroup0.isActive)
+        XCTAssertFalse(constraintGroup1.isActive)
+        XCTAssertEqual(view0.frame.maxY, 500)
+
+        constraintGroup0.isActive = false
+        constraintGroup1.isActive = true
+
+        host.setNeedsLayout()
+        host.layoutIfNeeded()
+
+        XCTAssertFalse(constraintGroup0.isActive)
+        XCTAssert(constraintGroup1.isActive)
+        XCTAssertEqual(view0.frame.maxY, 400)
+    }
 }

--- a/Tests/AlicerceTests/AutoLayout/CenterConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/CenterConstrainableProxyTestCase.swift
@@ -116,11 +116,48 @@ class CenterConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
         XCTAssertEqual(view3.center, host.center)
         XCTAssertEqual(view4.center, host.center)
     }
+
+    func testConstrain_WithOneCenterConstraintAndTwoConstraintGroups_ShouldReturnCorrectIsActiveValue() {
+
+        let constraintGroup0 = constrain(host, view0, activate: false) { host, view0 in
+            constraints0 = view0.center(in: host)
+        }
+
+        let constraintGroup1 = constrain(host, view0, activate: false) { host, view0 in
+            constraints1 = view0.center(in: host, offset: CGPoint(x: 100, y: 100))
+        }
+
+        XCTAssertConstraints(constraints0, expectedConstraints(view: view0, to: host, active: false))
+        XCTAssertConstraints(constraints1, expectedConstraints(view: view0, to: host, active: false, constant: 100))
+
+        constraintGroup0.isActive = true
+
+        host.layoutIfNeeded()
+
+        XCTAssert(constraintGroup0.isActive)
+        XCTAssert(constraintGroup1.isActive == false)
+        XCTAssertEqual(view0.center, host.center)
+
+        constraintGroup0.isActive = false
+        constraintGroup1.isActive = true
+
+        host.setNeedsLayout()
+        host.layoutIfNeeded()
+
+        XCTAssert(constraintGroup0.isActive == false)
+        XCTAssert(constraintGroup1.isActive)
+        XCTAssertEqual(view0.center, CGPoint(x: host.center.x + 100, y: host.center.y + 100))
+    }
 }
 
 private extension CenterConstrainableProxyTestCase {
 
-    func expectedConstraints(view: UIView, to host: UIView) -> [NSLayoutConstraint] {
+    func expectedConstraints(
+        view: UIView,
+        to host: UIView,
+        active: Bool = true,
+        constant: CGFloat = .zero
+    ) -> [NSLayoutConstraint] {
 
         let centerX = NSLayoutConstraint(
             item: view,
@@ -129,9 +166,9 @@ private extension CenterConstrainableProxyTestCase {
             toItem: host,
             attribute: .centerX,
             multiplier: 1,
-            constant: 0,
+            constant: constant,
             priority: .required,
-            active: true
+            active: active
         )
 
         let centerY = NSLayoutConstraint(
@@ -141,9 +178,9 @@ private extension CenterConstrainableProxyTestCase {
             toItem: host,
             attribute: .centerY,
             multiplier: 1,
-            constant: 0,
+            constant: constant,
             priority: .required,
-            active: true
+            active: active
         )
 
         return [centerX, centerY]

--- a/Tests/AlicerceTests/AutoLayout/CenterConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/CenterConstrainableProxyTestCase.swift
@@ -128,7 +128,7 @@ class CenterConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
         }
 
         XCTAssertConstraints(constraints0, expectedConstraints(view: view0, to: host, active: false))
-        XCTAssertConstraints(constraints1, expectedConstraints(view: view0, to: host, active: false, constant: 100))
+        XCTAssertConstraints(constraints1, expectedConstraints(view: view0, to: host, constant: 100, active: false))
 
         constraintGroup0.isActive = true
 
@@ -155,8 +155,8 @@ private extension CenterConstrainableProxyTestCase {
     func expectedConstraints(
         view: UIView,
         to host: UIView,
-        active: Bool = true,
-        constant: CGFloat = .zero
+        constant: CGFloat = .zero,
+        active: Bool = true
     ) -> [NSLayoutConstraint] {
 
         let centerX = NSLayoutConstraint(

--- a/Tests/AlicerceTests/AutoLayout/CenterXConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/CenterXConstrainableProxyTestCase.swift
@@ -236,7 +236,7 @@ class CenterXConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
         }
 
         XCTAssertConstraint(constraint0, expectedConstraint(view: view0, to: host, active: false))
-        XCTAssertConstraint(constraint1, expectedConstraint(view: view0, to: host, active: false, constant: 100))
+        XCTAssertConstraint(constraint1, expectedConstraint(view: view0, to: host, constant: 100, active: false))
 
         constraintGroup0.isActive = true
 
@@ -263,8 +263,8 @@ private extension CenterXConstrainableProxyTestCase {
     func expectedConstraint(
         view: UIView,
         to host: UIView,
-        active: Bool = true,
-        constant: CGFloat = .zero
+        constant: CGFloat = .zero,
+        active: Bool = true
     ) -> NSLayoutConstraint {
 
         NSLayoutConstraint(

--- a/Tests/AlicerceTests/AutoLayout/CenterXConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/CenterXConstrainableProxyTestCase.swift
@@ -224,11 +224,48 @@ class CenterXConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         XCTAssertConstraints(constraints, [])
     }
+
+    func testConstrain_WithCenterXConstraintAndTwoConstraintGroups_ShouldReturnCorrectIsActiveConstraint() {
+
+        let constraintGroup0 = constrain(host, view0, activate: false) { host, view0 in
+            constraint0 = view0.centerX(to: host)
+        }
+
+        let constraintGroup1 = constrain(host, view0, activate: false) { host, view0 in
+            constraint1 = view0.centerX(to: host, offset: 100)
+        }
+
+        XCTAssertConstraint(constraint0, expectedConstraint(view: view0, to: host, active: false))
+        XCTAssertConstraint(constraint1, expectedConstraint(view: view0, to: host, active: false, constant: 100))
+
+        constraintGroup0.isActive = true
+
+        host.layoutIfNeeded()
+
+        XCTAssert(constraintGroup0.isActive)
+        XCTAssertFalse(constraintGroup1.isActive)
+        XCTAssertEqual(view0.center.x, host.center.x)
+
+        constraintGroup0.isActive = false
+        constraintGroup1.isActive = true
+
+        host.setNeedsLayout()
+        host.layoutIfNeeded()
+
+        XCTAssertFalse(constraintGroup0.isActive)
+        XCTAssert(constraintGroup1.isActive)
+        XCTAssertEqual(view0.frame.midX, host.frame.midX + 100)
+    }
 }
 
 private extension CenterXConstrainableProxyTestCase {
 
-    func expectedConstraint(view: UIView, to host: UIView) -> NSLayoutConstraint {
+    func expectedConstraint(
+        view: UIView,
+        to host: UIView,
+        active: Bool = true,
+        constant: CGFloat = .zero
+    ) -> NSLayoutConstraint {
 
         NSLayoutConstraint(
             item: view,
@@ -237,9 +274,9 @@ private extension CenterXConstrainableProxyTestCase {
             toItem: host,
             attribute: .centerX,
             multiplier: 1,
-            constant: 0,
+            constant: constant,
             priority: .required,
-            active: true
+            active: active
         )
     }
 }

--- a/Tests/AlicerceTests/AutoLayout/CenterYConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/CenterYConstrainableProxyTestCase.swift
@@ -236,7 +236,7 @@ class CenterYConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
         }
 
         XCTAssertConstraint(constraint0, expectedConstraint(view: view0, to: host, active: false))
-        XCTAssertConstraint(constraint1, expectedConstraint(view: view0, to: host, active: false, constant: 100))
+        XCTAssertConstraint(constraint1, expectedConstraint(view: view0, to: host, constant: 100, active: false))
 
         constraintGroup0.isActive = true
 
@@ -263,8 +263,8 @@ private extension CenterYConstrainableProxyTestCase {
     func expectedConstraint(
         view: UIView,
         to host: UIView,
-        active: Bool = true,
-        constant: CGFloat = .zero
+        constant: CGFloat = .zero,
+        active: Bool = true
     ) -> NSLayoutConstraint {
 
         NSLayoutConstraint(

--- a/Tests/AlicerceTests/AutoLayout/CenterYConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/CenterYConstrainableProxyTestCase.swift
@@ -224,11 +224,48 @@ class CenterYConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         XCTAssertConstraints(constraints, [])
     }
+
+    func testConstrain_WithCenterYConstraintAndTwoConstraintGroups_ShouldReturnCorrectIsActiveConstraint() {
+
+        let constraintGroup0 = constrain(view0, host, activate: false) { view0, host in
+            constraint0 = view0.centerY(to: host)
+        }
+
+        let constraintGroup1 = constrain(view0, host, activate: false) { view0, host in
+            constraint1 = view0.centerY(to: host, offset: 100)
+        }
+
+        XCTAssertConstraint(constraint0, expectedConstraint(view: view0, to: host, active: false))
+        XCTAssertConstraint(constraint1, expectedConstraint(view: view0, to: host, active: false, constant: 100))
+
+        constraintGroup0.isActive = true
+
+        host.layoutIfNeeded()
+
+        XCTAssert(constraintGroup0.isActive)
+        XCTAssertFalse(constraintGroup1.isActive)
+        XCTAssertEqual(view0.center.y, host.center.y)
+
+        constraintGroup0.isActive = false
+        constraintGroup1.isActive = true
+
+        host.setNeedsLayout()
+        host.layoutIfNeeded()
+
+        XCTAssertFalse(constraintGroup0.isActive)
+        XCTAssert(constraintGroup1.isActive)
+        XCTAssertEqual(view0.center.y, host.center.y + 100)
+    }
 }
 
 private extension CenterYConstrainableProxyTestCase {
 
-    func expectedConstraint(view: UIView, to host: UIView) -> NSLayoutConstraint {
+    func expectedConstraint(
+        view: UIView,
+        to host: UIView,
+        active: Bool = true,
+        constant: CGFloat = .zero
+    ) -> NSLayoutConstraint {
 
         NSLayoutConstraint(
             item: view,
@@ -237,9 +274,9 @@ private extension CenterYConstrainableProxyTestCase {
             toItem: host,
             attribute: .centerY,
             multiplier: 1,
-            constant: 0,
+            constant: constant,
             priority: .required,
-            active: true
+            active: active
         )
     }
 }

--- a/Tests/AlicerceTests/AutoLayout/EdgesConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/EdgesConstrainableProxyTestCase.swift
@@ -104,7 +104,7 @@ final class EdgesConstrainableProxyTestCase: XCTestCase {
         XCTAssertEdgesConstraints(constraints0, expectedConstraints(view: view, to: host, active: false))
         XCTAssertEdgesConstraints(
             constraints1,
-            expectedConstraints(view: view, to: host, active: false, constants: insets)
+            expectedConstraints(view: view, to: host, constants: insets, active: false)
         )
 
         constraintGroup0.isActive = true
@@ -196,8 +196,8 @@ private extension EdgesConstrainableProxyTestCase {
         to host: UIView,
         relation: NSLayoutConstraint.Relation = .equal,
         priority: UILayoutPriority = .required,
-        active: Bool = true,
-        constants: UIEdgeInsets = .zero
+        constants: UIEdgeInsets = .zero,
+        active: Bool = true
     ) -> [NSLayoutConstraint] {
 
         return [

--- a/Tests/AlicerceTests/AutoLayout/EdgesConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/EdgesConstrainableProxyTestCase.swift
@@ -33,54 +33,7 @@ final class EdgesConstrainableProxyTestCase: XCTestCase {
             constraints = view.edges(to: host)
         }
 
-        let expected = [
-            NSLayoutConstraint(
-                item: view!,
-                attribute: .top,
-                relatedBy: .equal,
-                toItem: host,
-                attribute: .top,
-                multiplier: 1,
-                constant: 0,
-                priority: .required,
-                active: true
-            ),
-            NSLayoutConstraint(
-                item: view!,
-                attribute: .leading,
-                relatedBy: .equal,
-                toItem: host,
-                attribute: .leading,
-                multiplier: 1,
-                constant: 0,
-                priority: .required,
-                active: true
-            ),
-            NSLayoutConstraint(
-                item: view!,
-                attribute: .bottom,
-                relatedBy: .equal,
-                toItem: host,
-                attribute: .bottom,
-                multiplier: 1,
-                constant: 0,
-                priority: .required,
-                active: true
-            ),
-            NSLayoutConstraint(
-                item: view!,
-                attribute: .trailing,
-                relatedBy: .equal,
-                toItem: host,
-                attribute: .trailing,
-                multiplier: 1,
-                constant: 0,
-                priority: .required,
-                active: true
-            )
-        ]
-
-        XCTAssertEdgesConstraints(constraints, expected)
+        XCTAssertEdgesConstraints(constraints, expectedConstraints(view: view, to: host))
 
         host.layoutIfNeeded()
 
@@ -96,103 +49,11 @@ final class EdgesConstrainableProxyTestCase: XCTestCase {
             constraints2 = view.edges(to: host, relation: .equalOrGreater)
         }
 
-        let expected1 = [
-            NSLayoutConstraint(
-                item: view!,
-                attribute: .top,
-                relatedBy: .lessThanOrEqual,
-                toItem: host,
-                attribute: .top,
-                multiplier: 1,
-                constant: 0,
-                priority: .required,
-                active: true
-            ),
-            NSLayoutConstraint(
-                item: view!,
-                attribute: .leading,
-                relatedBy: .lessThanOrEqual,
-                toItem: host,
-                attribute: .leading,
-                multiplier: 1,
-                constant: 0,
-                priority: .required,
-                active: true
-            ),
-            NSLayoutConstraint(
-                item: view!,
-                attribute: .bottom,
-                relatedBy: .lessThanOrEqual,
-                toItem: host,
-                attribute: .bottom,
-                multiplier: 1,
-                constant: 0,
-                priority: .required,
-                active: true
-            ),
-            NSLayoutConstraint(
-                item: view!,
-                attribute: .trailing,
-                relatedBy: .lessThanOrEqual,
-                toItem: host,
-                attribute: .trailing,
-                multiplier: 1,
-                constant: 0,
-                priority: .required,
-                active: true
-            )
-        ]
-
-        XCTAssertEdgesConstraints(constraints1, expected1)
-
-        let expected2 = [
-            NSLayoutConstraint(
-                item: view!,
-                attribute: .top,
-                relatedBy: .greaterThanOrEqual,
-                toItem: host,
-                attribute: .top,
-                multiplier: 1,
-                constant: 0,
-                priority: .required,
-                active: true
-            ),
-            NSLayoutConstraint(
-                item: view!,
-                attribute: .leading,
-                relatedBy: .greaterThanOrEqual,
-                toItem: host,
-                attribute: .leading,
-                multiplier: 1,
-                constant: 0,
-                priority: .required,
-                active: true
-            ),
-            NSLayoutConstraint(
-                item: view!,
-                attribute: .bottom,
-                relatedBy: .greaterThanOrEqual,
-                toItem: host,
-                attribute: .bottom,
-                multiplier: 1,
-                constant: 0,
-                priority: .required,
-                active: true
-            ),
-            NSLayoutConstraint(
-                item: view!,
-                attribute: .trailing,
-                relatedBy: .greaterThanOrEqual,
-                toItem: host,
-                attribute: .trailing,
-                multiplier: 1,
-                constant: 0,
-                priority: .required,
-                active: true
-            )
-        ]
-
-        XCTAssertEdgesConstraints(constraints2, expected2)
+        XCTAssertEdgesConstraints(constraints1, expectedConstraints(view: view, to: host, relation: .lessThanOrEqual))
+        XCTAssertEdgesConstraints(
+            constraints2,
+            expectedConstraints(view: view, to: host, relation: .greaterThanOrEqual)
+        )
 
         host.layoutIfNeeded()
 
@@ -208,54 +69,7 @@ final class EdgesConstrainableProxyTestCase: XCTestCase {
             constraints = view.edges(to: host, insets: insets)
         }
 
-        let expected = [
-            NSLayoutConstraint(
-                item: view!,
-                attribute: .top,
-                relatedBy: .equal,
-                toItem: host,
-                attribute: .top,
-                multiplier: 1,
-                constant: 10,
-                priority: .required,
-                active: true
-            ),
-            NSLayoutConstraint(
-                item: view!,
-                attribute: .leading,
-                relatedBy: .equal,
-                toItem: host,
-                attribute: .leading,
-                multiplier: 1,
-                constant: 20,
-                priority: .required,
-                active: true
-            ),
-            NSLayoutConstraint(
-                item: view!,
-                attribute: .bottom,
-                relatedBy: .equal,
-                toItem: host,
-                attribute: .bottom,
-                multiplier: 1,
-                constant: -30,
-                priority: .required,
-                active: true
-            ),
-            NSLayoutConstraint(
-                item: view!,
-                attribute: .trailing,
-                relatedBy: .equal,
-                toItem: host,
-                attribute: .trailing,
-                multiplier: 1,
-                constant: -40,
-                priority: .required,
-                active: true
-            )
-        ]
-
-        XCTAssertEdgesConstraints(constraints, expected)
+        XCTAssertEdgesConstraints(constraints, expectedConstraints(view: view, to: host, constants: insets))
 
         host.layoutIfNeeded()
 
@@ -269,54 +83,47 @@ final class EdgesConstrainableProxyTestCase: XCTestCase {
             constraints = view.edges(to: host, priority: .init(666))
         }
 
-        let expected = [
-            NSLayoutConstraint(
-                item: view!,
-                attribute: .top,
-                relatedBy: .equal,
-                toItem: host,
-                attribute: .top,
-                multiplier: 1,
-                constant: 0,
-                priority: .init(666),
-                active: true
-            ),
-            NSLayoutConstraint(
-                item: view!,
-                attribute: .leading,
-                relatedBy: .equal,
-                toItem: host,
-                attribute: .leading,
-                multiplier: 1,
-                constant: 0,
-                priority: .init(666),
-                active: true
-            ),
-            NSLayoutConstraint(
-                item: view!,
-                attribute: .bottom,
-                relatedBy: .equal,
-                toItem: host,
-                attribute: .bottom,
-                multiplier: 1,
-                constant: 0,
-                priority: .init(666),
-                active: true
-            ),
-            NSLayoutConstraint(
-                item: view!,
-                attribute: .trailing,
-                relatedBy: .equal,
-                toItem: host,
-                attribute: .trailing,
-                multiplier: 1,
-                constant: 0,
-                priority: .init(666),
-                active: true
-            )
-        ]
+        XCTAssertEdgesConstraints(constraints, expectedConstraints(view: view, to: host, priority: .init(666)))
+    }
 
-        XCTAssertEdgesConstraints(constraints, expected)
+    func testConstrain_WithEdgesConstraintsAndTwoConstraintGroups_ShouldReturnCorrectIsActiveConstraint() {
+
+        var constraints0: [NSLayoutConstraint]!
+        var constraints1: [NSLayoutConstraint]!
+
+        let insets = UIEdgeInsets(top: 100, left: 100, bottom: 100, right: 100)
+
+        let constraintGroup0 = constrain(host, view, activate: false) { host, view in
+            constraints0 = view.edges(to: host)
+        }
+
+        let constraintGroup1 = constrain(host, view, activate: false) { host, view in
+            constraints1 = view.edges(to: host, insets: insets)
+        }
+
+        XCTAssertEdgesConstraints(constraints0, expectedConstraints(view: view, to: host, active: false))
+        XCTAssertEdgesConstraints(
+            constraints1,
+            expectedConstraints(view: view, to: host, active: false, constants: insets)
+        )
+
+        constraintGroup0.isActive = true
+
+        host.layoutIfNeeded()
+
+        XCTAssert(constraintGroup0.isActive)
+        XCTAssertFalse(constraintGroup1.isActive)
+        XCTAssertEqual(view.frame, host.frame)
+
+        constraintGroup0.isActive = false
+        constraintGroup1.isActive = true
+
+        host.setNeedsLayout()
+        host.layoutIfNeeded()
+
+        XCTAssertFalse(constraintGroup0.isActive)
+        XCTAssert(constraintGroup1.isActive)
+        XCTAssertEqual(view.frame, host.frame.inset(by: insets))
     }
 }
 
@@ -378,4 +185,66 @@ private func extract(
     }
 
     return (left, right)
+}
+
+// MARK: - Extensions
+
+private extension EdgesConstrainableProxyTestCase {
+
+    private func expectedConstraints(
+        view: UIView,
+        to host: UIView,
+        relation: NSLayoutConstraint.Relation = .equal,
+        priority: UILayoutPriority = .required,
+        active: Bool = true,
+        constants: UIEdgeInsets = .zero
+    ) -> [NSLayoutConstraint] {
+
+        return [
+            NSLayoutConstraint(
+                item: view,
+                attribute: .top,
+                relatedBy: relation,
+                toItem: host,
+                attribute: .top,
+                multiplier: 1,
+                constant: constants.top,
+                priority: priority,
+                active: active
+            ),
+            NSLayoutConstraint(
+                item: view,
+                attribute: .leading,
+                relatedBy: relation,
+                toItem: host,
+                attribute: .leading,
+                multiplier: 1,
+                constant: constants.left,
+                priority: priority,
+                active: active
+            ),
+            NSLayoutConstraint(
+                item: view,
+                attribute: .bottom,
+                relatedBy: relation,
+                toItem: host,
+                attribute: .bottom,
+                multiplier: 1,
+                constant: -constants.bottom,
+                priority: priority,
+                active: active
+            ),
+            NSLayoutConstraint(
+                item: view,
+                attribute: .trailing,
+                relatedBy: relation,
+                toItem: host,
+                attribute: .trailing,
+                multiplier: 1,
+                constant: -constants.right,
+                priority: priority,
+                active: active
+            )
+        ]
+    }
 }

--- a/Tests/AlicerceTests/AutoLayout/FirstBaselineConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/FirstBaselineConstrainableProxyTestCase.swift
@@ -76,4 +76,63 @@ final class FirstBaselineConstrainableProxyTestCase: BaseConstrainableProxyTestC
 
         XCTAssertConstraint(constraint, expected)
     }
+
+    func testConstrain_WithFirstBaselineConstraintAndTwoConstraintGroups_ShouldReturnCorrectIsActiveConstraint() {
+
+        var constraint0: NSLayoutConstraint!
+        var constraint1: NSLayoutConstraint!
+
+        let constraintGroup0 = constrain(host, view0, activate: false) { host, view0 in
+            constraint0 = view0.firstBaseline(to: host)
+        }
+
+        let constraintGroup1 = constrain(host, view0, activate: false) { host, view0 in
+            constraint1 = view0.firstBaseline(to: host, offset: 100)
+        }
+
+        let expected = [
+            NSLayoutConstraint(
+                item: view0!,
+                attribute: .firstBaseline,
+                relatedBy: .equal,
+                toItem: host,
+                attribute: .firstBaseline,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: false
+            ),
+            NSLayoutConstraint(
+                item: view0!,
+                attribute: .firstBaseline,
+                relatedBy: .equal,
+                toItem: host,
+                attribute: .firstBaseline,
+                multiplier: 1,
+                constant: 100,
+                priority: .required,
+                active: false
+            )
+        ]
+
+        XCTAssertConstraints([constraint0, constraint1], expected)
+
+        constraintGroup0.isActive = true
+
+        host.layoutIfNeeded()
+
+        XCTAssert(constraintGroup0.isActive)
+        XCTAssertFalse(constraintGroup1.isActive)
+        XCTAssertEqual(view0.frame.minY, host.frame.minY)
+
+        constraintGroup0.isActive = false
+        constraintGroup1.isActive = true
+
+        host.setNeedsLayout()
+        host.layoutIfNeeded()
+
+        XCTAssertFalse(constraintGroup0.isActive)
+        XCTAssert(constraintGroup1.isActive)
+        XCTAssertEqual(view0.frame.minY, host.frame.minY + 100)
+    }
 }

--- a/Tests/AlicerceTests/AutoLayout/HeightConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/HeightConstrainableProxyTestCase.swift
@@ -266,11 +266,48 @@ class HeightConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         XCTAssertConstraints(constraints, [])
     }
+
+    func testConstrain_WithHeightConstraintAndTwoConstraintGroups_ShouldReturnCorrectIsActiveConstraint() {
+
+        let constraintGroup0 = constrain(view0, activate: false) { view0 in
+            constraint0 = view0.height(Constants.height0)
+        }
+
+        let constraintGroup1 = constrain(view0, activate: false) { view0 in
+            constraint1 = view0.height(Constants.height1)
+        }
+
+        XCTAssertConstraints(
+            [constraint0, constraint1],
+            [
+                expectedConstraint(view: view0, height: Constants.height0, active: false),
+                expectedConstraint(view: view0, height: Constants.height1, active: false)
+            ]
+        )
+
+        constraintGroup0.isActive = true
+
+        host.layoutIfNeeded()
+
+        XCTAssert(constraintGroup0.isActive)
+        XCTAssertFalse(constraintGroup1.isActive)
+        XCTAssertEqual(view0.frame.height, Constants.height0)
+
+        constraintGroup0.isActive = false
+        constraintGroup1.isActive = true
+
+        host.setNeedsLayout()
+        host.layoutIfNeeded()
+
+        XCTAssertFalse(constraintGroup0.isActive)
+        XCTAssert(constraintGroup1.isActive)
+        XCTAssertEqual(view0.frame.height, Constants.height1)
+    }
 }
 
 private extension HeightConstrainableProxyTestCase {
 
-    func expectedConstraint(view: UIView, height: CGFloat) -> NSLayoutConstraint {
+    func expectedConstraint(view: UIView, height: CGFloat, active: Bool = true) -> NSLayoutConstraint {
 
         NSLayoutConstraint(
             item: view,
@@ -281,7 +318,7 @@ private extension HeightConstrainableProxyTestCase {
             multiplier: 1,
             constant: height,
             priority: .required,
-            active: true
+            active: active
         )
     }
 

--- a/Tests/AlicerceTests/AutoLayout/LastBaselineConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/LastBaselineConstrainableProxyTestCase.swift
@@ -76,4 +76,63 @@ final class LastBaselineConstrainableProxyTestCase: BaseConstrainableProxyTestCa
 
         XCTAssertConstraint(constraint, expected)
     }
+
+    func testConstrain_WithLastBaselineConstraintAndTwoConstraintGroups_ShouldReturnCorrectIsActiveConstraint() {
+
+        var constraint0: NSLayoutConstraint!
+        var constraint1: NSLayoutConstraint!
+
+        let constraintGroup0 = constrain(host, view0, activate: false) { host, view0 in
+            constraint0 = view0.lastBaseline(to: host)
+        }
+
+        let constraintGroup1 = constrain(host, view0, activate: false) { host, view0 in
+            constraint1 = view0.lastBaseline(to: host, offset: -100)
+        }
+
+        let expected = [
+            NSLayoutConstraint(
+                item: view0!,
+                attribute: .lastBaseline,
+                relatedBy: .equal,
+                toItem: host,
+                attribute: .lastBaseline,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: false
+            ),
+            NSLayoutConstraint(
+                item: view0!,
+                attribute: .lastBaseline,
+                relatedBy: .equal,
+                toItem: host,
+                attribute: .lastBaseline,
+                multiplier: 1,
+                constant: -100,
+                priority: .required,
+                active: false
+            )
+        ]
+
+        XCTAssertConstraints([constraint0, constraint1], expected)
+
+        constraintGroup0.isActive = true
+
+        host.layoutIfNeeded()
+
+        XCTAssert(constraintGroup0.isActive)
+        XCTAssertFalse(constraintGroup1.isActive)
+        XCTAssertEqual(view0.frame.maxY, host.frame.maxY)
+
+        constraintGroup0.isActive = false
+        constraintGroup1.isActive = true
+
+        host.setNeedsLayout()
+        host.layoutIfNeeded()
+
+        XCTAssertFalse(constraintGroup0.isActive)
+        XCTAssert(constraintGroup1.isActive)
+        XCTAssertEqual(view0.frame.maxY, host.frame.maxY - 100)
+    }
 }

--- a/Tests/AlicerceTests/AutoLayout/LeadingConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/LeadingConstrainableProxyTestCase.swift
@@ -280,4 +280,63 @@ final class LeadingConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
         XCTAssertEqual(view0.frame.minX, view1.frame.minX)
         XCTAssertEqual(view0.frame.minX, view2.frame.minX)
     }
+
+    func testConstrain_WithLeadingConstraintAndTwoConstraintGroups_ShouldReturnCorrectIsActiveConstraint() {
+
+        var constraint0: NSLayoutConstraint!
+        var constraint1: NSLayoutConstraint!
+
+        let constraintGroup0 = constrain(host, view0, activate: false) { host, view0 in
+            constraint0 = view0.leading(to: host)
+        }
+
+        let constraintGroup1 = constrain(host, view0, activate: false) { host, view0 in
+            constraint1 = view0.leading(to: host, offset: 100)
+        }
+
+        let expected = [
+            NSLayoutConstraint(
+                item: view0!,
+                attribute: .leading,
+                relatedBy: .equal,
+                toItem: host,
+                attribute: .leading,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: false
+            ),
+            NSLayoutConstraint(
+                item: view0!,
+                attribute: .leading,
+                relatedBy: .equal,
+                toItem: host,
+                attribute: .leading,
+                multiplier: 1,
+                constant: 100,
+                priority: .required,
+                active: false
+            )
+        ]
+
+        XCTAssertConstraints([constraint0, constraint1], expected)
+
+        constraintGroup0.isActive = true
+
+        host.layoutIfNeeded()
+
+        XCTAssert(constraintGroup0.isActive)
+        XCTAssertFalse(constraintGroup1.isActive)
+        XCTAssertEqual(view0.frame.minX, host.frame.minX)
+
+        constraintGroup0.isActive = false
+        constraintGroup1.isActive = true
+
+        host.setNeedsLayout()
+        host.layoutIfNeeded()
+
+        XCTAssertFalse(constraintGroup0.isActive)
+        XCTAssert(constraintGroup1.isActive)
+        XCTAssertEqual(view0.frame.minX, host.frame.minX + 100)
+    }
 }

--- a/Tests/AlicerceTests/AutoLayout/LeadingTrailingConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/LeadingTrailingConstrainableProxyTestCase.swift
@@ -64,4 +64,94 @@ final class LeadingTrailingConstrainableProxyTestCase: BaseConstrainableProxyTes
 
         XCTAssertConstraints(constraints, [])
     }
+
+    func testConstrain_WithDistributeHorizontallyConstraintAndTwoConstraintGroups_ShouldReturnCorrectIsActiveConstraint(
+    ) {
+
+        var constraints0: [NSLayoutConstraint]!
+        var constraints1: [NSLayoutConstraint]!
+
+        let constraintGroup0 = constrain(host, view0, view1, view2, activate: false) { host, view0, view1, view2 in
+            view0.leading(to: host, offset: 50)
+            constraints0 = [view0, view1, view2].distributeHorizontally()
+        }
+
+        let constraintGroup1 = constrain(host, view0, view1, view2, activate: false) { host, view0, view1, view2 in
+            view0.leading(to: host, offset: 50)
+            constraints1 = [view0, view1, view2].distributeHorizontally(margin: 20)
+        }
+
+        let expected0 = [
+            NSLayoutConstraint(
+                item: view1!,
+                attribute: .leading,
+                relatedBy: .equal,
+                toItem: view0,
+                attribute: .trailing,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: false
+            ),
+            NSLayoutConstraint(
+                item: view2!,
+                attribute: .leading,
+                relatedBy: .equal,
+                toItem: view1,
+                attribute: .trailing,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: false
+            )
+        ]
+
+        let expected1 = [
+            NSLayoutConstraint(
+                item: view1!,
+                attribute: .leading,
+                relatedBy: .equal,
+                toItem: view0,
+                attribute: .trailing,
+                multiplier: 1,
+                constant: 20,
+                priority: .required,
+                active: false
+            ),
+            NSLayoutConstraint(
+                item: view2!,
+                attribute: .leading,
+                relatedBy: .equal,
+                toItem: view1,
+                attribute: .trailing,
+                multiplier: 1,
+                constant: 20,
+                priority: .required,
+                active: false
+            )
+        ]
+
+        XCTAssertConstraints(constraints0, expected0)
+        XCTAssertConstraints(constraints1, expected1)
+
+        constraintGroup0.isActive = true
+
+        host.layoutIfNeeded()
+
+        XCTAssert(constraintGroup0.isActive)
+        XCTAssertFalse(constraintGroup1.isActive)
+        XCTAssertEqual(view0.frame.maxX, view1.frame.minX)
+        XCTAssertEqual(view1.frame.maxX, view2.frame.minX)
+
+        constraintGroup0.isActive = false
+        constraintGroup1.isActive = true
+
+        host.setNeedsLayout()
+        host.layoutIfNeeded()
+
+        XCTAssertFalse(constraintGroup0.isActive)
+        XCTAssert(constraintGroup1.isActive)
+        XCTAssertEqual(view0.frame.maxX + 20, view1.frame.minX)
+        XCTAssertEqual(view1.frame.maxX + 20, view2.frame.minX)
+    }
 }

--- a/Tests/AlicerceTests/AutoLayout/LeftConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/LeftConstrainableProxyTestCase.swift
@@ -204,4 +204,63 @@ final class LeftConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         XCTAssertEqual(layoutGuide.layoutFrame.minX, host.frame.minX)
     }
+
+    func testConstrain_WithLeftConstraintAndTwoConstraintGroups_ShouldReturnCorrectIsActiveConstraint() {
+
+        var constraint0: NSLayoutConstraint!
+        var constraint1: NSLayoutConstraint!
+
+        let constraintGroup0 = constrain(host, view0, activate: false) { host, view0 in
+            constraint0 = view0.left(to: host)
+        }
+
+        let constraintGroup1 = constrain(host, view0, activate: false) { host, view0 in
+            constraint1 = view0.left(to: host, offset: 100)
+        }
+
+        let expected = [
+            NSLayoutConstraint(
+                item: view0!,
+                attribute: .left,
+                relatedBy: .equal,
+                toItem: host,
+                attribute: .left,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: false
+            ),
+            NSLayoutConstraint(
+                item: view0!,
+                attribute: .left,
+                relatedBy: .equal,
+                toItem: host,
+                attribute: .left,
+                multiplier: 1,
+                constant: 100,
+                priority: .required,
+                active: false
+            )
+        ]
+
+        XCTAssertConstraints([constraint0, constraint1], expected)
+
+        constraintGroup0.isActive = true
+
+        host.layoutIfNeeded()
+
+        XCTAssert(constraintGroup0.isActive)
+        XCTAssertFalse(constraintGroup1.isActive)
+        XCTAssertEqual(view0.frame.minX, host.frame.minX)
+
+        constraintGroup0.isActive = false
+        constraintGroup1.isActive = true
+
+        host.setNeedsLayout()
+        host.layoutIfNeeded()
+
+        XCTAssertFalse(constraintGroup0.isActive)
+        XCTAssert(constraintGroup1.isActive)
+        XCTAssertEqual(view0.frame.minX, host.frame.minX + 100)
+    }
 }

--- a/Tests/AlicerceTests/AutoLayout/RightConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/RightConstrainableProxyTestCase.swift
@@ -204,4 +204,63 @@ final class RightConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         XCTAssertEqual(layoutGuide.layoutFrame.maxX, host.frame.maxX)
     }
+
+    func testConstrain_WithRightConstraintAndTwoConstraintGroups_ShouldReturnCorrectIsActiveConstraint() {
+
+        var constraint0: NSLayoutConstraint!
+        var constraint1: NSLayoutConstraint!
+
+        let constraintGroup0 = constrain(host, view0, activate: false) { host, view0 in
+            constraint0 = view0.right(to: host)
+        }
+
+        let constraintGroup1 = constrain(host, view0, activate: false) { host, view0 in
+            constraint1 = view0.right(to: host, offset: -100)
+        }
+
+        let expected = [
+            NSLayoutConstraint(
+                item: view0!,
+                attribute: .right,
+                relatedBy: .equal,
+                toItem: host,
+                attribute: .right,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: false
+            ),
+            NSLayoutConstraint(
+                item: view0!,
+                attribute: .right,
+                relatedBy: .equal,
+                toItem: host,
+                attribute: .right,
+                multiplier: 1,
+                constant: -100,
+                priority: .required,
+                active: false
+            )
+        ]
+
+        XCTAssertConstraints([constraint0, constraint1], expected)
+
+        constraintGroup0.isActive = true
+
+        host.layoutIfNeeded()
+
+        XCTAssert(constraintGroup0.isActive)
+        XCTAssertFalse(constraintGroup1.isActive)
+        XCTAssertEqual(view0.frame.maxX, host.frame.maxX)
+
+        constraintGroup0.isActive = false
+        constraintGroup1.isActive = true
+
+        host.setNeedsLayout()
+        host.layoutIfNeeded()
+
+        XCTAssertFalse(constraintGroup0.isActive)
+        XCTAssert(constraintGroup1.isActive)
+        XCTAssertEqual(view0.frame.maxX, host.frame.maxX - 100)
+    }
 }

--- a/Tests/AlicerceTests/AutoLayout/SizeConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/SizeConstrainableProxyTestCase.swift
@@ -157,11 +157,43 @@ class SizeConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         XCTAssertEqual(view0.frame.size, host.frame.size)
     }
+
+    func testConstrain_WithSizeConstraintAndTwoConstraintGroups_ShouldReturnCorrectIsActiveValue() {
+
+        let constraintGroup0 = constrain(view0, activate: false) { view0 in
+            constraints0 = view0.size(Constants.size0)
+        }
+
+        let constraintGroup1 = constrain(view0, activate: false) { view0 in
+            constraints1 = view0.size(Constants.size1)
+        }
+
+        XCTAssertConstraints(constraints0, expectedConstraints(view: view0, size: Constants.size0, active: false))
+        XCTAssertConstraints(constraints1, expectedConstraints(view: view0, size: Constants.size1, active: false))
+
+        constraintGroup0.isActive = true
+
+        host.layoutIfNeeded()
+
+        XCTAssert(constraintGroup0.isActive)
+        XCTAssertFalse(constraintGroup1.isActive)
+        XCTAssertEqual(view0.frame.size, Constants.size0)
+
+        constraintGroup0.isActive = false
+        constraintGroup1.isActive = true
+
+        host.setNeedsLayout()
+        host.layoutIfNeeded()
+
+        XCTAssertFalse(constraintGroup0.isActive)
+        XCTAssert(constraintGroup1.isActive)
+        XCTAssertEqual(view0.frame.size, Constants.size1)
+    }
 }
 
 private extension SizeConstrainableProxyTestCase {
 
-    private func expectedConstraints(view: UIView, size: CGSize) -> [NSLayoutConstraint] {
+    private func expectedConstraints(view: UIView, size: CGSize, active: Bool = true) -> [NSLayoutConstraint] {
 
         let width = NSLayoutConstraint(
             item: view,
@@ -172,7 +204,7 @@ private extension SizeConstrainableProxyTestCase {
             multiplier: 1,
             constant: size.width,
             priority: .required,
-            active: true
+            active: active
         )
 
         let height = NSLayoutConstraint(
@@ -184,7 +216,7 @@ private extension SizeConstrainableProxyTestCase {
             multiplier: 1,
             constant: size.height,
             priority: .required,
-            active: true
+            active: active
         )
 
         return [width, height]

--- a/Tests/AlicerceTests/AutoLayout/TopBottomConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/TopBottomConstrainableProxyTestCase.swift
@@ -64,4 +64,94 @@ final class TopBottomConstrainableProxyTestCase: BaseConstrainableProxyTestCase 
 
         XCTAssertConstraints(constraints, [])
     }
+
+    func testConstrain_WithDistributeVerticallyConstraintAndTwoConstraintGroups_ShouldReturnCorrectIsActiveConstraint(
+    ) {
+
+        var constraints0: [NSLayoutConstraint]!
+        var constraints1: [NSLayoutConstraint]!
+
+        let constraintGroup0 = constrain(host, view0, view1, view2, activate: false) { host, view0, view1, view2 in
+            view0.leading(to: host, offset: 50)
+            constraints0 = [view0, view1, view2].distributeVertically()
+        }
+
+        let constraintGroup1 = constrain(host, view0, view1, view2, activate: false) { host, view0, view1, view2 in
+            view0.leading(to: host, offset: 50)
+            constraints1 = [view0, view1, view2].distributeVertically(margin: 20)
+        }
+
+        let expected0 = [
+            NSLayoutConstraint(
+                item: view1!,
+                attribute: .top,
+                relatedBy: .equal,
+                toItem: view0,
+                attribute: .bottom,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: false
+            ),
+            NSLayoutConstraint(
+                item: view2!,
+                attribute: .top,
+                relatedBy: .equal,
+                toItem: view1,
+                attribute: .bottom,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: false
+            )
+        ]
+
+        let expected1 = [
+            NSLayoutConstraint(
+                item: view1!,
+                attribute: .top,
+                relatedBy: .equal,
+                toItem: view0,
+                attribute: .bottom,
+                multiplier: 1,
+                constant: 20,
+                priority: .required,
+                active: false
+            ),
+            NSLayoutConstraint(
+                item: view2!,
+                attribute: .top,
+                relatedBy: .equal,
+                toItem: view1,
+                attribute: .bottom,
+                multiplier: 1,
+                constant: 20,
+                priority: .required,
+                active: false
+            )
+        ]
+
+        XCTAssertConstraints(constraints0, expected0)
+        XCTAssertConstraints(constraints1, expected1)
+
+        constraintGroup0.isActive = true
+
+        host.layoutIfNeeded()
+
+        XCTAssert(constraintGroup0.isActive)
+        XCTAssertFalse(constraintGroup1.isActive)
+        XCTAssertEqual(view0.frame.maxY, view1.frame.minY)
+        XCTAssertEqual(view1.frame.maxY, view2.frame.minY)
+
+        constraintGroup0.isActive = false
+        constraintGroup1.isActive = true
+
+        host.setNeedsLayout()
+        host.layoutIfNeeded()
+
+        XCTAssertFalse(constraintGroup0.isActive)
+        XCTAssert(constraintGroup1.isActive)
+        XCTAssertEqual(view0.frame.maxY + 20, view1.frame.minY)
+        XCTAssertEqual(view1.frame.maxY + 20, view2.frame.minY)
+    }
 }

--- a/Tests/AlicerceTests/AutoLayout/TopConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/TopConstrainableProxyTestCase.swift
@@ -290,4 +290,63 @@ final class TopConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
         XCTAssertEqual(view0.frame.minY, view1.frame.minY)
         XCTAssertEqual(view0.frame.minY, view2.frame.minY)
     }
+
+    func testConstrain_WithTopConstraintAndTwoConstraintGroups_ShouldReturnCorrectIsActiveValue() {
+
+        var constraint0: NSLayoutConstraint!
+        var constraint1: NSLayoutConstraint!
+
+        let constraintGroup0 = constrain(host, view0, activate: false) { host, view0 in
+            constraint0 = view0.top(to: host)
+        }
+
+        let constraintGroup1 = constrain(host, view0, activate: false) { host, view0 in
+            constraint1 = view0.top(to: host, offset: 100)
+        }
+
+        let expected = [
+            NSLayoutConstraint(
+                item: view0!,
+                attribute: .top,
+                relatedBy: .equal,
+                toItem: host,
+                attribute: .top,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: false
+            ),
+            NSLayoutConstraint(
+                item: view0!,
+                attribute: .top,
+                relatedBy: .equal,
+                toItem: host,
+                attribute: .top,
+                multiplier: 1,
+                constant: 100,
+                priority: .required,
+                active: false
+            )
+        ]
+
+        XCTAssertConstraints([constraint0, constraint1], expected)
+
+        constraintGroup0.isActive = true
+
+        host.layoutIfNeeded()
+
+        XCTAssert(constraintGroup0.isActive)
+        XCTAssertFalse(constraintGroup1.isActive)
+        XCTAssertEqual(view0.frame.minY, host.frame.minY)
+
+        constraintGroup0.isActive = false
+        constraintGroup1.isActive = true
+
+        host.setNeedsLayout()
+        host.layoutIfNeeded()
+
+        XCTAssertFalse(constraintGroup0.isActive)
+        XCTAssert(constraintGroup1.isActive)
+        XCTAssertEqual(view0.frame.minY, host.frame.minY + 100)
+    }
 }

--- a/Tests/AlicerceTests/AutoLayout/TrailingConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/TrailingConstrainableProxyTestCase.swift
@@ -282,4 +282,63 @@ final class TrailingConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
         XCTAssertEqual(view0.frame.maxX, view1.frame.maxX)
         XCTAssertEqual(view0.frame.maxX, view2.frame.maxX)
     }
+
+    func testConstrain_WithTrailingConstraintAndTwoConstraintGroups_ShouldReturnCorrectIsActiveConstraint() {
+
+        var constraint0: NSLayoutConstraint!
+        var constraint1: NSLayoutConstraint!
+
+        let constraintGroup0 = constrain(host, view0, activate: false) { host, view0 in
+            constraint0 = view0.trailing(to: host)
+        }
+
+        let constraintGroup1 = constrain(host, view0, activate: false) { host, view0 in
+            constraint1 = view0.trailing(to: host, offset: -50)
+        }
+
+        let expected = [
+            NSLayoutConstraint(
+                item: view0!,
+                attribute: .trailing,
+                relatedBy: .equal,
+                toItem: host,
+                attribute: .trailing,
+                multiplier: 1,
+                constant: 0,
+                priority: .required,
+                active: false
+            ),
+            NSLayoutConstraint(
+                item: view0!,
+                attribute: .trailing,
+                relatedBy: .equal,
+                toItem: host,
+                attribute: .trailing,
+                multiplier: 1,
+                constant: -50,
+                priority: .required,
+                active: false
+            )
+        ]
+
+        XCTAssertConstraints([constraint0, constraint1], expected)
+
+        constraintGroup0.isActive = true
+
+        host.layoutIfNeeded()
+
+        XCTAssert(constraintGroup0.isActive)
+        XCTAssertFalse(constraintGroup1.isActive)
+        XCTAssertEqual(view0.frame.maxX, host.frame.maxX)
+
+        constraintGroup0.isActive = false
+        constraintGroup1.isActive = true
+
+        host.setNeedsLayout()
+        host.layoutIfNeeded()
+
+        XCTAssertFalse(constraintGroup0.isActive)
+        XCTAssert(constraintGroup1.isActive)
+        XCTAssertEqual(view0.frame.maxX, host.frame.maxX - 50)
+    }
 }

--- a/Tests/AlicerceTests/AutoLayout/WidthConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/WidthConstrainableProxyTestCase.swift
@@ -238,11 +238,48 @@ class WidthConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         XCTAssertConstraints(constraints, [])
     }
+
+    func testConstrain_WithWidthConstraintAndTwoConstraintGroups_ShouldReturnCorrectIsActiveConstraint() {
+
+        let constraintGroup0 = constrain(view0, activate: false) { view0 in
+            constraint0 = view0.width(Constants.width0)
+        }
+
+        let constraintGroup1 = constrain(view0, activate: false) { view0 in
+            constraint1 = view0.width(Constants.width1)
+        }
+
+        XCTAssertConstraints(
+            [constraint0, constraint1],
+            [
+                expectedConstraint(view: view0, width: Constants.width0, active: false),
+                expectedConstraint(view: view0, width: Constants.width1, active: false)
+            ]
+        )
+
+        constraintGroup0.isActive = true
+
+        host.layoutIfNeeded()
+
+        XCTAssert(constraintGroup0.isActive)
+        XCTAssertFalse(constraintGroup1.isActive)
+        XCTAssertEqual(view0.frame.width, Constants.width0)
+
+        constraintGroup0.isActive = false
+        constraintGroup1.isActive = true
+
+        host.setNeedsLayout()
+        host.layoutIfNeeded()
+
+        XCTAssertFalse(constraintGroup0.isActive)
+        XCTAssert(constraintGroup1.isActive)
+        XCTAssertEqual(view0.frame.width, Constants.width1)
+    }
 }
 
 private extension WidthConstrainableProxyTestCase {
 
-    func expectedConstraint(view: UIView, width: CGFloat) -> NSLayoutConstraint {
+    func expectedConstraint(view: UIView, width: CGFloat, active: Bool = true) -> NSLayoutConstraint {
 
         NSLayoutConstraint(
             item: view,
@@ -253,7 +290,7 @@ private extension WidthConstrainableProxyTestCase {
             multiplier: 1,
             constant: width,
             priority: .required,
-            active: true
+            active: active
         )
     }
 


### PR DESCRIPTION
### Checklist
- [x] I've rebased my changes on top of `master`
- [x] I've built and run the project to see all new and existing tests pass
- [x] I've followed the [Mindera swift style guide](https://github.com/Mindera/swift-style-guide)
- [x] I've read the [Contribution Guidelines](https://github.com/Mindera/Alicerce/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
The current constrain API didn't give us enough flexibility to work with various constraint groups for a view, as all constraints were activated after being set, which if we want something from some model layer to define which group is active, you'd to go though activation and deactivation which ampers performance.

### Description

- Simplified constrain API by removing constrain params from install and uninstall methods, as the ones being passed were those of local scope

- Added is active flag on constrain functions to enable if a group is active or not
