### PR TITLE
Change UInt instances to Int

### DIFF
--- a/Sources/Logging/Log.swift
+++ b/Sources/Logging/Log.swift
@@ -28,7 +28,7 @@ public enum Log {
         public let file: String
 
         /// The file line from where the log originated.
-        public let line: UInt
+        public let line: Int
 
         /// The function from where the log originated.
         public let function: String

--- a/Sources/Logging/Loggers/Log+DummyLogger.swift
+++ b/Sources/Logging/Loggers/Log+DummyLogger.swift
@@ -22,7 +22,7 @@ extension Log {
             level: Log.Level,
             message: @autoclosure () -> String,
             file: StaticString,
-            line: UInt,
+            line: Int,
             function: StaticString
         ) {
 

--- a/Sources/Logging/Loggers/Log+MultiLogger.swift
+++ b/Sources/Logging/Loggers/Log+MultiLogger.swift
@@ -86,7 +86,7 @@ extension Log {
             level: Log.Level,
             message: @autoclosure () -> String,
             file: StaticString = #file,
-            line: UInt = #line,
+            line: Int = #line,
             function: StaticString = #function
         ) {
 
@@ -112,7 +112,7 @@ extension Log {
             level: Log.Level,
             message: @autoclosure () -> String,
             file: StaticString = #file,
-            line: UInt = #line,
+            line: Int = #line,
             function: StaticString = #function
         ) {
 
@@ -139,7 +139,7 @@ extension Log {
             level: Level,
             message: @autoclosure () -> String,
             file: StaticString = #file,
-            line: UInt = #line,
+            line: Int = #line,
             function: StaticString = #function
         ) {
 

--- a/Sources/Logging/Loggers/Logger.swift
+++ b/Sources/Logging/Loggers/Logger.swift
@@ -19,7 +19,7 @@ public protocol Logger: AnyObject {
         level: Log.Level,
         message: @autoclosure () -> String,
         file: StaticString,
-        line: UInt,
+        line: Int,
         function: StaticString
     )
 }
@@ -36,7 +36,7 @@ public extension Logger {
     func verbose(
         _ message: @autoclosure () -> String,
         file: StaticString = #file,
-        line: UInt = #line,
+        line: Int = #line,
         function: StaticString = #function
     ) {
 
@@ -53,7 +53,7 @@ public extension Logger {
     func debug(
         _ message: @autoclosure () -> String,
         file: StaticString = #file,
-        line: UInt = #line,
+        line: Int = #line,
         function: StaticString = #function
     ) {
 
@@ -70,7 +70,7 @@ public extension Logger {
     func info(
         _ message: @autoclosure () -> String,
         file: StaticString = #file,
-        line: UInt = #line,
+        line: Int = #line,
         function: StaticString = #function
     ) {
 
@@ -87,7 +87,7 @@ public extension Logger {
     func warning(
         _ message: @autoclosure () -> String,
         file: StaticString = #file,
-        line: UInt = #line,
+        line: Int = #line,
         function: StaticString = #function
     ) {
 
@@ -104,7 +104,7 @@ public extension Logger {
     func error(
         _ message: @autoclosure () -> String,
         file: StaticString = #file,
-        line: UInt = #line,
+        line: Int = #line,
         function: StaticString = #function
     ) {
 
@@ -118,7 +118,7 @@ public extension Logger where Self: LogDestination {
         level: Log.Level,
         message: @autoclosure () -> String,
         file: StaticString,
-        line: UInt,
+        line: Int,
         function: StaticString
     ) {
 

--- a/Sources/Logging/Loggers/ModuleLogger.swift
+++ b/Sources/Logging/Loggers/ModuleLogger.swift
@@ -34,7 +34,7 @@ public protocol ModuleLogger: Logger {
         level: Log.Level,
         message: @autoclosure () -> String,
         file: StaticString,
-        line: UInt,
+        line: Int,
         function: StaticString
     )
 }
@@ -58,7 +58,7 @@ public extension ModuleLogger {
         _ module: Module,
         _ message: @autoclosure () -> String,
         file: StaticString = #file,
-        line: UInt = #line,
+        line: Int = #line,
         function: StaticString = #function
     ) {
 
@@ -82,7 +82,7 @@ public extension ModuleLogger {
         _ module: Module,
         _ message: @autoclosure () -> String,
         file: StaticString = #file,
-        line: UInt = #line,
+        line: Int = #line,
         function: StaticString = #function
     ) {
 
@@ -106,7 +106,7 @@ public extension ModuleLogger {
         _ module: Module,
         _ message: @autoclosure () -> String,
         file: StaticString = #file,
-        line: UInt = #line,
+        line: Int = #line,
         function: StaticString = #function
     ) {
 
@@ -130,7 +130,7 @@ public extension ModuleLogger {
         _ module: Module,
         _ message: @autoclosure () -> String,
         file: StaticString = #file,
-        line: UInt = #line,
+        line: Int = #line,
         function: StaticString = #function
     ) {
 
@@ -154,7 +154,7 @@ public extension ModuleLogger {
         _ module: Module,
         _ message: @autoclosure () -> String,
         file: StaticString = #file,
-        line: UInt = #line,
+        line: Int = #line,
         function: StaticString = #function
     ) {
 
@@ -170,7 +170,7 @@ public extension ModuleLogger where Self: LogDestination {
         level: Log.Level,
         message: @autoclosure () -> String,
         file: StaticString,
-        line: UInt,
+        line: Int,
         function: StaticString
     ) {
 
@@ -211,7 +211,7 @@ private extension Log {
 
     final class ForwardingLogger: Logger {
 
-        let upstreamLog: (Log.Level, () -> String, StaticString, UInt, StaticString) -> Void
+        let upstreamLog: (Log.Level, () -> String, StaticString, Int, StaticString) -> Void
 
         init<L: ModuleLogger>(scoping module: L.Module, from logger: L) {
 
@@ -224,7 +224,7 @@ private extension Log {
             level: Log.Level,
             message: @autoclosure () -> String,
             file: StaticString,
-            line: UInt,
+            line: Int,
             function: StaticString
         ) {
 

--- a/Sources/Persistence/PersistencePerformanceMetricsTracker.swift
+++ b/Sources/Persistence/PersistencePerformanceMetricsTracker.swift
@@ -7,10 +7,10 @@ import AlicercePerformanceMetrics
 public protocol PersistencePerformanceMetricsTracker: PerformanceMetricsTracker {
 
     /// A closure to be used when stopping measuring memory reads/writes.
-    typealias MemoryAccessStopClosure<E: Error> = (_ result: Result<(blobSize: UInt64, memorySize: UInt64), E>) -> Void
+    typealias MemoryAccessStopClosure<E: Error> = (_ result: Result<(blobSize: Int64, memorySize: Int64), E>) -> Void
 
     /// A closure to be used when stopping measuring disk reads/writes.
-    typealias DiskAccessStopClosure<E: Error> = (_ result: Result<(blobSize: UInt64, diskSize: UInt64), E>) -> Void
+    typealias DiskAccessStopClosure<E: Error> = (_ result: Result<(blobSize: Int64, diskSize: Int64), E>) -> Void
 
     /// The metadata key used for the used memory.
     var usedMemoryMetadataKey: Metadata.Key { get }

--- a/Sources/Utils/Token.swift
+++ b/Sources/Utils/Token.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public struct Token<Tag>: Hashable {
 
-    fileprivate let value: UInt64
+    fileprivate let value: Int64
 }
 
 public final class Tokenizer<Tag> {

--- a/Tests/AlicerceTests/Logging/Loggers/LoggerTestCase.swift
+++ b/Tests/AlicerceTests/Logging/Loggers/LoggerTestCase.swift
@@ -109,13 +109,13 @@ private enum MockModule: String, LogModule {
 
 private final class MockLogger: Logger {
 
-    var logInvokedClosure: ((Log.Level, String, StaticString, UInt, StaticString) -> Void)?
+    var logInvokedClosure: ((Log.Level, String, StaticString, Int, StaticString) -> Void)?
 
     func log(
         level: Log.Level,
         message: @autoclosure () -> String,
         file: StaticString,
-        line: UInt,
+        line: Int,
         function: StaticString
     ) {
 

--- a/Tests/AlicerceTests/Logging/Loggers/ModuleLoggerTestCase.swift
+++ b/Tests/AlicerceTests/Logging/Loggers/ModuleLoggerTestCase.swift
@@ -265,8 +265,8 @@ private enum MockModule: String, LogModule {
 
 private final class MockModuleLogger: ModuleLogger {
 
-    var logInvokedClosure: ((Log.Level, String, StaticString, UInt, StaticString) -> Void)?
-    var moduleLogInvokedClosure: ((Module, Log.Level, String, StaticString, UInt, StaticString) -> Void)?
+    var logInvokedClosure: ((Log.Level, String, StaticString, Int, StaticString) -> Void)?
+    var moduleLogInvokedClosure: ((Module, Log.Level, String, StaticString, Int, StaticString) -> Void)?
 
     typealias Module = MockModule
 
@@ -274,7 +274,7 @@ private final class MockModuleLogger: ModuleLogger {
         level: Log.Level,
         message: @autoclosure () -> String,
         file: StaticString,
-        line: UInt,
+        line: Int,
         function: StaticString
     ) {
 
@@ -286,7 +286,7 @@ private final class MockModuleLogger: ModuleLogger {
         level: Log.Level,
         message: @autoclosure () -> String,
         file: StaticString,
-        line: UInt,
+        line: Int,
         function: StaticString
     ) {
 

--- a/Tests/AlicerceTests/Persistence/DiskMemoryPersistenceTestCase.swift
+++ b/Tests/AlicerceTests/Persistence/DiskMemoryPersistenceTestCase.swift
@@ -17,7 +17,7 @@ final class DiskMemoryPersistenceTestCase: XCTestCase {
 
     func testInit_WhenInitialisedWithLimit_ItShouldNotHoldMoreThanThoseFiles() {
         let testName = "testInit_WhenInitialisedWithLimit_ItShouldNotHoldMoreThanThoseFiles"
-        let diskLimit = UInt64(Float(mrMinderSize) * 2.5) // add some "margin" because of filesystem extra bytes
+        let diskLimit = Int64(Float(mrMinderSize) * 2.5) // add some "margin" because of filesystem extra bytes
         let writeQueue = DispatchQueue(label: testName)
         let persistence = diskMemoryPersistence(withDiskLimit: diskLimit,
                                                 memLimit: 1,
@@ -48,7 +48,7 @@ final class DiskMemoryPersistenceTestCase: XCTestCase {
 
     func testSetObject_WhenAnObjectIsCached_ItShouldStoreTheObjectInDisk() {
         let testName = "testSetObject_WhenAnObjectIsCached_ItShouldStoreTheObjectInDisk"
-        let sizeLimit = UInt64(Float(mrMinderSize) * 1.5) // add some "margin" because of filesystem extra bytes
+        let sizeLimit = Int64(Float(mrMinderSize) * 1.5) // add some "margin" because of filesystem extra bytes
         let persistence = diskMemoryPersistence(withDiskLimit: sizeLimit,
                                                 memLimit: sizeLimit,
                                                 extraPath: testName)
@@ -72,7 +72,7 @@ final class DiskMemoryPersistenceTestCase: XCTestCase {
 
     func testSetObject_WhenAnObjectIsAlreadyCachedwithSameKey_ItShouldOverwriteTheObjectInDisk() {
         let testName = "testSetObject_WhenAnObjectIsAlreadyCachedwithSameKey_ItShouldOverwriteTheObjectInDisk"
-        let sizeLimit = UInt64(Float(mrMinderSize) * 1.5) // add some "margin" because of filesystem extra bytes
+        let sizeLimit = Int64(Float(mrMinderSize) * 1.5) // add some "margin" because of filesystem extra bytes
         let persistence = diskMemoryPersistence(withDiskLimit: sizeLimit,
                                                 memLimit: sizeLimit,
                                                 extraPath: testName)
@@ -114,7 +114,7 @@ final class DiskMemoryPersistenceTestCase: XCTestCase {
 
     func testRemoveObject_WhenACachedObjectIsRemoved_ItShouldRemoveTheObjectFromTheDisk() {
         let testName = "testRemoveObject_WhenACachedObjectIsRemoved_ItShouldRemoveTheObjectFromTheDisk"
-        let sizeLimit = UInt64(Float(mrMinderSize) * 1.5) // add some "margin" because of filesystem extra bytes
+        let sizeLimit = Int64(Float(mrMinderSize) * 1.5) // add some "margin" because of filesystem extra bytes
         let persistence = diskMemoryPersistence(withDiskLimit: sizeLimit,
                                                 memLimit: sizeLimit,
                                                 extraPath: testName)
@@ -190,7 +190,7 @@ final class DiskMemoryPersistenceTestCase: XCTestCase {
 
     func testObject_WhenAnObjectIsNotInMemoryButInDisk_ItShouldLoadTheObjectFromDisk() {
         let testName = "testObject_WhenAnObjectIsNotInMemoryButInDisk_ItShouldLoadTheObjectFromDisk"
-        let sizeLimit = UInt64(Float(mrMinderSize) * 1.5) // add some "margin" because of filesystem extra bytes
+        let sizeLimit = Int64(Float(mrMinderSize) * 1.5) // add some "margin" because of filesystem extra bytes
         var persistence = diskMemoryPersistence(withDiskLimit: sizeLimit,
                                                 memLimit: sizeLimit,
                                                 extraPath: testName)
@@ -233,7 +233,7 @@ final class DiskMemoryPersistenceTestCase: XCTestCase {
 
     func testObject_WhenWeTryToGetAnInexistingObject_ItShouldReturnNil() {
         let testName = "testObject_WhenAnObjectIsNotInMemoryButInDisk_ItShouldLoadTheObjectFromDisk"
-        let sizeLimit = UInt64(Float(mrMinderSize) * 1.5) // add some "margin" because of filesystem extra bytes
+        let sizeLimit = Int64(Float(mrMinderSize) * 1.5) // add some "margin" because of filesystem extra bytes
         let persistence = diskMemoryPersistence(withDiskLimit: sizeLimit, memLimit: sizeLimit, extraPath: testName)
 
         let readExpectation = expectation(description: "Cache miss")
@@ -257,7 +257,7 @@ final class DiskMemoryPersistenceTestCase: XCTestCase {
     func testSetObject_WhenAnObjectIsCachedWithPerformanceMetrics_ItShouldStoreTheObjectInDisk() {
         let testName = "testSetObject_WhenAnObjectIsCachedWithPerformanceMetrics_ItShouldStoreTheObjectInDisk"
         let performanceMetrics = MockPersistencePerformanceMetricsTracker()
-        let sizeLimit = UInt64(Float(mrMinderSize) * 1.5) // add some "margin" because of filesystem extra bytes
+        let sizeLimit = Int64(Float(mrMinderSize) * 1.5) // add some "margin" because of filesystem extra bytes
         let persistence = diskMemoryPersistence(withDiskLimit: sizeLimit,
                                                 memLimit: sizeLimit,
                                                 extraPath: testName,
@@ -302,7 +302,7 @@ final class DiskMemoryPersistenceTestCase: XCTestCase {
     func testRemoveObject_WhenACachedObjectIsRemovedWithPerformanceMetrics_ItShouldRemoveTheObjectFromTheDisk() {
         let testName = "testRemoveObject_WhenACachedObjectIsRemovedWithPerformanceMetrics_ItShouldRemoveTheObjectFromTheDisk"
         let performanceMetrics = MockPersistencePerformanceMetricsTracker()
-        let sizeLimit = UInt64(Float(mrMinderSize) * 1.5) // add some "margin" because of filesystem extra bytes
+        let sizeLimit = Int64(Float(mrMinderSize) * 1.5) // add some "margin" because of filesystem extra bytes
         let writeQueue = DispatchQueue(label: testName)
         let persistence = diskMemoryPersistence(withDiskLimit: sizeLimit,
                                                 memLimit: sizeLimit,
@@ -428,7 +428,7 @@ final class DiskMemoryPersistenceTestCase: XCTestCase {
     func testObject_WhenAnObjectIsNotInMemoryButInDiskWithPerformanceMetrics_ItShouldLoadTheObjectFromDisk() {
         let testName = "testObject_WhenAnObjectIsNotInMemoryButInDiskWithPerformanceMetrics_ItShouldLoadTheObjectFromDisk"
         let performanceMetrics = MockPersistencePerformanceMetricsTracker()
-        let sizeLimit = UInt64(Float(mrMinderSize) * 1.5) // add some "margin" because of filesystem extra bytes
+        let sizeLimit = Int64(Float(mrMinderSize) * 1.5) // add some "margin" because of filesystem extra bytes
         var persistence = diskMemoryPersistence(withDiskLimit: sizeLimit,
                                                 memLimit: sizeLimit,
                                                 extraPath: testName,
@@ -513,7 +513,7 @@ final class DiskMemoryPersistenceTestCase: XCTestCase {
     func testObject_WhenWeTryToGetAnInexistingObjectWithPerformanceMetrics_ItShouldReturnZeroBlobSize() {
         let testName = "testObject_WhenWeTryToGetAnInexistingObjectWithPerformanceMetrics_ItShouldReturnZeroBlobSize"
         let performanceMetrics = MockPersistencePerformanceMetricsTracker()
-        let sizeLimit = UInt64(Float(mrMinderSize) * 1.5) // add some "margin" because of filesystem extra bytes
+        let sizeLimit = Int64(Float(mrMinderSize) * 1.5) // add some "margin" because of filesystem extra bytes
         let persistence = diskMemoryPersistence(withDiskLimit: sizeLimit,
                                                 memLimit: sizeLimit,
                                                 extraPath: testName,
@@ -555,7 +555,7 @@ final class DiskMemoryPersistenceTestCase: XCTestCase {
 
     func testRemoveAll_WhenEmpty_ShouldSucceed() {
         let testName = "testRemoveAll_WhenEmpty_ShouldSucceed"
-        let sizeLimit = UInt64(Float(mrMinderSize) * 1.5) // add some "margin" because of filesystem extra bytes
+        let sizeLimit = Int64(Float(mrMinderSize) * 1.5) // add some "margin" because of filesystem extra bytes
         let persistence = diskMemoryPersistence(withDiskLimit: sizeLimit,
                                                 memLimit: sizeLimit,
                                                 extraPath: testName,
@@ -577,7 +577,7 @@ final class DiskMemoryPersistenceTestCase: XCTestCase {
 
     func testRemoveAll_WhenNotEmpty_ShouldSucceed() {
         let testName = "testRemoveAll_WhenNotEmpty_ShouldSucceed"
-        let sizeLimit = UInt64(Float(mrMinderSize) * 1.5) // add some "margin" because of filesystem extra bytes
+        let sizeLimit = Int64(Float(mrMinderSize) * 1.5) // add some "margin" because of filesystem extra bytes
         let persistence = diskMemoryPersistence(withDiskLimit: sizeLimit,
                                                 memLimit: sizeLimit,
                                                 extraPath: testName)
@@ -623,8 +623,8 @@ fileprivate let testPath = cachePath + "/test"
 
 fileprivate let mrMinder = imageFromFile(withName: "mr-minder", type: "png")
 
-fileprivate func diskMemoryPersistence(withDiskLimit diskLimit: UInt64,
-                                       memLimit: UInt64,
+fileprivate func diskMemoryPersistence(withDiskLimit diskLimit: Int64,
+                                       memLimit: Int64,
                                        extraPath: String = "test",
                                        performanceMetrics: PersistencePerformanceMetricsTracker? = nil,
                                        readQueue: DispatchQueue? = nil,
@@ -658,7 +658,7 @@ fileprivate var mrMinderData: Data = {
     return data
 }()
 
-fileprivate var mrMinderSize: UInt64 = UInt64((mrMinderData as NSData).length)
+fileprivate var mrMinderSize: Int64 = Int64((mrMinderData as NSData).length)
 
 fileprivate func fileExists(_ path: String) -> Bool {
     let finalPath = cachePath + "/" + path

--- a/Tests/AlicerceTests/Persistence/PersistencePerformanceMetricsTrackerTestCase.swift
+++ b/Tests/AlicerceTests/Persistence/PersistencePerformanceMetricsTrackerTestCase.swift
@@ -4,10 +4,10 @@ import XCTest
 class PersistencePerformanceMetricsTrackerTestCase: XCTestCase {
 
     private typealias MemoryAccessStopClosure =
-        (_ result: Result<(blobSize: UInt64, memorySize: UInt64), MockError>) -> Void
+        (_ result: Result<(blobSize: Int64, memorySize: Int64), MockError>) -> Void
 
     private typealias DiskAccessStopClosure =
-        (_ result: Result<(blobSize: UInt64, diskSize: UInt64), MockError>) -> Void
+        (_ result: Result<(blobSize: Int64, diskSize: Int64), MockError>) -> Void
 
     private enum MockError: Error {
         case 💩
@@ -33,8 +33,8 @@ class PersistencePerformanceMetricsTrackerTestCase: XCTestCase {
         let measure = self.expectation(description: "measure")
         defer { waitForExpectations(timeout: 1) }
 
-        let testBlobSize = UInt64(1337)
-        let testUsedMemorySize = UInt64(9001)
+        let testBlobSize = Int64(1337)
+        let testUsedMemorySize = Int64(9001)
         let testReturn = "🚀"
 
         tracker.measureInvokedClosure = { identifier, metadata in
@@ -83,8 +83,8 @@ class PersistencePerformanceMetricsTrackerTestCase: XCTestCase {
         let measure = self.expectation(description: "measure")
         defer { waitForExpectations(timeout: 1) }
 
-        let testBlobSize = UInt64(1337)
-        let testUsedMemorySize = UInt64(9001)
+        let testBlobSize = Int64(1337)
+        let testUsedMemorySize = Int64(9001)
         let testReturn = "🚀"
 
         tracker.measureInvokedClosure = { identifier, metadata in
@@ -133,8 +133,8 @@ class PersistencePerformanceMetricsTrackerTestCase: XCTestCase {
         let measure = self.expectation(description: "measure")
         defer { waitForExpectations(timeout: 1) }
 
-        let testBlobSize = UInt64(1337)
-        let testUsedDiskSize = UInt64(9001)
+        let testBlobSize = Int64(1337)
+        let testUsedDiskSize = Int64(9001)
         let testReturn = "🚀"
 
         tracker.measureInvokedClosure = { identifier, metadata in
@@ -183,8 +183,8 @@ class PersistencePerformanceMetricsTrackerTestCase: XCTestCase {
         let measure = self.expectation(description: "measure")
         defer { waitForExpectations(timeout: 1) }
 
-        let testBlobSize = UInt64(1337)
-        let testUsedDiskSize = UInt64(9001)
+        let testBlobSize = Int64(1337)
+        let testUsedDiskSize = Int64(9001)
         let testReturn = "🚀"
 
         tracker.measureInvokedClosure = { identifier, metadata in


### PR DESCRIPTION
<!-- Thanks for contributing to _Alicerce 🏗_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've rebased my changes on top of `master`
- [x] I've built and run the project to see all new and existing tests pass
- [x] I've followed the [Mindera swift style guide](https://github.com/Mindera/swift-style-guide)
- [x] I've read the [Contribution Guidelines](https://github.com/Mindera/Alicerce/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Use the recommended rule-of-thumb on the [official documentation](https://docs.swift.org/swift-book/LanguageGuide/TheBasics.html#//apple_ref/doc/uid/TP40014097-CH5-XID_411) and use signed integers instead of unsigned integers.

### Description
There aren't many instances of `UInt`, and the majority of them can be repurposed as signed integers, namely the instances related with Persistence, Logger and Token.

The only exceptions seem to be
- `XCT[Fail|AssertEqual|etc.]` methods that use line numbers as a parameter
- `UIColor` hexcode methods
- `Data` SPKI SHA256 Base64 encoded hashes