### PR TITLE
Add AutoLayout helper ConstraintGroupToggle

### DIFF
--- a/Alicerce.xcodeproj/project.pbxproj
+++ b/Alicerce.xcodeproj/project.pbxproj
@@ -292,6 +292,7 @@
 		1B7166BC216BE424008A8A46 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 1B7166B9216BE402008A8A46 /* Localizable.strings */; };
 		1BBEB6091F333E5600D06526 /* UIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BBEB6081F333E5600D06526 /* UIImage.swift */; };
 		1BBEB60C1F333E6E00D06526 /* UIImageTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BBEB60A1F333E6600D06526 /* UIImageTestCase.swift */; };
+		3E8D61952546F90400C08EA2 /* ConstraintGroupToggleTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E8D61932546F8AF00C08EA2 /* ConstraintGroupToggleTestCase.swift */; };
 		4833D5B423D0D2CE00EBD925 /* WidthConstrainableProxyTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4833D5B223D0D28C00EBD925 /* WidthConstrainableProxyTestCase.swift */; };
 		4838FE3023A94CE0007311F0 /* ConstrainableProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4838FE2823A94CE0007311F0 /* ConstrainableProxy.swift */; };
 		4838FE3123A94CE0007311F0 /* Array+ConstrainableProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4838FE2923A94CE0007311F0 /* Array+ConstrainableProxy.swift */; };
@@ -626,6 +627,7 @@
 		1B7166CD216C231E008A8A46 /* StringTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringTestCase.swift; sourceTree = "<group>"; };
 		1BBEB6081F333E5600D06526 /* UIImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImage.swift; sourceTree = "<group>"; };
 		1BBEB60A1F333E6600D06526 /* UIImageTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImageTestCase.swift; sourceTree = "<group>"; };
+		3E8D61932546F8AF00C08EA2 /* ConstraintGroupToggleTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstraintGroupToggleTestCase.swift; sourceTree = "<group>"; };
 		4833D5B223D0D28C00EBD925 /* WidthConstrainableProxyTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidthConstrainableProxyTestCase.swift; sourceTree = "<group>"; };
 		4838FE2823A94CE0007311F0 /* ConstrainableProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConstrainableProxy.swift; sourceTree = "<group>"; };
 		4838FE2923A94CE0007311F0 /* Array+ConstrainableProxy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Array+ConstrainableProxy.swift"; sourceTree = "<group>"; };
@@ -1472,6 +1474,7 @@
 				4833D5B223D0D28C00EBD925 /* WidthConstrainableProxyTestCase.swift */,
 				4838FE3C23A950CA007311F0 /* XCTAssertConstraint.swift */,
 				48A5ECCF23D5B9F70014B2B7 /* TopBottomConstrainableProxyTestCase.swift */,
+				3E8D61932546F8AF00C08EA2 /* ConstraintGroupToggleTestCase.swift */,
 			);
 			path = AutoLayout;
 			sourceTree = "<group>";
@@ -1804,6 +1807,7 @@
 				0A266FBF1ED59FCD009CD0D7 /* EmptyCoreDataStackModel.xcdatamodeld in Sources */,
 				4838FE5723A951E6007311F0 /* TopConstrainableProxyTestCase.swift in Sources */,
 				0A708F6E20E99D9F001784DA /* MockAnalyticsTracker.swift in Sources */,
+				3E8D61952546F90400C08EA2 /* ConstraintGroupToggleTestCase.swift in Sources */,
 				0A266F8C1ED59FB6009CD0D7 /* MultiTrackerTestCase.swift in Sources */,
 				0A85F0E720B3177E0095AFFB /* PublicKeyAlgorithmTestCase.swift in Sources */,
 				0A266F901ED59FB6009CD0D7 /* Route+ComponentTests.swift in Sources */,

--- a/Sources/AutoLayout/Constrain.swift
+++ b/Sources/AutoLayout/Constrain.swift
@@ -41,6 +41,45 @@ public final class ConstraintGroup {
     }
 }
 
+public final class ConstraintGroupToggle<T: Hashable> {
+
+    private var constraintGroups: [T: ConstraintGroup] = [:]
+    private let makeConstraintGroup: (T) -> ConstraintGroup?
+
+    public init(initial: T? = nil, _ makeConstraintGroup: @escaping (T) -> ConstraintGroup?) {
+
+        self.makeConstraintGroup = makeConstraintGroup
+
+        if let initial = initial {
+            activate(initial)
+        }
+    }
+
+    public func activate(_ key: T) {
+
+        var previousActiveConstraint: ConstraintGroup?
+
+        constraintGroups.forEach {
+            
+            if $0 != key && $1.isActive {
+                $1.isActive = false
+                previousActiveConstraint = $1
+            }
+        }
+
+        if let constraintGroup = constraintGroups[key] {
+            constraintGroup.isActive = true
+        } else {
+            if let constraintGroup = makeConstraintGroup(key) {
+                constraintGroups[key] = constraintGroup
+                constraintGroup.isActive = true
+            } else {
+                previousActiveConstraint?.isActive = true
+            }
+        }
+    }
+}
+
 @discardableResult
 public func constrain<A: LayoutItem>(
     _ a: A,

--- a/Tests/AlicerceTests/AutoLayout/ConstraintGroupToggleTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/ConstraintGroupToggleTestCase.swift
@@ -1,0 +1,254 @@
+import XCTest
+@testable import Alicerce
+
+
+class ConstraintGroupToggleTestCase: BaseConstrainableProxyTestCase {
+
+    private enum TestConstraintGroupKey: Hashable {
+        case first
+        case second
+        case third
+    }
+
+    func testNoInitialConstraint_WithEnumKey_ShouldNotActivateConstraints() {
+
+        var constraint1: NSLayoutConstraint!
+        var constraint2: NSLayoutConstraint!
+        var constraint3: NSLayoutConstraint!
+
+        let _ = ConstraintGroupToggle<TestConstraintGroupKey> { [weak self] in
+
+            guard let self = self else { return nil }
+
+            switch $0 {
+            case .first:
+                return constrain(self.host, self.view0) { host, view0 in
+                   constraint1 = view0.bottom(to: host, offset: -100)
+                }
+
+            case .second:
+                return constrain(self.host, self.view0) { host, view0 in
+                   constraint2 = view0.top(to: host, offset: -100)
+                }
+
+            case .third:
+                return constrain(self.host, self.view0) { host, view0 in
+                   constraint3 = view0.leading(to: host, offset: -100)
+                }
+            }
+        }
+
+        XCTAssertNil(constraint1)
+        XCTAssertNil(constraint2)
+        XCTAssertNil(constraint3)
+    }
+
+    func testInitialConstraint_WithEnumKey_ShouldActivateFirstConstraint() {
+
+        var constraint1: NSLayoutConstraint!
+        var constraint2: NSLayoutConstraint!
+        var constraint3: NSLayoutConstraint!
+
+        let _ = ConstraintGroupToggle(initial: TestConstraintGroupKey.first) { [weak self] in
+
+            guard let self = self else { return nil }
+
+            switch $0 {
+            case .first:
+                return constrain(self.host, self.view0) { host, view0 in
+                   constraint1 = view0.bottom(to: host, offset: -100)
+                }
+
+            case .second:
+                return constrain(self.host, self.view0) { host, view0 in
+                   constraint2 = view0.top(to: host, offset: -100)
+                }
+
+            case .third:
+                return constrain(self.host, self.view0) { host, view0 in
+                   constraint3 = view0.leading(to: host, offset: -100)
+                }
+            }
+        }
+
+        XCTAssert(constraint1.isActive)
+        XCTAssertNil(constraint2)
+        XCTAssertNil(constraint3)
+    }
+
+    func testActivateOneConstraint_WithEnumKey_ShouldDeactivateFirstConstraintAndActivateSecondConstraint() {
+
+        var constraint1: NSLayoutConstraint!
+        var constraint2: NSLayoutConstraint!
+        var constraint3: NSLayoutConstraint!
+
+        let group = ConstraintGroupToggle(initial: TestConstraintGroupKey.first) { [weak self] in
+
+            guard let self = self else { return nil }
+
+            switch $0 {
+            case .first:
+                return constrain(self.host, self.view0) { host, view0 in
+                   constraint1 = view0.bottom(to: host, offset: -100)
+                }
+
+            case .second:
+                return constrain(self.host, self.view0) { host, view0 in
+                   constraint2 = view0.top(to: host, offset: -100)
+                }
+
+            case .third:
+                return constrain(self.host, self.view0) { host, view0 in
+                   constraint3 = view0.leading(to: host, offset: -100)
+                }
+            }
+        }
+
+        group.activate(.second)
+
+        XCTAssertFalse(constraint1.isActive)
+        XCTAssert(constraint2.isActive)
+        XCTAssertNil(constraint3)
+    }
+
+    func testActivateTwoConstraints_WithEnumKey_ShouldDeactivateFirstAndSecondConstraintAndActivateThirdConstraint() {
+
+        var constraint1: NSLayoutConstraint!
+        var constraint2: NSLayoutConstraint!
+        var constraint3: NSLayoutConstraint!
+
+        let group = ConstraintGroupToggle(initial: TestConstraintGroupKey.first) { [weak self] in
+
+            guard let self = self else { return nil }
+
+            switch $0 {
+            case .first:
+                return constrain(self.host, self.view0) { host, view0 in
+                   constraint1 = view0.bottom(to: host, offset: -100)
+                }
+
+            case .second:
+                return constrain(self.host, self.view0) { host, view0 in
+                   constraint2 = view0.top(to: host, offset: -100)
+                }
+
+            case .third:
+                return constrain(self.host, self.view0) { host, view0 in
+                   constraint3 = view0.leading(to: host, offset: -100)
+                }
+            }
+        }
+
+        group.activate(.second)
+        group.activate(.third)
+
+        XCTAssertFalse(constraint1.isActive)
+        XCTAssertFalse(constraint2.isActive)
+        XCTAssert(constraint3.isActive)
+    }
+
+    func testReactivateConstraint_WithEnumKey_ShouldDeactivateSecondAndThirdConstraintAndActivateFirstConstraint() {
+
+        var constraint1: NSLayoutConstraint!
+        var constraint2: NSLayoutConstraint!
+        var constraint3: NSLayoutConstraint!
+
+        let group = ConstraintGroupToggle(initial: TestConstraintGroupKey.first) { [weak self]  in
+
+            guard let self = self else { return nil }
+
+            switch $0 {
+            case .first:
+                return constrain(self.host, self.view0) { host, view0 in
+                   constraint1 = view0.bottom(to: host, offset: -100)
+                }
+
+            case .second:
+                return constrain(self.host, self.view0) { host, view0 in
+                   constraint2 = view0.top(to: host, offset: -100)
+                }
+
+            case .third:
+                return constrain(self.host, self.view0) { host, view0 in
+                   constraint3 = view0.leading(to: host, offset: -100)
+                }
+            }
+        }
+
+        group.activate(.second)
+        group.activate(.third)
+        group.activate(.first)
+
+        XCTAssertTrue(constraint1.isActive)
+        XCTAssertFalse(constraint2.isActive)
+        XCTAssertFalse(constraint3.isActive)
+    }
+
+    func testReActivateConstraintCurrentConstraint_WithEnumKey_ShouldActivateFirstConstraint() {
+
+        var constraint1: NSLayoutConstraint!
+        var constraint2: NSLayoutConstraint!
+        var constraint3: NSLayoutConstraint!
+
+        let group = ConstraintGroupToggle(initial: TestConstraintGroupKey.first) {
+            [weak self] in
+
+            guard let self = self else { return nil }
+
+            switch $0 {
+            case .first:
+                return constrain(self.host, self.view0) { host, view0 in
+                   constraint1 = view0.bottom(to: host, offset: -100)
+                }
+
+            case .second:
+                return constrain(self.host, self.view0) { host, view0 in
+                   constraint2 = view0.top(to: host, offset: -100)
+                }
+
+            case .third:
+                return constrain(self.host, self.view0) { host, view0 in
+                   constraint3 = view0.leading(to: host, offset: -100)
+                }
+            }
+        }
+
+        group.activate(.first)
+
+        XCTAssertTrue(constraint1.isActive)
+        XCTAssertNil(constraint2)
+        XCTAssertNil(constraint3)
+    }
+
+    func testActivateUnhandledKeyCase_WithNonFiniteKeySet_ShouldMaintainCurrentConstraint() {
+
+        var constraint1: NSLayoutConstraint!
+        var constraint2: NSLayoutConstraint!
+
+        let group = ConstraintGroupToggle(initial: "constraint1") { [weak self]  in
+
+            guard let self = self else { return nil }
+
+            switch $0 {
+            case "constraint1":
+                return constrain(self.host, self.view0) { host, view0 in
+                   constraint1 = view0.bottom(to: host, offset: -100)
+                }
+
+            case "constraint2":
+                return constrain(self.host, self.view0) { host, view0 in
+                   constraint2 = view0.bottom(to: host, offset: -100)
+                }
+
+            default:
+                return nil
+            }
+
+        }
+
+        group.activate("constraint3")
+
+        XCTAssert(constraint1.isActive)
+        XCTAssertNil(constraint2)
+    }
+}


### PR DESCRIPTION
### Checklist
- [x] I've rebased my changes on top of `master`
- [x] I've built and run the project to see all new and existing tests pass
- [x] I've followed the [Mindera swift style guide](https://github.com/Mindera/swift-style-guide)
- [x] I've read the [Contribution Guidelines](https://github.com/Mindera/Alicerce/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
ConstraintGroupToggle handles switching between ConstraintGroups that can't be active at the same time, deactivating the current active group and only after activating the new one.

Went back and forth on a few decisions, the biggest one is whether we should allow the closure that builds our ConstraintGroups to return an optional ConstraintGroup. 

` private let makeConstraintGroup: (T) -> ConstraintGroup?`

I ended up using this approach to avoid returning empty ConstraintGroups in cases we don't want to. 

With this in mind the other decision was wether nil would deactivate all constraints or keep the last active constraint active. 
I went with keeping the last constraint active, but not really sure if it's the right call.

If someone has feelings on these issues please let me know 😅

Kudos to @filipe-lemos for the backbone of the code

### Description
Add ConstraintGroupToggle to AutoLayout.Constraint
Add UnitTests