### PR TITLE
Add the HTTP Status Code to the `noData` Error

### DIFF
--- a/Sources/Network/Network+URLSessionError.swift
+++ b/Sources/Network/Network+URLSessionError.swift
@@ -13,7 +13,7 @@ extension Network {
 
         case noRequest(Error)
         case http(HTTP.StatusCode, APIError?, URLResponse)
-        case noData(URLResponse)
+        case noData(HTTP.StatusCode, URLResponse)
         case url(URLError)
         case badResponse(URLResponse?)
         case retry(Retry.Error, Retry.State)
@@ -32,7 +32,7 @@ extension Network.URLSessionError {
             return nil
 
         case .http(_, _, let response),
-             .noData(let response):
+             .noData(_, let response):
             return response
 
         case .badResponse(let response):
@@ -62,11 +62,11 @@ extension Network.URLSessionError {
     public var statusCode: HTTP.StatusCode? {
 
         switch self {
-        case .http(let statusCode, _, _):
+        case .http(let statusCode, _, _),
+             .noData(let statusCode, _):
             return statusCode
 
         case .noRequest,
-             .noData,
              .url,
              .badResponse,
              .cancelled:

--- a/Sources/Network/Network+URLSessionNetworkStack.swift
+++ b/Sources/Network/Network+URLSessionNetworkStack.swift
@@ -205,7 +205,7 @@ extension Network {
                         resource: resource,
                         data: data,
                         response: response,
-                        error: .noData(urlResponse),
+                        error: .noData(httpStatusCode, urlResponse),
                         cancelableBag: cancelableBag,
                         completion: completion
                     )

--- a/Tests/AlicerceTests/Network/URLSessionNetworkStack+ErrorTestCase.swift
+++ b/Tests/AlicerceTests/Network/URLSessionNetworkStack+ErrorTestCase.swift
@@ -17,7 +17,7 @@ final class URLSessionNetworkStack_ErrorTestCase: XCTestCase {
 
         let noRequestError = Error.noRequest(DummyError.🕳)
         let httpError = Error.http(.unknownError(1337), DummyError.🕳, testResponse)
-        let noDataError = Error.noData(testResponse)
+        let noDataError = Error.noData(.unknownError(1337), testResponse)
         let urlError = Error.url(URLError(.badURL))
         let badResponseError = Error.badResponse(testResponse)
         let badNilResponseError = Error.badResponse(nil)
@@ -45,7 +45,7 @@ final class URLSessionNetworkStack_ErrorTestCase: XCTestCase {
 
         let noRequestError = Error.noRequest(DummyError.🕳)
         let httpError = Error.http(.unknownError(1337), DummyError.🕳, testResponse)
-        let noDataError = Error.noData(testResponse)
+        let noDataError = Error.noData(.unknownError(1337), testResponse)
         let urlError = Error.url(URLError(.badURL))
         let badResponseError = Error.badResponse(testResponse)
         let retryError = Error.retry(.retries(1337), .init(errors: [DummyError.🕳, urlError], totalDelay: 0))
@@ -73,7 +73,7 @@ final class URLSessionNetworkStack_ErrorTestCase: XCTestCase {
 
         let noRequestError = Error.noRequest(DummyError.🕳)
         let httpError = Error.http(.unknownError(1337), DummyError.🕳, testResponse)
-        let noDataError = Error.noData(testResponse)
+        let noDataError = Error.noData(.unknownError(1337), testResponse)
         let urlError = Error.url(URLError(.badURL))
         let badResponseError = Error.badResponse(testResponse)
         let retryError = Error.retry(.retries(1337), .init(errors: [DummyError.🕳, httpError], totalDelay: 0))
@@ -82,7 +82,7 @@ final class URLSessionNetworkStack_ErrorTestCase: XCTestCase {
 
         XCTAssertNil(noRequestError.statusCode)
         XCTAssertEqual(httpError.statusCode, .unknownError(1337))
-        XCTAssertNil(noDataError.statusCode)
+        XCTAssertEqual(noDataError.statusCode, .unknownError(1337))
         XCTAssertNil(urlError.statusCode)
         XCTAssertNil(badResponseError.statusCode)
         XCTAssertEqual(retryError.statusCode, .unknownError(1337))

--- a/Tests/AlicerceTests/Network/URLSessionNetworkStackTestCase.swift
+++ b/Tests/AlicerceTests/Network/URLSessionNetworkStackTestCase.swift
@@ -662,7 +662,8 @@ final class URLSessionNetworkStackTestCase: XCTestCase {
             switch result {
             case .success:
                 XCTFail("🔥 should throw an error 🤔")
-            case let .failure(.noData(response)):
+            case let .failure(.noData(receiveStatusCode, response)):
+                XCTAssertEqual(receiveStatusCode.statusCode, mockResponse.statusCode)
                 XCTAssertEqual(response, mockResponse)
             case let .failure(error):
                 XCTFail("🔥 received unexpected error 👉 \(error) 😱")


### PR DESCRIPTION
### Checklist
- [x] I've rebased my changes on top of `master`
- [x] I've built and run the project to see all new and existing tests pass
- [x] I've followed the [Mindera swift style guide](https://github.com/Mindera/swift-style-guide)
- [x] I've read the [Contribution Guidelines](https://github.com/Mindera/Alicerce/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
HTTP status code was added to the `.noData` `URLSessionError` in order to improve its retrieval without the need to downcast the `URLResponse` as a `HTTPURLResponse`.

### Description

- `Network+URLSessionError`: add the HTTP status code to the `noData`
error case and handle the `statusCode` variable return

- `Network+URLSessionNetworkStack`: send the HTTP status code with the
`noData` error to be handled in `handleFailedFetch`

- `URLSessionNetworkStack+ErrorTestCase`: fix error unit tests in order
to test the HTTP status code

- `URLSessionNetworkStackTestCase`: status code related fix
