### PR TITLE
Add missing public init to `StackOrchestrator.FetchResource`

### DIFF
--- a/Sources/StackOrchestrator/StackOrchestrator.swift
+++ b/Sources/StackOrchestrator/StackOrchestrator.swift
@@ -20,6 +20,7 @@ public enum StackOrchestrator {
         var persistenceKey: PersistenceKey
 
         public init(strategy: FetchStrategy, networkResource: NetworkResource, persistenceKey: PersistenceKey) {
+            
             self.strategy = strategy
             self.networkResource = networkResource
             self.persistenceKey = persistenceKey

--- a/Sources/StackOrchestrator/StackOrchestrator.swift
+++ b/Sources/StackOrchestrator/StackOrchestrator.swift
@@ -18,6 +18,12 @@ public enum StackOrchestrator {
         var strategy: FetchStrategy
         var networkResource: NetworkResource
         var persistenceKey: PersistenceKey
+
+        public init(strategy: FetchStrategy, networkResource: NetworkResource, persistenceKey: PersistenceKey) {
+            self.strategy = strategy
+            self.networkResource = networkResource
+            self.persistenceKey = persistenceKey
+        }
     }
 
     public enum FetchStrategy {


### PR DESCRIPTION

### Checklist
- [x] I've rebased my changes on top of `master`
- [x] I've built and run the project to see all new and existing tests pass
- [x] I've followed the [Mindera swift style guide](https://github.com/Mindera/swift-style-guide)
- [x] I've read the [Contribution Guidelines](https://github.com/Mindera/Alicerce/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
`StackOrchestrator.FetchResource` is missing its `public init` only having the synthesized internal `init`. 

### Description
`StackOrchestrator.FetchResource` needs to be inited as it's the typealias for `StackOrchestratorStore.Resource` and necessary as a parameter on `StackOrchestratorStore.fetch(resource:completion:)`. No helpers or alternative methods seem to be available for instantiating the struct so the absence of the explicit `init` is most likely an oversight.
