### PR TITLE
Add YAxisAnchors to baseline autolayout helpers

### DIFF
--- a/Sources/AutoLayout/ConstrainableProxy.swift
+++ b/Sources/AutoLayout/ConstrainableProxy.swift
@@ -50,6 +50,40 @@ public extension TopConstrainableProxy {
             priority: priority
         )
     }
+
+    @discardableResult
+    func topToFirstBaseline(
+        of anotherProxy: BaselineConstrainableProxy,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        constrain(
+            from: top,
+            to: anotherProxy.firstBaseline,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+
+    @discardableResult
+    func topToLastBaseline(
+        of anotherProxy: BaselineConstrainableProxy,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        constrain(
+            from: top,
+            to: anotherProxy.lastBaseline,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
 }
 
 public protocol BottomConstrainableProxy: ConstrainableProxy {
@@ -87,6 +121,40 @@ public extension BottomConstrainableProxy {
         constrain(
             from: bottom,
             to: anotherProxy.top,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+
+    @discardableResult
+    func bottomToFirstBaseline(
+        of anotherProxy: BaselineConstrainableProxy,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        constrain(
+            from: bottom,
+            to: anotherProxy.firstBaseline,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+
+    @discardableResult
+    func bottomToLastBaseline(
+        of anotherProxy: BaselineConstrainableProxy,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        constrain(
+            from: bottom,
+            to: anotherProxy.lastBaseline,
             offset: offset,
             relation: relation,
             priority: priority
@@ -384,6 +452,40 @@ public extension CenterYConstrainableProxy {
             to: view,
             toAttribute: .bottom,
             multiplier: multiplier,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+
+    @discardableResult
+    func centerYToFirstBaseline(
+        of anotherProxy: BaselineConstrainableProxy,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        constrain(
+            from: centerY,
+            to: anotherProxy.firstBaseline,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+
+    @discardableResult
+    func centerYToLastBaseline(
+        of anotherProxy: BaselineConstrainableProxy,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        constrain(
+            from: centerY,
+            to: anotherProxy.lastBaseline,
             offset: offset,
             relation: relation,
             priority: priority

--- a/Tests/AlicerceTests/AutoLayout/BottomConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/BottomConstrainableProxyTestCase.swift
@@ -334,7 +334,8 @@ final class BottomConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
             multiplier: 1,
             constant: 0,
             priority: .required,
-            active: true)
+            active: true
+        )
 
         XCTAssertConstraint(constraint, expected)
     }
@@ -355,7 +356,8 @@ final class BottomConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
             multiplier: 1,
             constant: 0,
             priority: .required,
-            active: true)
+            active: true
+        )
 
         XCTAssertConstraint(constraint, expected)
     }

--- a/Tests/AlicerceTests/AutoLayout/BottomConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/BottomConstrainableProxyTestCase.swift
@@ -317,4 +317,46 @@ final class BottomConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
         XCTAssert(constraintGroup1.isActive)
         XCTAssertEqual(view0.frame.maxY, 400)
     }
+
+    func testConstrain_WithBottomConstraint_ShouldSupportFirstBaselineAttribute() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view0) { host, view0 in
+            constraint = view0.bottomToFirstBaseline(of: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view0!,
+            attribute: .bottom,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .firstBaseline,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true)
+
+        XCTAssertConstraint(constraint, expected)
+    }
+
+    func testConstrain_WithBottomConstraint_ShouldSupportLastBaselineAttribute() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view0) { host, view0 in
+            constraint = view0.bottomToLastBaseline(of: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view0!,
+            attribute: .bottom,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .lastBaseline,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true)
+
+        XCTAssertConstraint(constraint, expected)
+    }
 }

--- a/Tests/AlicerceTests/AutoLayout/CenterYConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/CenterYConstrainableProxyTestCase.swift
@@ -256,6 +256,48 @@ class CenterYConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
         XCTAssert(constraintGroup1.isActive)
         XCTAssertEqual(view0.center.y, host.center.y + 100)
     }
+
+    func testConstrain_WithCenterY_ShouldSupportFirstBaselineAttribute() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view0) { host, view0 in
+            constraint = view0.centerYToFirstBaseline(of: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view0!,
+            attribute: .centerY,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .firstBaseline,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true)
+
+        XCTAssertConstraint(constraint, expected)
+    }
+
+    func testConstrain_WithCenterYConstraint_ShouldSupportLastBaselineAttribute() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view0) { host, view0 in
+            constraint = view0.centerYToLastBaseline(of: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view0!,
+            attribute: .centerY,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .lastBaseline,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true)
+
+        XCTAssertConstraint(constraint, expected)
+    }
 }
 
 private extension CenterYConstrainableProxyTestCase {

--- a/Tests/AlicerceTests/AutoLayout/CenterYConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/CenterYConstrainableProxyTestCase.swift
@@ -273,7 +273,8 @@ class CenterYConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
             multiplier: 1,
             constant: 0,
             priority: .required,
-            active: true)
+            active: true
+        )
 
         XCTAssertConstraint(constraint, expected)
     }
@@ -294,7 +295,8 @@ class CenterYConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
             multiplier: 1,
             constant: 0,
             priority: .required,
-            active: true)
+            active: true
+        )
 
         XCTAssertConstraint(constraint, expected)
     }

--- a/Tests/AlicerceTests/AutoLayout/TopConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/TopConstrainableProxyTestCase.swift
@@ -350,4 +350,48 @@ final class TopConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
         XCTAssert(constraintGroup1.isActive)
         XCTAssertEqual(view0.frame.minY, host.frame.minY + 100)
     }
+
+    func testConstrain_WithTopConstraint_ShouldSupportFirstBaselineAttribute() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view0) { host, view0 in
+            constraint = view0.topToFirstBaseline(of: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view0!,
+            attribute: .top,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .firstBaseline,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+    }
+
+    func testConstrain_WithTopConstraint_ShouldSupportLastBaselineAttribute() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view0) { host, view0 in
+            constraint = view0.topToLastBaseline(of: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view0!,
+            attribute: .top,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .lastBaseline,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+    }
 }


### PR DESCRIPTION
### Checklist
- [x] I've rebased my changes on top of `master`
- [x] I've built and run the project to see all new and existing tests pass
- [x] I've followed the [Mindera swift style guide](https://github.com/Mindera/swift-style-guide)
- [x] I've read the [Contribution Guidelines](https://github.com/Mindera/Alicerce/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Complementing our Autolayout API with YAxisAnchors to BaselineAnchors helpers.

### Description
Added helpers for top\bottom\centerY anchors to first\last BaselineAnchors.
Tested by applying the helper functions to two views and asserting the resulting constraint was equal to the expected.