### PR TITLE
Add `inout` variant of `groupedReduce`

### DIFF
--- a/Sources/Extensions/Foundation/Sequence.swift
+++ b/Sources/Extensions/Foundation/Sequence.swift
@@ -14,14 +14,47 @@ public extension Sequence {
     ///   - combine: a closure that combines the accumulating value of a group and produces a new accumulating value.
     ///   - groupBy: a closure that produces a key for each element in the sequence.
     /// - Returns: a dictionary containing the final accumulated values for each produced key.
-    func groupedReduce<K: Hashable, U>(initial: U,
-                                       combine: (U, Iterator.Element) throws -> U,
-                                       groupBy: (Iterator.Element) throws -> K) rethrows -> [K : U] {
+    func groupedReduce<K: Hashable, U>(
+        initial: U,
+        combine: (U, Iterator.Element) throws -> U,
+        groupBy: (Iterator.Element) throws -> K
+    ) rethrows -> [K : U] {
+
         var result: [K : U] = [:]
 
         for element in self {
             let key = try groupBy(element)
             result[key] = try combine(result[key] ?? initial, element)
+        }
+
+        return result
+    }
+
+    /// Returns the result of combining the elements of the sequence using the given combining closure, grouped by keys
+    /// generated using the a grouping closure. The result is a dictionary of type `[K : U]`. An initial value should
+    /// be given to be used as initial accumulating value in each group.
+    ///
+    /// This method is preferred over `groupedReduce(initial:combine:groupBy:)` for efficiency when the group `U` is a
+    /// copy-on-write type, for example an Array or a Dictionary.
+    ///
+    /// - Parameters:
+    ///   - initial: a value to be used as the initial accumulating value in each group.
+    ///   - combine: a closure that combines the accumulating value of a group and produces a new accumulating value.
+    ///   - groupBy: a closure that produces a key for each element in the sequence.
+    /// - Returns: a dictionary containing the final accumulated values for each produced key.
+    func groupedReduce<K: Hashable, U>(
+        into initial: U,
+        combine: (inout U, Iterator.Element) throws -> Void,
+        groupBy: (Iterator.Element) throws -> K
+    ) rethrows -> [K : U] {
+
+        var result: [K : U] = [:]
+
+        for element in self {
+            let key = try groupBy(element)
+            var group = result[key] ?? initial
+            try combine(&group, element)
+            result[key] = group
         }
 
         return result

--- a/Tests/AlicerceTests/Extensions/Foundation/SequenceTests.swift
+++ b/Tests/AlicerceTests/Extensions/Foundation/SequenceTests.swift
@@ -40,4 +40,40 @@ class SequenceTests: XCTestCase {
 
         XCTAssertEqual(groupedSeq, ["a".utf8.first! : 3, "b".utf8.first! : 2, "c".utf8.first! : 1, "d".utf8.first! : 1])
     }
+
+    func testGroupedReduceInto_WithNonEmptySequenceAndSameKeyType_ShouldReturnGroupedDictionary() {
+
+        let seq = ["a", "a", "a", "b", "b", "c", "d"]
+
+        let sumCombine: (inout Int, String) -> Void = { acc, element in acc += 1 }
+        let stringKey: (String) -> String = { $0 }
+
+        let groupedSeq: [String : Int] = seq.groupedReduce(into: 0, combine: sumCombine, groupBy: stringKey)
+
+        XCTAssertEqual(groupedSeq, ["a" : 3, "b" : 2, "c" : 1, "d" : 1])
+    }
+
+    func testGroupedReduceInto_WithEmptySequence_ShouldReturnEmptyDictionary() {
+
+        let seq: [String] = []
+
+        let sumCombine: (inout Int, String) -> Void = { acc, element in acc += 1 }
+        let stringKey: (String) -> String = { $0 }
+
+        let groupedSeq: [String : Int] = seq.groupedReduce(into: 0, combine: sumCombine, groupBy: stringKey)
+
+        XCTAssertEqual(groupedSeq, [:])
+    }
+
+    func testGroupedReduceInto_WithNonEmptySequenceAndDifferentKeyType_ShouldReturnGroupedDictionary() {
+
+        let seq = ["a", "a", "a", "b", "b", "c", "d"]
+
+        let sumCombine: (inout Int, String) -> Void = { acc, element in acc += 1 }
+        let utf8Key: (String) -> UTF8Char = { $0.utf8.first! }
+
+        let groupedSeq: [UTF8Char : Int] = seq.groupedReduce(into: 0, combine: sumCombine, groupBy: utf8Key)
+
+        XCTAssertEqual(groupedSeq, ["a".utf8.first! : 3, "b".utf8.first! : 2, "c".utf8.first! : 1, "d".utf8.first! : 1])
+    }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _Alicerce 🏗_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've rebased my changes on top of `master`
- [x] I've built and run the project to see all new and existing tests pass
- [x] I've followed the [Mindera swift style guide](https://github.com/Mindera/swift-style-guide)
- [x] I've read the [Contribution Guidelines](https://github.com/Mindera/Alicerce/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Similar to the stdlib's `reduce`, the `groupedReduce` can provide an
`inout` variant for improved efficiency when the group type has
copy-on-write semantics (like `Array` or `Dictionary`).

### Description
- Create new `groupedReduce(into:combine:groupBy)` variant with an
`inout` combine closure.
