### PR TITLE
Update codecov uploader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       WORKSPACE: Alicerce.xcworkspace
       SCHEME: Alicerce
       DERIVED_DATA_PATH: build
+      RESULT_BUNDLE_PATH: build-test.xcresult
     steps:
       - name: git checkout
         uses: actions/checkout@v2
@@ -53,10 +54,14 @@ jobs:
             -destination "$IOS_DESTINATION" \
             -derivedDataPath "$DERIVED_DATA_PATH" \
             -enableCodeCoverage YES \
+            -resultBundlePath "$RESULT_BUNDLE_PATH" \
             | xcbeautify
 
       - name: codecov upload
-        run: bash <(curl -s https://codecov.io/bash) -D $DERIVED_DATA_PATH -J "^$SCHEME$"
+        uses: codecov/codecov-action@v3
+        with:
+          xcode: true
+          xcode_archive_path: ${{ env.RESULT_BUNDLE_PATH }}
 
   swiftpm:
     name: SwiftPM Build


### PR DESCRIPTION
### Checklist
- [x] I've rebased my changes on top of `master`
- [x] I've built and run the project to see all new and existing tests pass
- [x] I've followed the [Mindera swift style guide](https://github.com/Mindera/swift-style-guide)
- [x] I've read the [Contribution Guidelines](https://github.com/Mindera/Alicerce/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

- Codecov has deprecated the old bash script, so we need to update our CI to use the new uploader.

### Description

- Migrate CI to use the new codecov uploader via GH action.
