### PR TITLE
Improve `EdgesConstrainableProxy` API ↔️

### DIFF
--- a/Alicerce.podspec
+++ b/Alicerce.podspec
@@ -32,6 +32,7 @@ Pod::Spec.new do |s|
 
     s.subspec 'AutoLayout' do |ss|
         ss.source_files = 'Sources/AutoLayout/*.swift'
+        ss.dependency 'Alicerce/Extensions/UIKit'
         ss.frameworks   = 'UIKit'
     end
 

--- a/Alicerce.xcodeproj/project.pbxproj
+++ b/Alicerce.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		0A09A1AA20EEEA5A008EFAF3 /* PerformanceMetricsTrackerTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A09A1A620EEEA28008EFAF3 /* PerformanceMetricsTrackerTestCase.swift */; };
 		0A1083E220CD8322003969AB /* DispatchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1083E120CD8322003969AB /* DispatchQueue.swift */; };
 		0A1083E520CDA8AF003969AB /* MockLogLevelFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1083E320CDA8AA003969AB /* MockLogLevelFormatter.swift */; };
+		0A10F21B27172B15006CBA7A /* UIEdgeInsetsTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A10F21A27172B15006CBA7A /* UIEdgeInsetsTestCase.swift */; };
+		0A10F21D27172B8F006CBA7A /* NSDirectionalEdgeInsetsTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A10F21C27172B8F006CBA7A /* NSDirectionalEdgeInsetsTestCase.swift */; };
 		0A11894820F3BAB800AF8229 /* MockPerformanceMetricsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A11894620F3BA2400AF8229 /* MockPerformanceMetricsTracker.swift */; };
 		0A11894920F3C9E900AF8229 /* PerformanceMetrics+MultiTrackerTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A09A1A820EEEA4B008EFAF3 /* PerformanceMetrics+MultiTrackerTestCase.swift */; };
 		0A11894B20F3CB6800AF8229 /* StackOrchestratorPerformanceMetricsTrackerTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A11894A20F3CB6800AF8229 /* StackOrchestratorPerformanceMetricsTrackerTestCase.swift */; };
@@ -45,6 +47,8 @@
 		0A166EE42210B8BB00EC6686 /* CoreDataStack+CRUD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A166EE32210B8BB00EC6686 /* CoreDataStack+CRUD.swift */; };
 		0A166EE62210C15F00EC6686 /* CoreDataStack+Factories.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A166EE52210C15F00EC6686 /* CoreDataStack+Factories.swift */; };
 		0A166EE92210C59200EC6686 /* TestEntity+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A166EE72210C58300EC6686 /* TestEntity+Utils.swift */; };
+		0A26025D2717020200A8E8A6 /* UIEdgeInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A26025C2717020200A8E8A6 /* UIEdgeInsets.swift */; };
+		0A26025F2717027300A8E8A6 /* NSDirectionalEdgeInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A26025E2717027300A8E8A6 /* NSDirectionalEdgeInsets.swift */; };
 		0A265E1D20EAEA8A00A55ED9 /* BoxTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A265E1C20EAEA8A00A55ED9 /* BoxTestCase.swift */; };
 		0A265E1F20EAEC7500A55ED9 /* URLRequestTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A265E1E20EAEC7500A55ED9 /* URLRequestTestCase.swift */; };
 		0A265E2120EAEEB900A55ED9 /* HTTPTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A265E2020EAEEB900A55ED9 /* HTTPTestCase.swift */; };
@@ -367,6 +371,8 @@
 		0A09A1A820EEEA4B008EFAF3 /* PerformanceMetrics+MultiTrackerTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PerformanceMetrics+MultiTrackerTestCase.swift"; sourceTree = "<group>"; };
 		0A1083E120CD8322003969AB /* DispatchQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchQueue.swift; sourceTree = "<group>"; };
 		0A1083E320CDA8AA003969AB /* MockLogLevelFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockLogLevelFormatter.swift; sourceTree = "<group>"; };
+		0A10F21A27172B15006CBA7A /* UIEdgeInsetsTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIEdgeInsetsTestCase.swift; sourceTree = "<group>"; };
+		0A10F21C27172B8F006CBA7A /* NSDirectionalEdgeInsetsTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSDirectionalEdgeInsetsTestCase.swift; sourceTree = "<group>"; };
 		0A11894620F3BA2400AF8229 /* MockPerformanceMetricsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPerformanceMetricsTracker.swift; sourceTree = "<group>"; };
 		0A11894A20F3CB6800AF8229 /* StackOrchestratorPerformanceMetricsTrackerTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StackOrchestratorPerformanceMetricsTrackerTestCase.swift; sourceTree = "<group>"; };
 		0A11894C20F416EB00AF8229 /* PersistencePerformanceMetricsTrackerTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistencePerformanceMetricsTrackerTestCase.swift; sourceTree = "<group>"; };
@@ -377,6 +383,8 @@
 		0A166EE32210B8BB00EC6686 /* CoreDataStack+CRUD.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CoreDataStack+CRUD.swift"; sourceTree = "<group>"; };
 		0A166EE52210C15F00EC6686 /* CoreDataStack+Factories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CoreDataStack+Factories.swift"; sourceTree = "<group>"; };
 		0A166EE72210C58300EC6686 /* TestEntity+Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TestEntity+Utils.swift"; sourceTree = "<group>"; };
+		0A26025C2717020200A8E8A6 /* UIEdgeInsets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIEdgeInsets.swift; sourceTree = "<group>"; };
+		0A26025E2717027300A8E8A6 /* NSDirectionalEdgeInsets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSDirectionalEdgeInsets.swift; sourceTree = "<group>"; };
 		0A265E1C20EAEA8A00A55ED9 /* BoxTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoxTestCase.swift; sourceTree = "<group>"; };
 		0A265E1E20EAEC7500A55ED9 /* URLRequestTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLRequestTestCase.swift; sourceTree = "<group>"; };
 		0A265E2020EAEEB900A55ED9 /* HTTPTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPTestCase.swift; sourceTree = "<group>"; };
@@ -900,7 +908,9 @@
 			children = (
 				0A266F0E1ED33B65009CD0D7 /* CAGradientLayer.swift */,
 				0A266F0C1ED33B34009CD0D7 /* CALayer.swift */,
+				0A26025E2717027300A8E8A6 /* NSDirectionalEdgeInsets.swift */,
 				0A3C2CBE1EA7E18500EFB7D4 /* UIColor.swift */,
+				0A26025C2717020200A8E8A6 /* UIEdgeInsets.swift */,
 				1BBEB6081F333E5600D06526 /* UIImage.swift */,
 				0A3C2CBF1EA7E18500EFB7D4 /* UIViewController.swift */,
 			);
@@ -994,7 +1004,9 @@
 		0A3C2D381EA7E1EE00EFB7D4 /* UIKit */ = {
 			isa = PBXGroup;
 			children = (
+				0A10F21C27172B8F006CBA7A /* NSDirectionalEdgeInsetsTestCase.swift */,
 				0A3C2D391EA7E1EE00EFB7D4 /* UIColorTestCase.swift */,
+				0A10F21A27172B15006CBA7A /* UIEdgeInsetsTestCase.swift */,
 				1BBEB60A1F333E6600D06526 /* UIImageTestCase.swift */,
 				0A3C2D3A1EA7E1EE00EFB7D4 /* UIViewControllerTestCase.swift */,
 			);
@@ -1803,6 +1815,7 @@
 				0A85F0E720B3177E0095AFFB /* PublicKeyAlgorithmTestCase.swift in Sources */,
 				0A266F901ED59FB6009CD0D7 /* Route+ComponentTests.swift in Sources */,
 				0A266F911ED59FB6009CD0D7 /* Route+TrieNode_AddTests.swift in Sources */,
+				0A10F21B27172B15006CBA7A /* UIEdgeInsetsTestCase.swift in Sources */,
 				0A7CC0F1208FF76B009F3A6E /* DictionaryTests.swift in Sources */,
 				0A266F921ED59FB6009CD0D7 /* Route+TrieNode_InitTests.swift in Sources */,
 				0A266F931ED59FB6009CD0D7 /* Route+TrieNode_MatchTests.swift in Sources */,
@@ -1821,6 +1834,7 @@
 				0A11894D20F416EB00AF8229 /* PersistencePerformanceMetricsTrackerTestCase.swift in Sources */,
 				0A266F981ED59FB6009CD0D7 /* ThreadTestCase.swift in Sources */,
 				0AEEE11020CF1E4900B47687 /* BashLogLevelFormatterTestCase.swift in Sources */,
+				0A10F21D27172B8F006CBA7A /* NSDirectionalEdgeInsetsTestCase.swift in Sources */,
 				0A266F9A1ED59FB6009CD0D7 /* ConsoleLogDestinationTestCase.swift in Sources */,
 				0AB34A062085385A001F2979 /* UnfairLockTestCase.swift in Sources */,
 				0A266F9B1ED59FB6009CD0D7 /* MockMetadataLogDestination.swift in Sources */,
@@ -1997,6 +2011,7 @@
 				1B4033581ED8927E00B4B03D /* ViewModelCollectionViewCell.swift in Sources */,
 				0A3C2D8C1EA7E5DD00EFB7D4 /* Router.swift in Sources */,
 				0A3C2D8E1EA7E5DD00EFB7D4 /* Dictionary.swift in Sources */,
+				0A26025F2717027300A8E8A6 /* NSDirectionalEdgeInsets.swift in Sources */,
 				73C6051B20F3BBA300D0B643 /* Token.swift in Sources */,
 				0A266F0F1ED33B65009CD0D7 /* CAGradientLayer.swift in Sources */,
 				0ACFA72F20AEC92700D2E280 /* AuthenticationChallengeHandler.swift in Sources */,
@@ -2040,6 +2055,7 @@
 				0A90843A1EBCBFB200616076 /* ReusableView.swift in Sources */,
 				1B667A0C20127C7000A8CD5A /* StackOrchestratorPerformanceMetricsTracker.swift in Sources */,
 				0A83885D1EB1F6B000C1E835 /* NSManagedObjectContext+CoreDataStack.swift in Sources */,
+				0A26025D2717020200A8E8A6 /* UIEdgeInsets.swift in Sources */,
 				0ACFA73120AEC95C00D2E280 /* PublicKeyAlgorithm.swift in Sources */,
 				0A3C2D9E1EA7E5DD00EFB7D4 /* LogDestination.swift in Sources */,
 				0A9084391EBCBFB200616076 /* NibView.swift in Sources */,

--- a/Package.swift
+++ b/Package.swift
@@ -50,7 +50,7 @@ let package = Package(
 
         // multi module targets
         .target(name: "AlicerceAnalytics", dependencies: ["AlicerceCore"], path: "Sources/Analytics"),
-        .target(name: "AlicerceAutoLayout", path: "Sources/AutoLayout"),
+        .target(name: "AlicerceAutoLayout", dependencies: ["AlicerceExtensions"], path: "Sources/AutoLayout"),
         .target(
             name: "AlicerceCore",
             dependencies: ["AlicerceExtensions"],

--- a/Sources/AutoLayout/ConstrainableProxy.swift
+++ b/Sources/AutoLayout/ConstrainableProxy.swift
@@ -1,5 +1,8 @@
 // swiftlint:disable file_length function_parameter_count
 
+#if canImport(AlicerceExtensions)
+import AlicerceExtensions
+#endif
 import UIKit
 
 public protocol ConstrainableProxy: AnyObject {
@@ -377,18 +380,52 @@ public extension EdgesConstrainableProxy {
     func edges(
         to anotherProxy: EdgesConstrainableProxy,
         insets: UIEdgeInsets = .zero,
-        relation: ConstraintRelation = .equal,
-        priority: UILayoutPriority = .required
+        topRelation: ConstraintRelation = .equal,
+        topPriority: UILayoutPriority = .required,
+        leadingRelation: ConstraintRelation = .equal,
+        leadingPriority: UILayoutPriority = .required,
+        bottomRelation: ConstraintRelation = .equal,
+        bottomPriority: UILayoutPriority = .required,
+        trailingRelation: ConstraintRelation = .equal,
+        trailingPriority: UILayoutPriority = .required
     ) -> [NSLayoutConstraint] {
 
-        let constraints: [NSLayoutConstraint] = [
-            top(to: anotherProxy, offset: insets.top, relation: relation, priority: priority),
-            leading(to: anotherProxy, offset: insets.left, relation: relation, priority: priority),
-            bottom(to: anotherProxy, offset: -insets.bottom, relation: relation, priority: priority),
-            trailing(to: anotherProxy, offset: -insets.right, relation: relation, priority: priority)
+        [
+            top(to: anotherProxy, offset: insets.top, relation: topRelation, priority:topPriority),
+            leading(to: anotherProxy, offset: insets.left, relation: leadingRelation, priority: leadingPriority),
+            bottom(to: anotherProxy, offset: -insets.bottom, relation: bottomRelation, priority: bottomPriority),
+            trailing(to: anotherProxy, offset: -insets.right, relation: trailingRelation, priority: trailingPriority)
         ]
+    }
 
-        return constraints
+    @_disfavoredOverload
+    @available(iOS 11.0, *)
+    @discardableResult
+    func edges(
+        to anotherProxy: EdgesConstrainableProxy,
+        directionalInsets insets: NSDirectionalEdgeInsets = .zero,
+        topRelation: ConstraintRelation = .equal,
+        topPriority: UILayoutPriority = .required,
+        leadingRelation: ConstraintRelation = .equal,
+        leadingPriority: UILayoutPriority = .required,
+        bottomRelation: ConstraintRelation = .equal,
+        bottomPriority: UILayoutPriority = .required,
+        trailingRelation: ConstraintRelation = .equal,
+        trailingPriority: UILayoutPriority = .required
+    ) -> [NSLayoutConstraint] {
+
+        edges(
+            to: anotherProxy,
+            insets: insets.nonDirectional,
+            topRelation: topRelation,
+            topPriority: topPriority,
+            leadingRelation: leadingRelation,
+            leadingPriority: leadingPriority,
+            bottomRelation: bottomRelation,
+            bottomPriority: bottomPriority,
+            trailingRelation: trailingRelation,
+            trailingPriority: trailingPriority
+        )
     }
 }
 

--- a/Sources/Extensions/UIKit/NSDirectionalEdgeInsets.swift
+++ b/Sources/Extensions/UIKit/NSDirectionalEdgeInsets.swift
@@ -1,0 +1,7 @@
+import UIKit
+
+@available(iOS 11.0, *)
+extension NSDirectionalEdgeInsets {
+
+    public var nonDirectional: UIEdgeInsets { .init(top: top, left: leading, bottom: bottom, right: trailing) }
+}

--- a/Sources/Extensions/UIKit/UIEdgeInsets.swift
+++ b/Sources/Extensions/UIKit/UIEdgeInsets.swift
@@ -1,0 +1,7 @@
+import UIKit
+
+extension UIEdgeInsets {
+
+    @available(iOS 11.0, *)
+    public var directional: NSDirectionalEdgeInsets { .init(top: top, leading: left, bottom: bottom, trailing: right) }
+}

--- a/Tests/AlicerceTests/AutoLayout/EdgesConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/EdgesConstrainableProxyTestCase.swift
@@ -26,6 +26,8 @@ final class EdgesConstrainableProxyTestCase: XCTestCase {
         super.tearDown()
     }
 
+    // MARK: - UIEdgeInsets variant
+
     func testConstrain_WithEdgesConstraints_ShouldSupportRelativeEquality() {
 
         var constraints: [NSLayoutConstraint]!
@@ -45,14 +47,27 @@ final class EdgesConstrainableProxyTestCase: XCTestCase {
         var constraints1: [NSLayoutConstraint]!
         var constraints2: [NSLayoutConstraint]!
         constrain(host, view) { host, view in
-            constraints1 = view.edges(to: host, relation: .equalOrLess)
-            constraints2 = view.edges(to: host, relation: .equalOrGreater)
+            constraints1 = view.edges(to: host, topRelation: .equalOrLess, bottomRelation: .equalOrGreater)
+            constraints2 = view.edges(to: host, leadingRelation: .equalOrGreater, trailingRelation: .equalOrLess)
         }
 
-        XCTAssertEdgesConstraints(constraints1, expectedConstraints(view: view, to: host, relation: .lessThanOrEqual))
+        XCTAssertEdgesConstraints(
+            constraints1,
+            expectedConstraints(
+                view: view,
+                to: host,
+                topRelation: .lessThanOrEqual,
+                bottomRelation: .greaterThanOrEqual
+            )
+        )
         XCTAssertEdgesConstraints(
             constraints2,
-            expectedConstraints(view: view, to: host, relation: .greaterThanOrEqual)
+            expectedConstraints(
+                view: view,
+                to: host,
+                leadingRelation: .greaterThanOrEqual,
+                trailingRelation: .lessThanOrEqual
+            )
         )
 
         host.layoutIfNeeded()
@@ -80,10 +95,26 @@ final class EdgesConstrainableProxyTestCase: XCTestCase {
 
         var constraints: [NSLayoutConstraint]!
         constrain(host, view) { host, view in
-            constraints = view.edges(to: host, priority: .init(666))
+            constraints = view.edges(
+                to: host,
+                topPriority: .init(666),
+                leadingPriority: .init(222),
+                bottomPriority: .init(999),
+                trailingPriority: .init(444)
+            )
         }
 
-        XCTAssertEdgesConstraints(constraints, expectedConstraints(view: view, to: host, priority: .init(666)))
+        XCTAssertEdgesConstraints(
+            constraints,
+            expectedConstraints(
+                view: view,
+                to: host,
+                topPriority: .init(666),
+                leadingPriority: .init(222),
+                bottomPriority: .init(999),
+                trailingPriority: .init(444)
+            )
+        )
     }
 
     func testConstrain_WithEdgesConstraintsAndTwoConstraintGroups_ShouldReturnCorrectIsActiveConstraint() {
@@ -124,6 +155,154 @@ final class EdgesConstrainableProxyTestCase: XCTestCase {
         XCTAssertFalse(constraintGroup0.isActive)
         XCTAssert(constraintGroup1.isActive)
         XCTAssertEqual(view.frame, host.frame.inset(by: insets))
+    }
+
+    // MARK: - NSDirectionalEdgeInsets variant
+
+    @available(iOS 11.0, *)
+    func testConstrain_WithDirectionalEdgesConstraints_ShouldSupportRelativeEquality() {
+
+        var constraints: [NSLayoutConstraint]!
+        constrain(host, view) { host, view in
+            constraints = view.edges(to: host, directionalInsets: .zero)
+        }
+
+        XCTAssertEdgesConstraints(constraints, expectedDirectionalConstraints(view: view, to: host))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame, host.frame)
+    }
+
+    @available(iOS 11.0, *)
+    func testConstrain_withDirectionalEdgesConstraints_ShouldSupportRelativeInequalities() {
+
+        var constraints1: [NSLayoutConstraint]!
+        var constraints2: [NSLayoutConstraint]!
+        constrain(host, view) { host, view in
+            constraints1 = view.edges(
+                to: host,
+                directionalInsets: .zero,
+                topRelation: .equalOrLess,
+                bottomRelation: .equalOrGreater
+            )
+            constraints2 = view.edges(
+                to: host,
+                directionalInsets: .zero,
+                leadingRelation: .equalOrGreater,
+                trailingRelation: .equalOrLess
+            )
+        }
+
+        XCTAssertEdgesConstraints(
+            constraints1,
+            expectedDirectionalConstraints(
+                view: view,
+                to: host,
+                topRelation: .lessThanOrEqual,
+                bottomRelation: .greaterThanOrEqual
+            )
+        )
+        XCTAssertEdgesConstraints(
+            constraints2,
+            expectedDirectionalConstraints(
+                view: view,
+                to: host,
+                leadingRelation: .greaterThanOrEqual,
+                trailingRelation: .lessThanOrEqual
+            )
+        )
+
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame, host.frame)
+    }
+
+    @available(iOS 11.0, *)
+    func testConstrain_WithDirectionalEdgesConstraints_ShouldSupportInsets() {
+
+        let insets = NSDirectionalEdgeInsets(top: 10, leading: 20, bottom: 30, trailing: 40)
+
+        var constraints: [NSLayoutConstraint]!
+        constrain(host, view) { host, view in
+            constraints = view.edges(to: host, directionalInsets: insets)
+        }
+
+        XCTAssertEdgesConstraints(constraints, expectedDirectionalConstraints(view: view, to: host, constants: insets))
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view.frame, host.frame.inset(by: insets.nonDirectional))
+    }
+
+    @available(iOS 11.0, *)
+    func testConstrain_WithDirectionalEdgesConstraints_ShouldSupportCustomPriority() {
+
+        var constraints: [NSLayoutConstraint]!
+        constrain(host, view) { host, view in
+            constraints = view.edges(
+                to: host,
+                directionalInsets: .zero,
+                topPriority: .init(666),
+                leadingPriority: .init(222),
+                bottomPriority: .init(999),
+                trailingPriority: .init(444)
+            )
+        }
+
+        XCTAssertEdgesConstraints(
+            constraints,
+            expectedDirectionalConstraints(
+                view: view,
+                to: host,
+                topPriority: .init(666),
+                leadingPriority: .init(222),
+                bottomPriority: .init(999),
+                trailingPriority: .init(444)
+            )
+        )
+    }
+
+    @available(iOS 11.0, *)
+    func testConstrain_WithDirectionalEdgesConstraintsAndTwoConstraintGroups_ShouldReturnCorrectIsActiveConstraint() {
+
+        var constraints0: [NSLayoutConstraint]!
+        var constraints1: [NSLayoutConstraint]!
+
+        let insets = NSDirectionalEdgeInsets(top: 100, leading: 100, bottom: 100, trailing: 100)
+
+        let constraintGroup0 = constrain(host, view, activate: false) { host, view in
+            constraints0 = view.edges(to: host, directionalInsets: .zero)
+        }
+
+        let constraintGroup1 = constrain(host, view, activate: false) { host, view in
+            constraints1 = view.edges(to: host, directionalInsets: insets)
+        }
+
+        XCTAssertEdgesConstraints(constraints0, expectedDirectionalConstraints(view: view, to: host, active: false))
+        XCTAssertEdgesConstraints(
+            constraints1,
+            expectedDirectionalConstraints(view: view, to: host, constants: insets, active: false)
+        )
+
+        constraintGroup0.isActive = true
+
+        host.layoutIfNeeded()
+
+        XCTAssert(constraintGroup0.isActive)
+        XCTAssertFalse(constraintGroup1.isActive)
+        XCTAssertEqual(view.frame, host.frame)
+
+        constraintGroup0.isActive = false
+        constraintGroup1.isActive = true
+
+        host.setNeedsLayout()
+        host.layoutIfNeeded()
+
+        XCTAssertFalse(constraintGroup0.isActive)
+        XCTAssert(constraintGroup1.isActive)
+        XCTAssertEqual(view.frame, host.frame.inset(by: insets.nonDirectional))
     }
 }
 
@@ -194,9 +373,15 @@ private extension EdgesConstrainableProxyTestCase {
     private func expectedConstraints(
         view: UIView,
         to host: UIView,
-        relation: NSLayoutConstraint.Relation = .equal,
-        priority: UILayoutPriority = .required,
         constants: UIEdgeInsets = .zero,
+        topRelation: NSLayoutConstraint.Relation = .equal,
+        topPriority: UILayoutPriority = .required,
+        leadingRelation: NSLayoutConstraint.Relation = .equal,
+        leadingPriority: UILayoutPriority = .required,
+        bottomRelation: NSLayoutConstraint.Relation = .equal,
+        bottomPriority: UILayoutPriority = .required,
+        trailingRelation: NSLayoutConstraint.Relation = .equal,
+        trailingPriority: UILayoutPriority = .required,
         active: Bool = true
     ) -> [NSLayoutConstraint] {
 
@@ -204,47 +389,79 @@ private extension EdgesConstrainableProxyTestCase {
             NSLayoutConstraint(
                 item: view,
                 attribute: .top,
-                relatedBy: relation,
+                relatedBy: topRelation,
                 toItem: host,
                 attribute: .top,
                 multiplier: 1,
                 constant: constants.top,
-                priority: priority,
+                priority: topPriority,
                 active: active
             ),
             NSLayoutConstraint(
                 item: view,
                 attribute: .leading,
-                relatedBy: relation,
+                relatedBy: leadingRelation,
                 toItem: host,
                 attribute: .leading,
                 multiplier: 1,
                 constant: constants.left,
-                priority: priority,
+                priority: leadingPriority,
                 active: active
             ),
             NSLayoutConstraint(
                 item: view,
                 attribute: .bottom,
-                relatedBy: relation,
+                relatedBy: bottomRelation,
                 toItem: host,
                 attribute: .bottom,
                 multiplier: 1,
                 constant: -constants.bottom,
-                priority: priority,
+                priority: bottomPriority,
                 active: active
             ),
             NSLayoutConstraint(
                 item: view,
                 attribute: .trailing,
-                relatedBy: relation,
+                relatedBy: trailingRelation,
                 toItem: host,
                 attribute: .trailing,
                 multiplier: 1,
                 constant: -constants.right,
-                priority: priority,
+                priority: trailingPriority,
                 active: active
             )
         ]
+    }
+
+    @available(iOS 11.0, *)
+    private func expectedDirectionalConstraints(
+        view: UIView,
+        to host: UIView,
+        constants: NSDirectionalEdgeInsets = .zero,
+        topRelation: NSLayoutConstraint.Relation = .equal,
+        topPriority: UILayoutPriority = .required,
+        leadingRelation: NSLayoutConstraint.Relation = .equal,
+        leadingPriority: UILayoutPriority = .required,
+        bottomRelation: NSLayoutConstraint.Relation = .equal,
+        bottomPriority: UILayoutPriority = .required,
+        trailingRelation: NSLayoutConstraint.Relation = .equal,
+        trailingPriority: UILayoutPriority = .required,
+        active: Bool = true
+    ) -> [NSLayoutConstraint] {
+
+        expectedConstraints(
+            view: view,
+            to: host,
+            constants: constants.nonDirectional,
+            topRelation: topRelation,
+            topPriority: topPriority,
+            leadingRelation: leadingRelation,
+            leadingPriority: leadingPriority,
+            bottomRelation: bottomRelation,
+            bottomPriority: bottomPriority,
+            trailingRelation: trailingRelation,
+            trailingPriority: trailingPriority,
+            active: active
+        )
     }
 }

--- a/Tests/AlicerceTests/Extensions/UIKit/NSDirectionalEdgeInsetsTestCase.swift
+++ b/Tests/AlicerceTests/Extensions/UIKit/NSDirectionalEdgeInsetsTestCase.swift
@@ -1,0 +1,16 @@
+import XCTest
+import UIKit
+
+@testable import Alicerce
+
+@available(iOS 11.0, *)
+final class NSDirectionalEdgeInsetsTestCase: XCTestCase {
+
+    func test_nonDirectional_ShouldReturnInstanceWithCorrectValues() {
+
+        XCTAssertEqual(
+            NSDirectionalEdgeInsets(top: 1, leading: 2, bottom: 3, trailing: 4).nonDirectional,
+            UIEdgeInsets(top: 1, left: 2, bottom: 3, right: 4)
+        )
+    }
+}

--- a/Tests/AlicerceTests/Extensions/UIKit/UIEdgeInsetsTestCase.swift
+++ b/Tests/AlicerceTests/Extensions/UIKit/UIEdgeInsetsTestCase.swift
@@ -1,0 +1,16 @@
+import XCTest
+import UIKit
+
+@testable import Alicerce
+
+final class UIEdgeInsetsTestCase: XCTestCase {
+
+    @available(iOS 11.0, *)
+    func test_directional_ShouldReturnInstanceWithCorrectValues() {
+
+        XCTAssertEqual(
+            UIEdgeInsets(top: 1, left: 2, bottom: 3, right: 4).directional,
+            NSDirectionalEdgeInsets(top: 1, leading: 2, bottom: 3, trailing: 4)
+        )
+    }
+}


### PR DESCRIPTION
### Checklist
- [x] I've rebased my changes on top of `master`
- [x] I've built and run the project to see all new and existing tests pass
- [x] I've followed the [Mindera swift style guide](https://github.com/Mindera/swift-style-guide)
- [x] I've read the [Contribution Guidelines](https://github.com/Mindera/Alicerce/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Until now, it wasn't possible to define edges constraints using a `NSDirectionalEdgeInsets` value, requiring one to convert them to `UIEdgeInsets`.

Additionally, the `EdgesConstrainableProxy.edges()` API only received a single `relation` and `priority` parameters for all edges, which is often not ideal in real scenarios. Some examples are: 
 - allow a single edge constraint to "break"with a smaller `priority` and not others
 - allow edges to "shrink" towards the center, where the `relation` needs to be inverted between `leading`/`trailing` or `top`/`bottom`.

To address the above, a new overload was added to `EdgesConstrainableProxy` that takes in a `NSDirectionalEdgeInsets`  instance, and new edge-specific relation/priority parameters were added. 

## Changes

### Description

- Add a new `EdgesConstrainableProxy.edges` overload that receives a `NSDirectionalEdgeInsets` instance instead of a `UIEdgeInsets`.

- Allow tweaking `relation` and `priority` for each edge of a `EdgesConstrainableProxy`.

- Create helpers to convert between `UIEdgesInsets` and `NSDirectionalEdgesInsets`.
