### PR TITLE
Feature/failable uicolor init

### DIFF
--- a/Sources/Extensions/Foundation/String.swift
+++ b/Sources/Extensions/Foundation/String.swift
@@ -15,7 +15,7 @@ public extension String {
         return nsString.substring(with: nsRange) as String
     }
 
-    func prepeding(_ other: String) -> String {
+    func prepending(_ other: String) -> String {
         return other + self
     }
 }

--- a/Sources/Extensions/Foundation/String.swift
+++ b/Sources/Extensions/Foundation/String.swift
@@ -14,6 +14,10 @@ public extension String {
     func substring(with nsRange: NSRange) -> String {
         return nsString.substring(with: nsRange) as String
     }
+
+    func prepeding(_ other: String) -> String {
+        return other + self
+    }
 }
 
 public extension String {

--- a/Sources/Extensions/UIKit/UIColor.swift
+++ b/Sources/Extensions/UIKit/UIColor.swift
@@ -1,33 +1,45 @@
 import UIKit
 
 public extension UIColor {
-    private static let divisor = CGFloat(255)
-
     private typealias Components = (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat)
 
-    convenience init(hex: String) {
+    private enum ColorError: String, LocalizedError {
+        case invalidHexValue = "😱 Cannot convert string into `UInt64`"
+        case invalidHexSize = "😱 hex size not supported 😇"
+    }
+
+    private static let divisor = CGFloat(255)
+
+    convenience init(hexValue hex: String) throws {
         let hex = hex.trimmingCharacters(in: .whitespacesAndNewlines)
             .replacingOccurrences(of: "#", with: "")
 
         var hexValue: UInt64 = 0
 
         guard Scanner(string: hex).scanHexInt64(&hexValue) else {
-            fatalError("😱 Cannot convert string into `UInt64`")
+            throw ColorError.invalidHexValue
         }
 
-        let components: Components = {
+        let components: Components = try {
             switch hex.count {
             case 6: return UIColor.components(fromHex6: hexValue)
             case 8: return UIColor.components(fromHex8: hexValue)
-            default: fatalError("😱 hex size not supported 😇")
+            default: throw ColorError.invalidHexSize
             }
         }()
 
         self.init(red: components.red, green: components.green, blue: components.blue, alpha: components.alpha)
     }
 
-    var hexString: String {
+    convenience init(hex: String) {
+        do {
+            try self.init(hexValue: hex)
+        } catch {
+            fatalError(error.localizedDescription)
+        }
+    }
 
+    var hexString: String {
         var components = UIColor.components(fromHex6: 0)
         getRed(&components.red, green: &components.green, blue: &components.blue, alpha: &components.alpha)
 
@@ -40,7 +52,6 @@ public extension UIColor {
     }
 
     var hexStringWithAlpha: String {
-
         var components = UIColor.components(fromHex8: 0)
         getRed(&components.red, green: &components.green, blue: &components.blue, alpha: &components.alpha)
 
@@ -64,7 +75,6 @@ public extension UIColor {
     }
 
     private static func components(fromHex8 hex: UInt64) -> Components {
-
         let alpha = CGFloat((hex & 0xFF000000) >> 24) / UIColor.divisor
         let red = CGFloat((hex & 0x00FF0000) >> 16) / UIColor.divisor
         let green = CGFloat((hex & 0x0000FF00) >> 8) / UIColor.divisor

--- a/Sources/Extensions/UIKit/UIColor.swift
+++ b/Sources/Extensions/UIKit/UIColor.swift
@@ -3,11 +3,16 @@ import UIKit
 public extension UIColor {
     private typealias Components = (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat)
 
-    private enum ColorError: String, LocalizedError {
-        case invalidHexValue = "😱 Cannot convert string into `UInt64`"
-        case invalidHexSize = "😱 hex size not supported 😇"
+    private enum ColorError: LocalizedError {
+        case invalidHexValue(String)
+        case invalidHexSize(String)
 
-        var localizedDescription: String { rawValue }
+        var localizedDescription: String {
+            switch self {
+            case let .invalidHexValue(hex): "😱 Cannot convert `#\(hex)` into `UInt64`"
+            case let .invalidHexSize(hex): "😱 Hex size of `#\(hex)` not supported 😇"
+            }
+        }
     }
 
     private static let divisor = CGFloat(255)
@@ -19,14 +24,14 @@ public extension UIColor {
         var hexValue: UInt64 = 0
 
         guard Scanner(string: hex).scanHexInt64(&hexValue) else {
-            throw ColorError.invalidHexValue
+            throw ColorError.invalidHexValue(hex)
         }
 
         let components: Components = try {
             switch hex.count {
             case 6: return UIColor.components(fromHex6: hexValue)
             case 8: return UIColor.components(fromHex8: hexValue)
-            default: throw ColorError.invalidHexSize
+            default: throw ColorError.invalidHexSize(hex)
             }
         }()
 
@@ -42,6 +47,7 @@ public extension UIColor {
     }
 
     var hexString: String {
+
         var components = UIColor.components(fromHex6: 0)
         getRed(&components.red, green: &components.green, blue: &components.blue, alpha: &components.alpha)
 
@@ -54,6 +60,7 @@ public extension UIColor {
     }
 
     var hexStringWithAlpha: String {
+
         var components = UIColor.components(fromHex8: 0)
         getRed(&components.red, green: &components.green, blue: &components.blue, alpha: &components.alpha)
 
@@ -69,6 +76,7 @@ public extension UIColor {
     // MARK: - Private Methods
 
     private static func components(fromHex6 hex: UInt64) -> Components {
+
         let red = CGFloat((hex & 0xFF0000) >> 16) / UIColor.divisor
         let green = CGFloat((hex & 0x00FF00) >> 8) / UIColor.divisor
         let blue = CGFloat(hex & 0x0000FF) / UIColor.divisor
@@ -77,6 +85,7 @@ public extension UIColor {
     }
 
     private static func components(fromHex8 hex: UInt64) -> Components {
+
         let alpha = CGFloat((hex & 0xFF000000) >> 24) / UIColor.divisor
         let red = CGFloat((hex & 0x00FF0000) >> 16) / UIColor.divisor
         let green = CGFloat((hex & 0x0000FF00) >> 8) / UIColor.divisor

--- a/Sources/Extensions/UIKit/UIColor.swift
+++ b/Sources/Extensions/UIKit/UIColor.swift
@@ -4,7 +4,7 @@ public extension UIColor {
     convenience init(hexValue: String) throws {
         let hex = hexValue
             .filter { $0.isLetter || $0.isNumber }
-            .prepeding("ff")
+            .prepending("ff")
             .suffix(8)
             .asString
 

--- a/Sources/Extensions/UIKit/UIColor.swift
+++ b/Sources/Extensions/UIKit/UIColor.swift
@@ -6,6 +6,8 @@ public extension UIColor {
     private enum ColorError: String, LocalizedError {
         case invalidHexValue = "😱 Cannot convert string into `UInt64`"
         case invalidHexSize = "😱 hex size not supported 😇"
+
+        var localizedDescription: String { rawValue }
     }
 
     private static let divisor = CGFloat(255)

--- a/Sources/Extensions/UIKit/UIColor.swift
+++ b/Sources/Extensions/UIKit/UIColor.swift
@@ -1,39 +1,24 @@
 import UIKit
 
 public extension UIColor {
-    private typealias Components = (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat)
+    convenience init(hexValue: String) throws {
+        let hex = hexValue
+            .filter { $0.isLetter || $0.isNumber }
+            .prepeding("ff")
+            .suffix(8)
+            .asString
 
-    private enum ColorError: LocalizedError {
-        case invalidHexValue(String)
-        case invalidHexSize(String)
-
-        var localizedDescription: String {
-            switch self {
-            case let .invalidHexValue(hex): "😱 Cannot convert `#\(hex)` into `UInt64`"
-            case let .invalidHexSize(hex): "😱 Hex size of `#\(hex)` not supported 😇"
-            }
-        }
-    }
-
-    private static let divisor = CGFloat(255)
-
-    convenience init(hexValue hex: String) throws {
-        let hex = hex.trimmingCharacters(in: .whitespacesAndNewlines)
-            .replacingOccurrences(of: "#", with: "")
-
-        var hexValue: UInt64 = 0
-
-        guard Scanner(string: hex).scanHexInt64(&hexValue) else {
-            throw ColorError.invalidHexValue(hex)
+        guard hex.count == 8 else {
+            throw ColorError.invalidHexSize(hexValue)
         }
 
-        let components: Components = try {
-            switch hex.count {
-            case 6: return UIColor.components(fromHex6: hexValue)
-            case 8: return UIColor.components(fromHex8: hexValue)
-            default: throw ColorError.invalidHexSize(hex)
-            }
-        }()
+        var hexInt: UInt64 = 0
+
+        guard Scanner(string: hex).scanHexInt64(&hexInt) else {
+            throw ColorError.invalidHexValue(hexValue)
+        }
+
+        let components = UIColor.components(hex: hexInt)
 
         self.init(red: components.red, green: components.green, blue: components.blue, alpha: components.alpha)
     }
@@ -47,21 +32,44 @@ public extension UIColor {
     }
 
     var hexString: String {
-
-        var components = UIColor.components(fromHex6: 0)
-        getRed(&components.red, green: &components.green, blue: &components.blue, alpha: &components.alpha)
-
-        let r = Int(components.red * UIColor.divisor)
-        let g = Int(components.green * UIColor.divisor)
-        let b = Int(components.blue * UIColor.divisor)
-        let rgb: Int = r << 16 | g << 8 | b << 0
-
-        return String(format:"#%06x", rgb)
+        String(format:"#%06x", (asHexIntWithAlpha & 0x00FFFFFF))
     }
 
     var hexStringWithAlpha: String {
+        String(format:"#%08x", asHexIntWithAlpha)
+    }
+}
 
-        var components = UIColor.components(fromHex8: 0)
+private extension UIColor {
+    typealias Components = (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat)
+
+    enum ColorError: LocalizedError {
+        case invalidHexValue(String)
+        case invalidHexSize(String)
+
+        var localizedDescription: String {
+            switch self {
+            case let .invalidHexValue(hex): "😱 Cannot convert `#\(hex)` into `UInt64`"
+            case let .invalidHexSize(hex): "😱 Hex size of `#\(hex)` not supported 😇"
+            }
+        }
+    }
+
+    static let divisor = CGFloat(255)
+
+    static func components(hex: UInt64) -> Components {
+
+        let alpha = CGFloat((hex & 0xFF000000) >> 24) / UIColor.divisor
+        let red = CGFloat((hex & 0x00FF0000) >> 16) / UIColor.divisor
+        let green = CGFloat((hex & 0x0000FF00) >> 8) / UIColor.divisor
+        let blue = CGFloat(hex & 0x000000FF) / UIColor.divisor
+
+        return (red, green, blue, alpha)
+    }
+
+    var asHexIntWithAlpha: Int {
+
+        var components = UIColor.components(hex: 0)
         getRed(&components.red, green: &components.green, blue: &components.blue, alpha: &components.alpha)
 
         let a = Int(components.alpha * UIColor.divisor)
@@ -70,27 +78,12 @@ public extension UIColor {
         let b = Int(components.blue * UIColor.divisor)
         let argb: Int = a << 24 | r << 16 | g << 8 | b << 0
 
-        return String(format:"#%08x", argb)
+        return argb
     }
+}
 
-    // MARK: - Private Methods
-
-    private static func components(fromHex6 hex: UInt64) -> Components {
-
-        let red = CGFloat((hex & 0xFF0000) >> 16) / UIColor.divisor
-        let green = CGFloat((hex & 0x00FF00) >> 8) / UIColor.divisor
-        let blue = CGFloat(hex & 0x0000FF) / UIColor.divisor
-
-        return (red, green, blue, 1.0)
-    }
-
-    private static func components(fromHex8 hex: UInt64) -> Components {
-
-        let alpha = CGFloat((hex & 0xFF000000) >> 24) / UIColor.divisor
-        let red = CGFloat((hex & 0x00FF0000) >> 16) / UIColor.divisor
-        let green = CGFloat((hex & 0x0000FF00) >> 8) / UIColor.divisor
-        let blue = CGFloat(hex & 0x000000FF) / UIColor.divisor
-
-        return (red, green, blue, alpha)
+private extension String.SubSequence {
+    var asString: String {
+        String(self)
     }
 }

--- a/Sources/Persistence/DiskMemoryPersistenceStack.swift
+++ b/Sources/Persistence/DiskMemoryPersistenceStack.swift
@@ -501,7 +501,7 @@ extension Persistence.DiskMemoryPersistenceStack: NSCacheDelegate {
     }
 }
 
-private final class DiskMemoryBlockOperation: BlockOperation {
+private final class DiskMemoryBlockOperation: BlockOperation, @unchecked Sendable {
 
     required init(qos: QualityOfService = .default, block: @escaping () -> Swift.Void) {
         super.init()

--- a/Sources/Persistence/DiskMemoryPersistenceStack.swift
+++ b/Sources/Persistence/DiskMemoryPersistenceStack.swift
@@ -501,7 +501,7 @@ extension Persistence.DiskMemoryPersistenceStack: NSCacheDelegate {
     }
 }
 
-private final class DiskMemoryBlockOperation: BlockOperation, @unchecked Sendable {
+private final class DiskMemoryBlockOperation: BlockOperation {
 
     required init(qos: QualityOfService = .default, block: @escaping () -> Swift.Void) {
         super.init()

--- a/Tests/AlicerceTests/Extensions/UIKit/UIColorTestCase.swift
+++ b/Tests/AlicerceTests/Extensions/UIKit/UIColorTestCase.swift
@@ -92,4 +92,25 @@ final class UIColorTestCase: XCTestCase {
         XCTAssertEqual(ciTransparentColor.blue, 1.0)
         XCTAssertEqual(ciTransparentColor.alpha, 0.0)
     }
+
+    func testGibberishInput_WithValidColorHex_ShouldSucceed() throws {
+        let gibberish = "@ff&ff*ff%f#f"
+
+        let color = try UIColor(hexValue: gibberish)
+
+        let ciColor = CIColor(color: color)
+
+        XCTAssertEqual(ciColor.red, 1.0)
+        XCTAssertEqual(ciColor.green, 1.0)
+        XCTAssertEqual(ciColor.blue, 1.0)
+        XCTAssertEqual(ciColor.alpha, 1.0)
+    }
+
+    func testGibberishInput_WithInvalidColorHex_ShouldFail() {
+        let string = "random string"
+
+        let color = try? UIColor(hexValue: string)
+
+        XCTAssertNil(color)
+    }
 }

--- a/Tests/HostAppRequiringTests/Extensions/StringTestCase.swift
+++ b/Tests/HostAppRequiringTests/Extensions/StringTestCase.swift
@@ -60,4 +60,11 @@ class StringTestCase_Localizable: XCTestCase {
 
         XCTAssertNotEqual(localizedHelperTestWithArguments, resultString)
     }
+
+    func testPrepending_ShouldSucceed() {
+        let world = "world!"
+        let hello = "Hello, "
+
+        XCTAssertEqual(world.prepending(hello), "Hello, world!")
+    }
 }


### PR DESCRIPTION
<!-- Thanks for contributing to _Alicerce 🏗_! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [ ] I've rebased my changes on top of `master`
- [ ] I've built and run the project to see all new and existing tests pass
- [ ] I've followed the [Mindera swift style guide](https://github.com/Mindera/swift-style-guide)
- [ ] I've read the [Contribution Guidelines](https://github.com/Mindera/Alicerce/blob/master/CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary.

### Motivation and Context

Would be helpful to have a failable init for UIColor. In the project i'm working on we're using Alicerce and would be nice to have this functionality readily available from Alicerce

### Description

The changes simply add a new convenience init for UIColor, while still keeping the old one (same params) that used to fatalError on fail
