### PR TITLE
Make url scheme and host match and register case insensitive

### DIFF
--- a/Sources/DeepLinking/Route+TrieRouter.swift
+++ b/Sources/DeepLinking/Route+TrieRouter.swift
@@ -178,6 +178,7 @@ extension Route {
         private func parseAnnotatedRoute(_ route: URL) throws -> [Route.Component] {
 
             // use a wildcard for empty schemes/hosts, to match any scheme/host
+            // URL scheme and host comparison should be case insensitive in conformance to RFC-3986
             let schemeComponent = (route.scheme?.lowercased()).constantOrWildcardComponent
             let hostComponent = (route.host?.lowercased()).constantOrWildcardComponent
 
@@ -204,6 +205,7 @@ extension Route {
         private func parseMatchRoute(_ route: URL) throws -> MatchRoute {
 
             // use an empty string for empty scheme/host, to match wildcard scheme/host
+            // URL scheme and host comparison should be case insensitive in conformance to RFC-3986
             let schemeComponent = route.scheme?.lowercased() ?? ""
             let hostComponent = route.host?.lowercased() ?? ""
             let pathComponents = route.pathComponents.filter { $0 != "/" }

--- a/Sources/DeepLinking/Route+TrieRouter.swift
+++ b/Sources/DeepLinking/Route+TrieRouter.swift
@@ -178,8 +178,8 @@ extension Route {
         private func parseAnnotatedRoute(_ route: URL) throws -> [Route.Component] {
 
             // use a wildcard for empty schemes/hosts, to match any scheme/host
-            let schemeComponent = route.scheme.constantOrWildcardComponent
-            let hostComponent = route.host.constantOrWildcardComponent
+            let schemeComponent = (route.scheme?.lowercased()).constantOrWildcardComponent
+            let hostComponent = (route.host?.lowercased()).constantOrWildcardComponent
 
             do {
                 let pathComponents = try route.pathComponents.filter { $0 != "/" }.map(Route.Component.init(component:))
@@ -204,8 +204,8 @@ extension Route {
         private func parseMatchRoute(_ route: URL) throws -> MatchRoute {
 
             // use an empty string for empty scheme/host, to match wildcard scheme/host
-            let schemeComponent = route.scheme ?? ""
-            let hostComponent = route.host ?? ""
+            let schemeComponent = route.scheme?.lowercased() ?? ""
+            let hostComponent = route.host?.lowercased() ?? ""
             let pathComponents = route.pathComponents.filter { $0 != "/" }
 
             let routeComponents = [schemeComponent, hostComponent] + pathComponents

--- a/Tests/AlicerceTests/DeepLinking/Route+TrieRouter_DescriptionTests.swift
+++ b/Tests/AlicerceTests/DeepLinking/Route+TrieRouter_DescriptionTests.swift
@@ -57,22 +57,22 @@ class Route_TrieRouter_DescriptionTests: XCTestCase {
         XCTAssertEqual(
             router.description,
             """
-            ├──┬ schemeB
-            │  ├──┬ hostB
+            ├──┬ schemeb
+            │  ├──┬ hosta
+            │  │  └──● AnyRouteHandler<String>(P)
+            │  │
+            │  ├──┬ hostb
             │  │  └──┬ path
             │  │     ├──┬ *
             │  │     │  └──● AnyRouteHandler<String>(R)
             │  │     │
             │  │     └──● AnyRouteHandler<String>(Q)
             │  │
-            │  ├──┬ hostA
-            │  │  └──● AnyRouteHandler<String>(P)
-            │  │
             │  └──┬ *
             │     └──● AnyRouteHandler<String>(O)
             │
-            ├──┬ schemeA
-            │  ├──┬ hostC
+            ├──┬ schemea
+            │  ├──┬ hostc
             │  │  └──┬ *
             │  │     └──┬ yet
             │  │        └──┬ another

--- a/Tests/AlicerceTests/DeepLinking/Route+TrieRouter_RouteTests.swift
+++ b/Tests/AlicerceTests/DeepLinking/Route+TrieRouter_RouteTests.swift
@@ -130,14 +130,16 @@ class Route_TrieRouter_RouteTests: XCTestCase {
         XCTAssertRouteSucceeds(initial: [("/", testHandler)], route: "://")
     }
 
-    func testRoute_WithCaseInsensetiveScheme_shouldSucceed() {
+    func testRoute_WithCaseInsensitiveMatchingScheme_ShouldSucceed() {
         XCTAssertRouteSucceeds(initial: [("HTTP://", testHandler)], route: "http://")
         XCTAssertRouteSucceeds(initial: [("HTTP://host/", testHandler)], route: "http://host/")
         XCTAssertRouteSucceeds(initial: [("HTTP://host/path", testHandler)], route: "http://host/path")
+        XCTAssertRouteSucceeds(initial: [("HtTp://host/path", testHandler)], route: "http://host/path")
 
         XCTAssertRouteSucceeds(initial: [("http://", testHandler)], route: "HTTP://")
         XCTAssertRouteSucceeds(initial: [("http://host/", testHandler)], route: "HTTP://host/")
         XCTAssertRouteSucceeds(initial: [("http://host/path", testHandler)], route: "HTTP://host/path")
+        XCTAssertRouteSucceeds(initial: [("http://host/path", testHandler)], route: "httP://host/path")
     }
 
     // MARK: host
@@ -173,12 +175,14 @@ class Route_TrieRouter_RouteTests: XCTestCase {
         XCTAssertRouteSucceeds(initial: [("/", testHandler)], route: ":///")
     }
 
-    func testRoute_WithCaseInsensetiveHost_shouldSucceed() {
+    func testRoute_WithCaseInsensitiveMatchingHost_ShouldSucceed() {
         XCTAssertRouteSucceeds(initial: [("http://HOST/", testHandler)], route: "http://host/")
         XCTAssertRouteSucceeds(initial: [("http://HOST/path", testHandler)], route: "http://host/path")
+        XCTAssertRouteSucceeds(initial: [("http://HosT/path", testHandler)], route: "http://host/path")
 
         XCTAssertRouteSucceeds(initial: [("http://host/", testHandler)], route: "http://HOST/")
         XCTAssertRouteSucceeds(initial: [("http://host/path", testHandler)], route: "http://HOST/path")
+        XCTAssertRouteSucceeds(initial: [("http://host/path", testHandler)], route: "http://hOSt/path")
     }
 
     // MARK: single level path

--- a/Tests/AlicerceTests/DeepLinking/Route+TrieRouter_RouteTests.swift
+++ b/Tests/AlicerceTests/DeepLinking/Route+TrieRouter_RouteTests.swift
@@ -130,6 +130,16 @@ class Route_TrieRouter_RouteTests: XCTestCase {
         XCTAssertRouteSucceeds(initial: [("/", testHandler)], route: "://")
     }
 
+    func testRoute_WithCaseInsensetiveScheme_shouldSucceed() {
+        XCTAssertRouteSucceeds(initial: [("HTTP://", testHandler)], route: "http://")
+        XCTAssertRouteSucceeds(initial: [("HTTP://host/", testHandler)], route: "http://host/")
+        XCTAssertRouteSucceeds(initial: [("HTTP://host/path", testHandler)], route: "http://host/path")
+
+        XCTAssertRouteSucceeds(initial: [("http://", testHandler)], route: "HTTP://")
+        XCTAssertRouteSucceeds(initial: [("http://host/", testHandler)], route: "HTTP://host/")
+        XCTAssertRouteSucceeds(initial: [("http://host/path", testHandler)], route: "HTTP://host/path")
+    }
+
     // MARK: host
 
     func testRoute_WithMatchingHost_ShouldSucceed() {
@@ -161,6 +171,14 @@ class Route_TrieRouter_RouteTests: XCTestCase {
         XCTAssertRouteSucceeds(initial: [("/", testHandler)], route: "/")
         XCTAssertRouteSucceeds(initial: [("/", testHandler)], route: "://")
         XCTAssertRouteSucceeds(initial: [("/", testHandler)], route: ":///")
+    }
+
+    func testRoute_WithCaseInsensetiveHost_shouldSucceed() {
+        XCTAssertRouteSucceeds(initial: [("http://HOST/", testHandler)], route: "http://host/")
+        XCTAssertRouteSucceeds(initial: [("http://HOST/path", testHandler)], route: "http://host/path")
+
+        XCTAssertRouteSucceeds(initial: [("http://host/", testHandler)], route: "http://HOST/")
+        XCTAssertRouteSucceeds(initial: [("http://host/path", testHandler)], route: "http://HOST/path")
     }
 
     // MARK: single level path


### PR DESCRIPTION
<!-- Thanks for contributing to _Alicerce 🏗_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've rebased my changes on top of `master`
- [x] I've built and run the project to see all new and existing tests pass
- [x] I've followed the [Mindera swift style guide](https://github.com/Mindera/swift-style-guide)
- [x] I've read the [Contribution Guidelines](https://github.com/Mindera/Alicerce/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
The current implementation did not account for [RFC-3986](https://tools.ietf.org/html/rfc3986#section-6.2.2.1), and by doing so if the user entered an URL with a capital letters in the scheme or the host the match would fail.
By complying to the norm, this behaviour is now accounted for, and the issue is fixed.

### Description
Forcing the scheme and host from the user's input URL to be lowercased before parsing them to the match method.
Changed a UnitTest to accommodate to the base code changes.
Tested applying the code to a working project and running the app on a physical device to debug the deep links and universal links

