### PR TITLE
Rename `KeyboardObserver` private funcs

### DIFF
--- a/Sources/Observers/KeyboardObserver.swift
+++ b/Sources/Observers/KeyboardObserver.swift
@@ -35,12 +35,12 @@ public final class KeyboardObserver: NSObject {
         self.tapGestureRecognizer = tapGestureRecognizer
 
         NotificationCenter.default.addObserver(self,
-                                               selector: #selector(keyboardDidShow),
+                                               selector: #selector(keyboardBecameVisible),
                                                name: UIResponder.keyboardDidShowNotification,
                                                object: nil)
 
         NotificationCenter.default.addObserver(self,
-                                               selector: #selector(keyboardDidHide),
+                                               selector: #selector(keyboardBecameInvisible),
                                                name: UIResponder.keyboardDidHideNotification,
                                                object: nil)
     }
@@ -53,11 +53,11 @@ public final class KeyboardObserver: NSObject {
 
     // MARK: - Private Methods
 
-    @objc private func keyboardDidShow() {
+    @objc private func keyboardBecameVisible() {
         isKeyboardVisible = true
     }
 
-    @objc private func keyboardDidHide() {
+    @objc private func keyboardBecameInvisible() {
         isKeyboardVisible = false
     }
 

--- a/Sources/Observers/KeyboardObserver.swift
+++ b/Sources/Observers/KeyboardObserver.swift
@@ -35,12 +35,12 @@ public final class KeyboardObserver: NSObject {
         self.tapGestureRecognizer = tapGestureRecognizer
 
         NotificationCenter.default.addObserver(self,
-                                               selector: #selector(keyboardBecameVisible),
+                                               selector: #selector(handleKeyboardDidShow(_:)),
                                                name: UIResponder.keyboardDidShowNotification,
                                                object: nil)
 
         NotificationCenter.default.addObserver(self,
-                                               selector: #selector(keyboardBecameInvisible),
+                                               selector: #selector(handleKeyboardDidHide(_:)),
                                                name: UIResponder.keyboardDidHideNotification,
                                                object: nil)
     }
@@ -53,11 +53,14 @@ public final class KeyboardObserver: NSObject {
 
     // MARK: - Private Methods
 
-    @objc private func keyboardBecameVisible() {
+    // The following functions were renamed from `keyboardDidShow` and `keyboardDidHide` to `handleKeyboardDidShow` and
+    // `handleKeyboardDidHide`, respectively, because they matched private Apple APIs
+
+    @objc private func handleKeyboardDidShow(_ notification: NSNotification) {
         isKeyboardVisible = true
     }
 
-    @objc private func keyboardBecameInvisible() {
+    @objc private func handleKeyboardDidHide(_ notification: NSNotification) {
         isKeyboardVisible = false
     }
 


### PR DESCRIPTION
### Checklist
- [x] I've rebased my changes on top of `master`
- [x] I've built and run the project to see all new and existing tests pass
- [x] I've followed the [Mindera swift style guide](https://github.com/Mindera/swift-style-guide)
- [x] I've read the [Contribution Guidelines](https://github.com/Mindera/Alicerce/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
According to a message received from App Store Connect, `keyboardDidHide` and `keyboardDidShow` are methods that match the private Apple APIs. The solution should pass by renaming said methods.

### Description
- Rename `keyboardDidHide` and `keyboardDidShow` to `keyboardBecameVisible` and `keyboardBecameInvisible` respectively

Observation: we could opt for other names like `onKeyboardDidHide` or `receivedKeyboardDidHideNotification`