### PR TITLE
Enable fork PRs CI to run codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,10 @@ on:
       - master
     tags:
       - '[0-9]+\.[0-9]+\.[0-9]+'
-  pull_request:
+  pull_request_target: # forks don't have access to secrets if we use `pull_request`, which is required for codecov
     branches:
       - master
+    types: [labeled] # ensure PRs are labelled, which can only be done by users with triage access
 
 env:
   # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#xcode
@@ -24,6 +25,7 @@ jobs:
   env-details:
     name: Environment details
     runs-on: macos-14
+    if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run ci') }}
     steps:
       - name: xcode version
         run: xcodebuild -version -sdk
@@ -39,6 +41,7 @@ jobs:
   build-test:
     name: Build and Test
     runs-on: macos-14
+    if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run ci') }}
     env:
       WORKSPACE: Alicerce.xcworkspace
       SCHEME: Alicerce
@@ -133,6 +136,7 @@ jobs:
   swiftpm:
     name: SwiftPM Build
     runs-on: macos-14
+    if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run ci') }}
     env:
       WORKSPACE: Alicerce.xcworkspace
       SCHEME: "Alicerce (SPM)"
@@ -203,6 +207,7 @@ jobs:
   cocoapods:
     name: CocoaPods Verification
     runs-on: macos-14
+    if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run ci') }}
     steps:
       - name: git checkout
         uses: actions/checkout@v3
@@ -232,6 +237,7 @@ jobs:
   carthage:
     name: Carthage Verification
     runs-on: macos-14
+    if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run ci') }}
     env:
       # Use Xcode 15.3 (latest) for Carthage to avoid iOS device/simulator version mismatches
       DEVELOPER_DIR: "/Applications/Xcode_15.3.app/Contents/Developer"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
   pull_request_target: # forks don't have access to secrets if we use `pull_request`, which is required for codecov
     branches:
       - master
-    types: [labeled] # ensure PRs are labelled, which can only be done by users with triage access
 
 env:
   # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#xcode
@@ -25,7 +24,10 @@ jobs:
   env-details:
     name: Environment details
     runs-on: macos-14
-    if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run ci') }}
+    if: |
+      github.event_name == 'push' ||
+      !github.event.pull_request.head.repo.fork ||
+      (github.event.pull_request.head.repo.fork && contains(github.event.pull_request.labels.*.name, 'run ci'))
     steps:
       - name: xcode version
         run: xcodebuild -version -sdk
@@ -41,7 +43,10 @@ jobs:
   build-test:
     name: Build and Test
     runs-on: macos-14
-    if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run ci') }}
+    if: |
+      github.event_name == 'push' ||
+      !github.event.pull_request.head.repo.fork ||
+      (github.event.pull_request.head.repo.fork && contains(github.event.pull_request.labels.*.name, 'run ci'))
     env:
       WORKSPACE: Alicerce.xcworkspace
       SCHEME: Alicerce
@@ -136,7 +141,10 @@ jobs:
   swiftpm:
     name: SwiftPM Build
     runs-on: macos-14
-    if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run ci') }}
+    if: |
+      github.event_name == 'push' ||
+      !github.event.pull_request.head.repo.fork ||
+      (github.event.pull_request.head.repo.fork && contains(github.event.pull_request.labels.*.name, 'run ci'))
     env:
       WORKSPACE: Alicerce.xcworkspace
       SCHEME: "Alicerce (SPM)"
@@ -207,7 +215,10 @@ jobs:
   cocoapods:
     name: CocoaPods Verification
     runs-on: macos-14
-    if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run ci') }}
+    if: |
+      github.event_name == 'push' ||
+      !github.event.pull_request.head.repo.fork ||
+      (github.event.pull_request.head.repo.fork && contains(github.event.pull_request.labels.*.name, 'run ci'))
     steps:
       - name: git checkout
         uses: actions/checkout@v3
@@ -237,7 +248,10 @@ jobs:
   carthage:
     name: Carthage Verification
     runs-on: macos-14
-    if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run ci') }}
+    if: |
+      github.event_name == 'push' ||
+      !github.event.pull_request.head.repo.fork ||
+      (github.event.pull_request.head.repo.fork && contains(github.event.pull_request.labels.*.name, 'run ci'))
     env:
       # Use Xcode 15.3 (latest) for Carthage to avoid iOS device/simulator version mismatches
       DEVELOPER_DIR: "/Applications/Xcode_15.3.app/Contents/Developer"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,6 @@ jobs:
   env-details:
     name: Environment details
     runs-on: macos-14
-    if: |
-      github.event_name == 'push' ||
-      !github.event.pull_request.head.repo.fork
     steps:
       - name: xcode version
         run: xcodebuild -version -sdk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,7 @@ jobs:
     runs-on: macos-14
     if: |
       github.event_name == 'push' ||
-      !github.event.pull_request.head.repo.fork ||
-      (github.event.pull_request.head.repo.fork && contains(github.event.pull_request.labels.*.name, 'run ci'))
+      !github.event.pull_request.head.repo.fork
     steps:
       - name: xcode version
         run: xcodebuild -version -sdk


### PR DESCRIPTION
<!-- Thanks for contributing to _Alicerce 🏗_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've rebased my changes on top of `master`
- [x] I've built and run the project to see all new and existing tests pass
- [x] I've followed the [Mindera swift style guide](https://github.com/Mindera/swift-style-guide)
- [x] I've read the [Contribution Guidelines](https://github.com/Mindera/Alicerce/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context

For security reasons, fork PRs don't have access to secrets if we use `pull_request` in GH Actions CI spec, only if we use `pull_request_target`, which has its own security implications. See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

Codecov status reporting in CI requires a token, so for fork PRs to be able to do so we migrated to `pull_request_target` with the caveat that MRs have to be labelled and have the `run ci` label applied, which can only be done by someone with triage access to the repo.

This should give us a good compromise in terms of security.

### Description

Update `ci.yml` specification to allow fork PRs CI to run codecov, but only when labelled with the `run ci` label.
