### PR TITLE
Create `xToCenterX` and `xToCenterY` AutoLayout Helpers

### DIFF
--- a/Sources/AutoLayout/ConstrainableProxy.swift
+++ b/Sources/AutoLayout/ConstrainableProxy.swift
@@ -87,6 +87,23 @@ public extension TopConstrainableProxy {
             priority: priority
         )
     }
+
+    @discardableResult
+    func topToCenterY(
+        of anotherProxy: CenterYConstrainableProxy,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        constrain(
+            from: top,
+            to: anotherProxy.centerY,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
 }
 
 public protocol BottomConstrainableProxy: ConstrainableProxy {
@@ -158,6 +175,23 @@ public extension BottomConstrainableProxy {
         constrain(
             from: bottom,
             to: anotherProxy.lastBaseline,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+
+    @discardableResult
+    func bottomToCenterY(
+        of anotherProxy: CenterYConstrainableProxy,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        constrain(
+            from: bottom,
+            to: anotherProxy.centerY,
             offset: offset,
             relation: relation,
             priority: priority
@@ -264,6 +298,23 @@ public extension LeftConstrainableProxy {
             priority: priority
         )
     }
+
+    @discardableResult
+    func leftToCenterX(
+        of anotherProxy: CenterXConstrainableProxy,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        constrain(
+            from: left,
+            to: anotherProxy.centerX,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
 }
 
 public protocol RightConstrainableProxy: ConstrainableProxy {
@@ -301,6 +352,23 @@ public extension RightConstrainableProxy {
         constrain(
             from: right,
             to: anotherProxy.left,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+
+    @discardableResult
+    func rightToCenterX(
+        of anotherProxy: CenterXConstrainableProxy,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        constrain(
+            from: right,
+            to: anotherProxy.centerX,
             offset: offset,
             relation: relation,
             priority: priority
@@ -811,6 +879,24 @@ public extension BaselineConstrainableProxy {
     }
 
     @discardableResult
+    func firstBaselineToCenterY(
+        of view: CenterYConstrainableProxy,
+        multiplier: CGFloat = 1,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        constrain(
+            from: firstBaseline,
+            to: view.centerY,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+
+    @discardableResult
     func lastBaseline(
         to view: BaselineConstrainableProxy,
         offset: CGFloat = 0,
@@ -855,6 +941,24 @@ public extension BaselineConstrainableProxy {
         constrain(
             from: lastBaseline,
             to: view.bottom,
+            offset: offset,
+            relation: relation,
+            priority: priority
+        )
+    }
+
+    @discardableResult
+    func lastBaselineToCenterY(
+        of view: CenterYConstrainableProxy,
+        multiplier: CGFloat = 1,
+        offset: CGFloat = 0,
+        relation: ConstraintRelation = .equal,
+        priority: UILayoutPriority = .required
+    ) -> NSLayoutConstraint {
+
+        constrain(
+            from: lastBaseline,
+            to: view.centerY,
             offset: offset,
             relation: relation,
             priority: priority

--- a/Tests/AlicerceTests/AutoLayout/BottomConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/BottomConstrainableProxyTestCase.swift
@@ -361,4 +361,30 @@ final class BottomConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         XCTAssertConstraint(constraint, expected)
     }
+
+    func testConstrain_WithBottomConstraint_ShouldSupportCenterYAttribute() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view0) { host, view0 in
+            constraint = view0.bottomToCenterY(of: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view0!,
+            attribute: .bottom,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .centerY,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.maxY, host.center.y)
+    }
 }

--- a/Tests/AlicerceTests/AutoLayout/FirstBaselineConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/FirstBaselineConstrainableProxyTestCase.swift
@@ -78,6 +78,28 @@ final class FirstBaselineConstrainableProxyTestCase: BaseConstrainableProxyTestC
         XCTAssertConstraint(constraint, expected)
     }
 
+    func testConstrain_WithFirstBaselineToCenterYConstraint_ShouldSupportRelativeEquality() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view0) { host, view in
+            constraint = view.firstBaselineToCenterY(of: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view0!,
+            attribute: .firstBaseline,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .centerY,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+    }
+
     func testConstrain_WithFirstBaselineConstraintAndTwoConstraintGroups_ShouldReturnCorrectIsActiveConstraint() {
 
         var constraint0: NSLayoutConstraint!

--- a/Tests/AlicerceTests/AutoLayout/LastBaselineConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/LastBaselineConstrainableProxyTestCase.swift
@@ -78,6 +78,28 @@ final class LastBaselineConstrainableProxyTestCase: BaseConstrainableProxyTestCa
         XCTAssertConstraint(constraint, expected)
     }
 
+    func testConstrain_WithLastBaselineToCenterYConstraint_ShouldSupportRelativeEquality() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view0) { host, view in
+            constraint = view.lastBaselineToCenterY(of: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view0!,
+            attribute: .lastBaseline,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .centerY,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+    }
+
     func testConstrain_WithLastBaselineConstraintAndTwoConstraintGroups_ShouldReturnCorrectIsActiveConstraint() {
 
         var constraint0: NSLayoutConstraint!

--- a/Tests/AlicerceTests/AutoLayout/LeftConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/LeftConstrainableProxyTestCase.swift
@@ -157,6 +157,31 @@ final class LeftConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
         XCTAssertEqual(view0.frame.minX, 500)
     }
 
+    func testConstrain_WithLeftConstraint_ShouldSupportCenterXAttribute() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view0) { host, view0 in
+            constraint = view0.leftToCenterX(of: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view0!,
+            attribute: .left,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .centerX,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true)
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.minX, host.center.x)
+    }
+
     func testConstrain_WithLeftConstraint_ShouldSupportCustomPriority() {
 
         var constraint: NSLayoutConstraint!

--- a/Tests/AlicerceTests/AutoLayout/RightConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/RightConstrainableProxyTestCase.swift
@@ -157,6 +157,31 @@ final class RightConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
         XCTAssertEqual(view0.frame.maxX, 0)
     }
 
+    func testConstrain_WithRightConstraint_ShouldSupportCenterXAttribute() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view0) { host, view0 in
+            constraint = view0.rightToCenterX(of: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view0!,
+            attribute: .right,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .centerX,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true)
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.maxX, host.center.x)
+    }
+
     func testConstrain_WithRightConstraint_ShouldSupportCustomPriority() {
 
         var constraint: NSLayoutConstraint!

--- a/Tests/AlicerceTests/AutoLayout/TopConstrainableProxyTestCase.swift
+++ b/Tests/AlicerceTests/AutoLayout/TopConstrainableProxyTestCase.swift
@@ -394,4 +394,30 @@ final class TopConstrainableProxyTestCase: BaseConstrainableProxyTestCase {
 
         XCTAssertConstraint(constraint, expected)
     }
+
+    func testConstrain_WithTopConstraint_ShouldSupportCenterYAttribute() {
+
+        var constraint: NSLayoutConstraint!
+        constrain(host, view0) { host, view0 in
+            constraint = view0.topToCenterY(of: host)
+        }
+
+        let expected = NSLayoutConstraint(
+            item: view0!,
+            attribute: .top,
+            relatedBy: .equal,
+            toItem: host,
+            attribute: .centerY,
+            multiplier: 1,
+            constant: 0,
+            priority: .required,
+            active: true
+        )
+
+        XCTAssertConstraint(constraint, expected)
+
+        host.layoutIfNeeded()
+
+        XCTAssertEqual(view0.frame.minY, host.center.y)
+    }
 }


### PR DESCRIPTION
### Checklist
- [x] I've rebased my changes on top of `master`
- [x] I've built and run the project to see all new and existing tests pass
- [x] I've followed the [Mindera swift style guide](https://github.com/Mindera/swift-style-guide)
- [x] I've read the [Contribution Guidelines](https://github.com/Mindera/Alicerce/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Currently Alicerce's AutoLayout helpers only provide a `centerYToX` variant for each of the respective anchors, with the corresponding `xToCenterY` APIs missing for said anchors. The same applies to some `centerX` APIs. While this doesn't limit the creation of constraints, it forces a view inversion when defining constraints, in order to define those particular constraints. This piece of work aims to implement these missing helpers in order to improve this.

### Description
## Changes

- `xToCenterY`: add new AutoLayout helpers for Y anchors:
   + `top`
   + `bottom`
   + `firstBaseline`
   + `lastBaseline`

- `xToCenterX`: and new AutoLayout helpers to missing X anchors:
   + `left`
   + `right`

- `Unit Tests`:  add new UTs to cover newly added helpers

<!-- Thanks for contributing to _Alicerce 🏗_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->
