### PR TITLE
Migrate to Swift 5️⃣.7️⃣

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,8 @@ on:
 
 env:
   # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-12-Readme.md#xcode
-  DEVELOPER_DIR: /Applications/Xcode_13.4.1.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_14.0.app/Contents/Developer
+  IOS_DESTINATION: "platform=iOS Simulator,name=iPhone 14 Pro,OS=latest"
 
 jobs:
   env-details:
@@ -33,7 +34,6 @@ jobs:
     env:
       WORKSPACE: Alicerce.xcworkspace
       SCHEME: Alicerce
-      IOS_DESTINATION: "platform=iOS Simulator,name=iPhone 13 Pro,OS=latest"
       DERIVED_DATA_PATH: build
     steps:
       - name: git checkout
@@ -64,7 +64,6 @@ jobs:
     env:
       WORKSPACE: Alicerce.xcworkspace
       SCHEME: "Alicerce (SPM)"
-      IOS_DESTINATION: "platform=iOS Simulator,name=iPhone 13 Pro,OS=latest"
     steps:
       - name: git checkout
         uses: actions/checkout@v2

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -17,6 +17,7 @@ disabled_rules:
     - identifier_name
     - colon
     - opening_brace
+    - void_function_in_ternary
 opt_in_rules:
     - empty_count
     - closure_spacing

--- a/Alicerce.podspec
+++ b/Alicerce.podspec
@@ -16,9 +16,9 @@ Pod::Spec.new do |s|
     s.source        = { :git => 'https://github.com/Mindera/Alicerce.git', :tag => "#{s.version}" }
 
     s.module_name   = 'Alicerce'
-    s.swift_version = '5.6'
+    s.swift_version = '5.7'
 
-    s.ios.deployment_target = '10.0'
+    s.ios.deployment_target = '11.0'
 
     s.subspec 'Core' do |ss|
         ss.source_files = 'Sources/{Utils,Shared}/**/*.swift'

--- a/Alicerce.xcodeproj/project.pbxproj
+++ b/Alicerce.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -1783,6 +1783,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		9708743E219F086000264EE3 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -2187,7 +2188,11 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = Tests/AlicerceTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mindera.AlicerceTests;
 				PRODUCT_MODULE_NAME = AlicerceTests;
@@ -2234,7 +2239,11 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = Tests/AlicerceTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mindera.AlicerceTests;
 				PRODUCT_MODULE_NAME = AlicerceTests;
@@ -2288,7 +2297,11 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = Resources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MARKETING_VERSION = 0.16.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mindera.Alicerce;
@@ -2342,7 +2355,11 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = Resources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MARKETING_VERSION = 0.16.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mindera.Alicerce;
@@ -2384,7 +2401,10 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = Tests/DummyHostApp/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mindera.alicerce.DummyHostApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2418,7 +2438,10 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = Tests/DummyHostApp/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mindera.alicerce.DummyHostApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2455,7 +2478,11 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = Tests/HostAppRequiringTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mindera.alicerce.HostAppRequiringTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2490,7 +2517,11 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = Tests/HostAppRequiringTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mindera.alicerce.HostAppRequiringTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2556,7 +2587,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -2604,7 +2635,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";

--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.7
 
 import PackageDescription
 
 let package = Package(
     name: "Alicerce",
     platforms: [
-        .iOS(.v10)
+        .iOS(.v11)
     ],
     products: [
         // single module product, mutually exclusive with *all* other products (which use sub-modules)!

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![license](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://github.com/Mindera/Alicerce/blob/master/LICENSE)
 [![release](https://img.shields.io/github/release/Mindera/Alicerce.svg)](https://github.com/Mindera/Alicerce/releases)
 ![platforms](https://img.shields.io/badge/platforms-iOS-lightgrey.svg)
-[![Swift 5.6](https://img.shields.io/badge/Swift-5.6-orange.svg?style=flat)](https://developer.apple.com/swift/)
+[![Swift 5.7](https://img.shields.io/badge/Swift-5.7-orange.svg?style=flat)](https://developer.apple.com/swift/)
 [![Carthage](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![CocoaPods](https://img.shields.io/cocoapods/v/Alicerce.svg)](https://cocoapods.org/)
 [![SwiftPM](https://img.shields.io/badge/SwiftPM-compatible-orange.svg)](#swift-package-manager)
@@ -50,7 +50,13 @@ TODO
 
 ## Compatibility ✅
 
-### `0.16.0...master`
+### `master`
+
+- iOS 11.0+
+- Xcode 14.0
+- Swift 5.7
+
+### `0.16.0`
 
 - iOS 10.0+
 - Xcode 13.4

--- a/Sources/Network/NetworkStack.swift
+++ b/Sources/Network/NetworkStack.swift
@@ -11,16 +11,15 @@ public protocol NetworkStack: AnyObject {
     associatedtype Response
     associatedtype FetchError: Error
 
-    typealias CompletionClosure<T, E: Swift.Error> = (Result<Network.Value<T, Response>, E>) -> Void
-    typealias FetchCompletionClosure = CompletionClosure<Remote, FetchError>
-
-    typealias FetchResult = Result<Network.Value<Remote, Response>, FetchError>
-
     @discardableResult
     func fetch(resource: Resource, completion: @escaping FetchCompletionClosure) -> Cancelable
 }
 
 extension NetworkStack {
+
+    public typealias CompletionClosure<T, E: Error> = (Result<Network.Value<T, Response>, E>) -> Void
+    public typealias FetchCompletionClosure = CompletionClosure<Remote, FetchError>
+    public typealias FetchResult = Result<Network.Value<Remote, Response>, FetchError>
 
     @discardableResult
     public func fetchAndDecode<T>(

--- a/Sources/StackOrchestrator/StackOrchestratorStore.swift
+++ b/Sources/StackOrchestrator/StackOrchestratorStore.swift
@@ -18,11 +18,6 @@ public protocol StackOrchestratorStore: AnyObject {
     typealias Resource = StackOrchestrator.FetchResource<Network.Resource, Persistence.Key>
     typealias FetchError = StackOrchestrator.FetchError
 
-    typealias CompletionClosure<T, E: Swift.Error> =
-        (Result<StackOrchestrator.FetchValue<T, Response>, E>) -> Void
-
-    typealias FetchCompletionClosure = CompletionClosure<Payload, FetchError>
-
     var networkStack: Network { get }
     var persistenceStack: Persistence { get }
     var performanceMetrics: StackOrchestratorPerformanceMetricsTracker? { get }
@@ -34,6 +29,11 @@ public protocol StackOrchestratorStore: AnyObject {
 }
 
 extension StackOrchestratorStore {
+
+    public typealias CompletionClosure<T, E: Swift.Error> =
+        (Result<StackOrchestrator.FetchValue<T, Response>, E>) -> Void
+
+    public typealias FetchCompletionClosure = CompletionClosure<Payload, FetchError>
 
     @discardableResult
     public func fetchAndDecode<T>(

--- a/script/carthage.sh
+++ b/script/carthage.sh
@@ -11,9 +11,12 @@ set -euo pipefail
 xcconfig=$(mktemp /tmp/static.xcconfig.XXXXXX)
 trap 'rm -f "$xcconfig"' INT TERM HUP EXIT
 
-# For Xcode 12 and 13 make sure EXCLUDED_ARCHS is set to arm architectures otherwise
+# For Xcode 12+ make sure EXCLUDED_ARCHS is set to arm architectures otherwise
 # the build will fail on lipo due to duplicate architectures.
-echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1300 = arm64 arm64e armv7 armv7s armv6 armv8' >> $xcconfig
+
+XCODE_VERSION_MAJ=1400 # should mirror XCODE_VERSION_MAJOR - update accordingly
+
+echo "EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_${XCODE_VERSION_MAJ} = arm64 arm64e armv7 armv7s armv6 armv8" >> $xcconfig
 echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
 
 export XCODE_XCCONFIG_FILE="$xcconfig"


### PR DESCRIPTION
<!-- Thanks for contributing to _Alicerce 🏗_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've rebased my changes on top of `master`
- [x] I've built and run the project to see all new and existing tests pass
- [x] I've followed the [Mindera swift style guide](https://github.com/Mindera/swift-style-guide)
- [x] I've read the [Contribution Guidelines](https://github.com/Mindera/Alicerce/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
GH Actions' macOS 12 images have Xcode 14.0 available which means that Swift 5.7 is available to use in CI.

https://github.com/actions/virtual-environments/blob/main/images/macos/macos-12-Readme.md#xcode

### Description

- Move typealiases in `NetworkStack` and `StackOrchestratorStore` to extensions to fix build errors - possibly compiler regressions.

- Update `ci.yml`:
  + Set `DEVELOPER_DIR` env var to point to Xcode 14.0.
  + Unify `IOS_DESTINATION` env var and uipdate it do use iPhone 14 Pro.

- Bump iOS target version to 11 as that's the minimum version supported by Xcode 14 (https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes):
  + Project
  + Package.swift
  + podspec

- Update Package.swift's `// swift-tools-version` to 5.7.

- Update podspec's `swift_version` to 5.7.

- Update `README.md`.

- Fix `carthage.sh` script to use a new `$(XCODE_VERSION_MAJ)` var instead of an hardcoded value that easier to miss.

- Unmark SwiftLint's Run Script "Based on dependency analysis" setting so that it doesn't expect input/output files.
