### PR TITLE
Implement scoped loggers from `ModuleLogger`s 🍰

### DIFF
--- a/Tests/AlicerceTests/Logging/Loggers/ModuleLoggerTestCase.swift
+++ b/Tests/AlicerceTests/Logging/Loggers/ModuleLoggerTestCase.swift
@@ -175,6 +175,88 @@ class ModuleLoggerTestCase: XCTestCase {
 
         log.error("message", file: "filename.ext", line: 1337, function: "function")
     }
+
+    // scopedLogger(for:)
+
+    func testScopedLogger_WithVerboseLog_ShouldInvokeUpstreamLogWithCorrectModuleAndLogLevel() {
+
+        let scopedLogger = log.scopedLogger(for: .🤖)
+
+        log.moduleLogInvokedClosure = { module, level, message, file, line, function in
+            XCTAssertEqual(module, MockModule.🤖)
+            XCTAssertEqual(level, .verbose)
+            XCTAssertEqual(message, "message")
+            XCTAssertEqual(file.description, "filename.ext")
+            XCTAssertEqual(line, 1337)
+            XCTAssertEqual(function.description, "function")
+        }
+
+        scopedLogger.verbose("message", file: "filename.ext", line: 1337, function: "function")
+    }
+
+    func testScopedLogger_WithDebugLog_ShouldInvokeUpstreamLogWithCorrectModuleAndLogLevel() {
+
+        let scopedLogger = log.scopedLogger(for: .🤖)
+
+        log.moduleLogInvokedClosure = { module, level, message, file, line, function in
+            XCTAssertEqual(module, MockModule.🤖)
+            XCTAssertEqual(level, .debug)
+            XCTAssertEqual(message, "message")
+            XCTAssertEqual(file.description, "filename.ext")
+            XCTAssertEqual(line, 1337)
+            XCTAssertEqual(function.description, "function")
+        }
+
+        scopedLogger.debug("message", file: "filename.ext", line: 1337, function: "function")
+    }
+
+    func testScopedLogger_WithInfoLog_ShouldInvokeUpstreamLogWithCorrectModuleAndLogLevel() {
+
+        let scopedLogger = log.scopedLogger(for: .🤖)
+
+        log.moduleLogInvokedClosure = { module, level, message, file, line, function in
+            XCTAssertEqual(module, MockModule.🤖)
+            XCTAssertEqual(level, .info)
+            XCTAssertEqual(message, "message")
+            XCTAssertEqual(file.description, "filename.ext")
+            XCTAssertEqual(line, 1337)
+            XCTAssertEqual(function.description, "function")
+        }
+
+        scopedLogger.info("message", file: "filename.ext", line: 1337, function: "function")
+    }
+
+    func testScopedLogger_WithWarningLog_ShouldInvokeUpstreamLogWithCorrectModuleAndLogLevel() {
+
+        let scopedLogger = log.scopedLogger(for: .🤖)
+
+        log.moduleLogInvokedClosure = { module, level, message, file, line, function in
+            XCTAssertEqual(module, MockModule.🤖)
+            XCTAssertEqual(level, .warning)
+            XCTAssertEqual(message, "message")
+            XCTAssertEqual(file.description, "filename.ext")
+            XCTAssertEqual(line, 1337)
+            XCTAssertEqual(function.description, "function")
+        }
+
+        scopedLogger.warning("message", file: "filename.ext", line: 1337, function: "function")
+    }
+
+    func testScopedLogger_WithErrorLog_ShouldInvokeUpstreamLogWithCorrectModuleAndLogLevel() {
+
+        let scopedLogger = log.scopedLogger(for: .🤖)
+
+        log.moduleLogInvokedClosure = { module, level, message, file, line, function in
+            XCTAssertEqual(module, MockModule.🤖)
+            XCTAssertEqual(level, .error)
+            XCTAssertEqual(message, "message")
+            XCTAssertEqual(file.description, "filename.ext")
+            XCTAssertEqual(line, 1337)
+            XCTAssertEqual(function.description, "function")
+        }
+
+        scopedLogger.error("message", file: "filename.ext", line: 1337, function: "function")
+    }
 }
 
 private enum MockModule: String, LogModule {


### PR DESCRIPTION
### Checklist
- [x] I've rebased my changes on top of `master`
- [x] I've built and run the project to see all new and existing tests pass
- [x] I've followed the [Mindera swift style guide](https://github.com/Mindera/swift-style-guide)
- [x] I've read the [Contribution Guidelines](https://github.com/Mindera/Alicerce/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

On certain occasions, one needs to pass in a simple `Logger` instance but want log events forwarded to a larger logging infrastructure.

If we're dealing with a `ModuleLogger` with multiple registered modules, one may want to derive a simpler `Logger` that sends all events under a single module to the upstream logger. To achieve that, `ModuleLogger` can now create scoped loggers via a new `scopedLogger(for:)` helper.

### Description

- Create `ModuleLogger.scopedLogger(for:)` helper.

- Create new `Log.ForwardingLogger` private helper class to forward log events to an upstream (Module) logger.