### PR TITLE
Migrate to Swift 5️⃣.4️⃣

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
   build-test:
     name: Build and Test
-    runs-on: macOS-10.15
+    runs-on: macos-11
     env:
       WORKSPACE: Alicerce.xcworkspace
       SCHEME: Alicerce
@@ -104,7 +104,7 @@ jobs:
 
   carthage:
     name: Carthage Verification
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
       - name: git checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,12 @@ on:
 
 env:
   # https://github.com/actions/virtual-environments/tree/main/images/macos
-  DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_12.5.app/Contents/Developer
 
 jobs:
   env-details:
     name: Environment details
-    runs-on: macOS-10.15
+    runs-on: macOS-11
     steps:
       - name: xcode version
         run: xcodebuild -version -sdk
@@ -60,7 +60,7 @@ jobs:
 
   swiftpm:
     name: SwiftPM Build
-    runs-on: macOS-10.15
+    runs-on: macOS-11
     env:
       PLATFORM_TARGET: x86_64-apple-ios14.0-simulator
     steps:
@@ -75,7 +75,7 @@ jobs:
 
   cocoapods:
     name: CocoaPods Verification
-    runs-on: macOS-10.15
+    runs-on: macOS-11
     steps:
       - name: git checkout
         uses: actions/checkout@v2
@@ -114,7 +114,7 @@ jobs:
 
   release-github:
     name: GitHub Release
-    runs-on: macOS-10.15
+    runs-on: macOS-11
     needs: [build-test, swiftpm, cocoapods, carthage]
     if: startsWith(github.ref, 'refs/tags/')
     steps:
@@ -133,7 +133,7 @@ jobs:
 
   release-cocoapods:
     name: CocoaPods Release
-    runs-on: macOS-10.15
+    runs-on: macOS-11
     needs: [build-test, swiftpm, cocoapods, carthage]
     if: startsWith(github.ref, 'refs/tags/')
     steps:

--- a/Alicerce.podspec
+++ b/Alicerce.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
     s.source        = { :git => 'https://github.com/Mindera/Alicerce.git', :tag => "#{s.version}" }
 
     s.module_name   = 'Alicerce'
-    s.swift_version = '5.3'
+    s.swift_version = '5.4'
 
     s.ios.deployment_target = '10.0'
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![license](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://github.com/Mindera/Alicerce/blob/master/LICENSE)
 [![release](https://img.shields.io/github/release/Mindera/Alicerce.svg)](https://github.com/Mindera/Alicerce/releases)
 ![platforms](https://img.shields.io/badge/platforms-iOS-lightgrey.svg)
-[![Swift 5.3](https://img.shields.io/badge/Swift-5.3-orange.svg?style=flat)](https://developer.apple.com/swift/)
+[![Swift 5.4](https://img.shields.io/badge/Swift-5.4-orange.svg?style=flat)](https://developer.apple.com/swift/)
 [![Carthage](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![CocoaPods](https://img.shields.io/cocoapods/v/Alicerce.svg)](https://cocoapods.org/)
 [![SwiftPM](https://img.shields.io/badge/SwiftPM-compatible-orange.svg)](#swift-package-manager)
@@ -50,10 +50,16 @@ TODO
 
 ## Compatibility ✅
 
-### `0.11.0` ... `master` 
+### `master`
 
 - iOS 10.0+
-- Xcode 12
+- Xcode 12.5
+- Swift 5.4
+
+### `0.11.0` ... `0.12.0` (latest)
+
+- iOS 10.0+
+- Xcode 12.4
 - Swift 5.3
 
 ### `0.9.0` ... `0.10.0`

--- a/Tests/AlicerceTests/AutoLayout/NSLayoutConstraintTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/NSLayoutConstraintTestCase.swift
@@ -62,8 +62,8 @@ final class NSLayoutConstraintTestCase: XCTestCase {
 
     func testWithPriority_WithAnyValue_ShouldReturnItself() {
 
-        XCTAssert(constraint.with(priority: .defaultHigh) === constraint)
-        XCTAssert(constraint.with(priority: .init(666)) === constraint)
+        XCTAssertIdentical(constraint.with(priority: .defaultHigh), constraint)
+        XCTAssertIdentical(constraint.with(priority: .init(666)), constraint)
     }
 
     // MARK: - Activation
@@ -86,7 +86,7 @@ final class NSLayoutConstraintTestCase: XCTestCase {
 
     func testSetActive_WithAnyValue_ShouldReturnItself() {
 
-        XCTAssert(constraint.set(active: false) === constraint)
-        XCTAssert(constraint.set(active: true) === constraint)
+        XCTAssertIdentical(constraint.set(active: false), constraint)
+        XCTAssertIdentical(constraint.set(active: true), constraint)
     }
 }

--- a/Tests/AlicerceTests/AutoLayout/XCTAssertConstraint.swift
+++ b/Tests/AlicerceTests/AutoLayout/XCTAssertConstraint.swift
@@ -11,10 +11,10 @@ func XCTAssertConstraint(
         XCTAssertFalse(item.translatesAutoresizingMaskIntoConstraints, file: file, line: line)
     }
 
-    XCTAssert(constraint1.firstItem === constraint2.firstItem, file: file, line: line)
+    XCTAssertIdentical(constraint1.firstItem, constraint2.firstItem, file: file, line: line)
     XCTAssertEqual(constraint1.firstAttribute, constraint2.firstAttribute, file: file, line: line)
 
-    XCTAssert(constraint1.secondItem === constraint2.secondItem, file: file, line: line)
+    XCTAssertIdentical(constraint1.secondItem, constraint2.secondItem, file: file, line: line)
     XCTAssertEqual(constraint1.secondAttribute, constraint2.secondAttribute, file: file, line: line)
 
     XCTAssertEqual(constraint1.relation, constraint2.relation, file: file, line: line)
@@ -39,10 +39,10 @@ func XCTAssertConstraints(
             XCTAssertFalse(item.translatesAutoresizingMaskIntoConstraints, file: file, line: line)
         }
 
-        XCTAssert(constraint1.firstItem === constraint2.firstItem, file: file, line: line)
+        XCTAssertIdentical(constraint1.firstItem, constraint2.firstItem, file: file, line: line)
         XCTAssertEqual(constraint1.firstAttribute, constraint2.firstAttribute, file: file, line: line)
 
-        XCTAssert(constraint1.secondItem === constraint2.secondItem, file: file, line: line)
+        XCTAssertIdentical(constraint1.secondItem, constraint2.secondItem, file: file, line: line)
         XCTAssertEqual(constraint1.secondAttribute, constraint2.secondAttribute, file: file, line: line)
 
         XCTAssertEqual(constraint1.relation, constraint2.relation, file: file, line: line)

--- a/Tests/AlicerceTests/DeepLinking/Route+TrieRouter_RouteTests.swift
+++ b/Tests/AlicerceTests/DeepLinking/Route+TrieRouter_RouteTests.swift
@@ -556,7 +556,7 @@ class Route_TrieRouter_RouteTests: XCTestCase {
         var handler = TestHandler()
         handler.didHandle = { _route, _, _ in
 
-            XCTAssert(route === _route)
+            XCTAssertIdentical(route, _route)
             handleExpectation.fulfill()
         }
 

--- a/Tests/AlicerceTests/DeepLinking/Route+TrieRouter_UnregisterTests.swift
+++ b/Tests/AlicerceTests/DeepLinking/Route+TrieRouter_UnregisterTests.swift
@@ -294,6 +294,6 @@ private extension Route_TrieRouter_UnregisterTests {
         let registerRoute = initialRoute?.url(file: file, line: line) ?? _route
 
         XCTAssertNoThrow(try router.register(registerRoute, handler: testHandler), file: file, line: line)
-        XCTAssert(try router.unregister(_route) === testHandler, file: file, line: line)
+        XCTAssertIdentical(try router.unregister(_route), testHandler, file: file, line: line)
     }
 }

--- a/Tests/AlicerceTests/Logging/Loggers/MultiLoggerTestCase.swift
+++ b/Tests/AlicerceTests/Logging/Loggers/MultiLoggerTestCase.swift
@@ -176,7 +176,7 @@ class MultiLoggerTestCase: XCTestCase {
 
         let onError: MultiLogger.LogDestinationErrorClosure = { errorDestination, error in
             defer { errorExpectation.fulfill() }
-            XCTAssert((errorDestination as? AnyMetadataLogDestination<MockMetadataKey>)?._wrapped === destination)
+            XCTAssertIdentical((errorDestination as? AnyMetadataLogDestination<MockMetadataKey>)?._wrapped, destination)
             guard case MockError.😱 = error else { return XCTFail("unexpected error \(error)") }
         }
 
@@ -249,7 +249,7 @@ class MultiLoggerTestCase: XCTestCase {
 
         let onError: MultiLogger.LogDestinationErrorClosure = { errorDestination, error in
             defer { errorExpectation.fulfill() }
-            XCTAssert((errorDestination as? AnyMetadataLogDestination<MockMetadataKey>)?._wrapped === destination)
+            XCTAssertIdentical((errorDestination as? AnyMetadataLogDestination<MockMetadataKey>)?._wrapped, destination)
             guard case MockError.😱 = error else { return XCTFail("unexpected error \(error)") }
         }
 
@@ -307,7 +307,7 @@ class MultiLoggerTestCase: XCTestCase {
 
         let onError: MultiLogger.LogDestinationErrorClosure = { errorDestination, error in
             defer { errorExpectation.fulfill() }
-            XCTAssert((errorDestination as? AnyMetadataLogDestination<MockMetadataKey>)?._wrapped === destination)
+            XCTAssertIdentical((errorDestination as? AnyMetadataLogDestination<MockMetadataKey>)?._wrapped, destination)
             guard case MockError.😱 = error else { return XCTFail("unexpected error \(error)") }
         }
 

--- a/Tests/AlicerceTests/Network/Network+BaseRequestMakingTestCase.swift
+++ b/Tests/AlicerceTests/Network/Network+BaseRequestMakingTestCase.swift
@@ -24,7 +24,7 @@ class Network_BaseRequestMakingTestCase: XCTestCase {
             return mockCancelable
         }
 
-        XCTAssert(cancelable === mockCancelable)
+        XCTAssertIdentical(cancelable, mockCancelable)
     }
 
     func testEndpoint_WithFailureEndpointMakeRequest_ShouldReturnFailure() {
@@ -48,6 +48,6 @@ class Network_BaseRequestMakingTestCase: XCTestCase {
             return mockCancelable
         }
 
-        XCTAssert(cancelable === mockCancelable)
+        XCTAssertIdentical(cancelable, mockCancelable)
     }
 }

--- a/Tests/AlicerceTests/Network/NetworkTestCase.swift
+++ b/Tests/AlicerceTests/Network/NetworkTestCase.swift
@@ -13,7 +13,7 @@ class NetworkTestCase: XCTestCase {
         let mappedValue = value.mapValue { v, r in String(v) }
 
         XCTAssertEqual(mappedValue.value, "1337")
-        XCTAssert(mappedValue.response === response)
+        XCTAssertIdentical(mappedValue.response, response)
     }
 
     func testMapValue_WithFailureMap_ShouldThrow() {

--- a/Tests/AlicerceTests/Network/URLSessionNetworkStackTestCase.swift
+++ b/Tests/AlicerceTests/Network/URLSessionNetworkStackTestCase.swift
@@ -701,7 +701,7 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
         let testAuthenticationChallengeHandler = MockAuthenticationChallengeHandler()
         testAuthenticationChallengeHandler.mockHandleClosure = { challenge in
             defer { expectation1.fulfill() }
-            XCTAssert(challenge === testAuthenticationChallenge)
+            XCTAssertIdentical(challenge, testAuthenticationChallenge)
 
             return (testAuthDisposition, testCredential)
         }

--- a/Tests/AlicerceTests/Network/URLSessionResourceInterceptorTestCase.swift
+++ b/Tests/AlicerceTests/Network/URLSessionResourceInterceptorTestCase.swift
@@ -17,7 +17,7 @@ class URLSessionResourceInterceptorTestCase: XCTestCase {
             return mockCancelable
         }
 
-        XCTAssert(cancelable === mockCancelable)
+        XCTAssertIdentical(cancelable, mockCancelable)
     }
 
     func testDefaultInterceptMakeRequestResult_WithFailureResult_ShouldInvokeHandlerAndPropagateResult() {
@@ -32,7 +32,7 @@ class URLSessionResourceInterceptorTestCase: XCTestCase {
             return mockCancelable
         }
 
-        XCTAssert(cancelable === mockCancelable)
+        XCTAssertIdentical(cancelable, mockCancelable)
     }
 
     func testDefaultInterceptFailedTask_ShouldReturnNoneAction() {
@@ -71,7 +71,7 @@ class URLSessionResourceInterceptorTestCase: XCTestCase {
             return mockCancelable
         }
 
-        XCTAssert(cancelable === mockCancelable)
+        XCTAssertIdentical(cancelable, mockCancelable)
     }
 
     func testAuthenticatorInterceptMakeRequestResult_WithFailureResult_ShouldInvokeHandlerAndPropagateResult() {
@@ -86,7 +86,7 @@ class URLSessionResourceInterceptorTestCase: XCTestCase {
             return mockCancelable
         }
 
-        XCTAssert(cancelable === mockCancelable)
+        XCTAssertIdentical(cancelable, mockCancelable)
     }
 
     func testAuthenticatorInterceptFailedTask_ShouldReturnAuthenticatorAction() {

--- a/Tests/AlicerceTests/Utils/BuilderCacheTestCase.swift
+++ b/Tests/AlicerceTests/Utils/BuilderCacheTestCase.swift
@@ -78,7 +78,7 @@ class BuilderCacheTestCase: XCTestCase {
         let dateFormatter1 = cache.object(SimpleDateFormatterKey("yyyy-MM-dd'T'HH:mm:ssZ"))
         let dateFormatter2 = cache.object(SimpleDateFormatterKey("yyyy-MM-dd'T'HH:mm:ssZ"))
 
-        XCTAssertTrue(dateFormatter1 === dateFormatter2)
+        XCTAssertIdentical(dateFormatter1, dateFormatter2)
     }
 
     func testCache_WithSameComplexKey_ShouldReturnSameObject() {
@@ -86,7 +86,7 @@ class BuilderCacheTestCase: XCTestCase {
         let dateFormatter1 = cache.object(ComplexDateFormatterKey.utc(dateFormat: "yyyy-MM-dd'T'HH:mm:ssZ"))
         let dateFormatter2 = cache.object(ComplexDateFormatterKey.utc(dateFormat: "yyyy-MM-dd'T'HH:mm:ssZ"))
 
-        XCTAssertTrue(dateFormatter1 === dateFormatter2)
+        XCTAssertIdentical(dateFormatter1, dateFormatter2)
     }
 
     func testCache_WithDifferentSimpleKeys_ShouldReturnDifferentObjects() {
@@ -94,7 +94,7 @@ class BuilderCacheTestCase: XCTestCase {
         let dateFormatter1 = cache.object(SimpleDateFormatterKey("yyyy-MM-dd'T'HH:mm:ssZ"))
         let dateFormatter2 = cache.object(SimpleDateFormatterKey("yyyy-MM-dd'T'HH:mm:ss"))
 
-        XCTAssertFalse(dateFormatter1 === dateFormatter2)
+        XCTAssertNotIdentical(dateFormatter1, dateFormatter2)
     }
 
     func testCache_WithDifferentComplexKey_ShouldReturnDifferentObjects() {
@@ -102,7 +102,7 @@ class BuilderCacheTestCase: XCTestCase {
         let dateFormatter1 = cache.object(ComplexDateFormatterKey.utc(dateFormat: "yyyy-MM-dd'T'HH:mm:ssZ"))
         let dateFormatter2 = cache.object(ComplexDateFormatterKey.local(dateFormat: "yyyy-MM-dd'T'HH:mm:ssZ"))
 
-        XCTAssertFalse(dateFormatter1 === dateFormatter2)
+        XCTAssertNotIdentical(dateFormatter1, dateFormatter2)
     }
 
     func testCache_WithDifferentKeyTypes_ShouldReturnDifferentObjects() {
@@ -110,7 +110,7 @@ class BuilderCacheTestCase: XCTestCase {
         let dateFormatter1 = cache.object(SimpleDateFormatterKey("yyyy-MM-dd'T'HH:mm:ssZ"))
         let dateFormatter2 = cache.object(ComplexDateFormatterKey.utc(dateFormat: "yyyy-MM-dd'T'HH:mm:ssZ"))
 
-        XCTAssertFalse(dateFormatter1 === dateFormatter2)
+        XCTAssertNotIdentical(dateFormatter1, dateFormatter2)
     }
 
     func testCache_WithEvict_ShouldGenerateNewObject() {
@@ -119,7 +119,7 @@ class BuilderCacheTestCase: XCTestCase {
         cache.evict(SimpleDateFormatterKey("yyyy-MM-dd'T'HH:mm:ssZ"))
         let dateFormatter2 = cache.object(SimpleDateFormatterKey("yyyy-MM-dd'T'HH:mm:ssZ"))
 
-        XCTAssertFalse(dateFormatter1 === dateFormatter2)
+        XCTAssertNotIdentical(dateFormatter1, dateFormatter2)
     }
 
 
@@ -129,6 +129,6 @@ class BuilderCacheTestCase: XCTestCase {
         cache.evictAll()
         let dateFormatter2 = cache.object(SimpleDateFormatterKey("yyyy-MM-dd'T'HH:mm:ssZ"))
 
-        XCTAssertFalse(dateFormatter1 === dateFormatter2)
+        XCTAssertNotIdentical(dateFormatter1, dateFormatter2)
     }
 }


### PR DESCRIPTION
### Checklist
- [x] I've rebased my changes on top of `master`
- [x] I've built and run the project to see all new and existing tests pass
- [x] I've followed the [Mindera swift style guide](https://github.com/Mindera/swift-style-guide)
- [x] I've read the [Contribution Guidelines](https://github.com/Mindera/Alicerce/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

Until recently, macOS 11 images were only available privately in GH Actions, but apparently they can now be used by everyone (again). This means that Xcode 12.5 and Swift 5.4 are now available.

We still needed to fill out a form, which I just did and was approved ✅  

Reference: actions/virtual-environments#2486, [macos-11-onboarding.md](https://github.com/actions/virtual-environments/blob/main/docs/macos-11-onboarding.md)

### Description

- Update `ci.yml` macOS image to `macOS-11`.

- Update `ci.yml` `DEVELOPER_DIR` to point to Xcode 12.5.

- Update podspec's `swift_version` to 5.4.

- Update `README.md`.

- Migrate `XCTAssert`'s that compared references via `===` to use the new `XCTAssertIdentical` and `XCTAssertNotIdentical` XCTest APIs.
